### PR TITLE
Add reporting instance field to Event

### DIFF
--- a/recorder/event.go
+++ b/recorder/event.go
@@ -46,12 +46,12 @@ type Event struct {
 	// A human-readable description of this event.
 	// Maximum length 39,000 characters
 	// +required
-	Message string `json:"message,omitempty"`
+	Message string `json:"message"`
 
 	// A machine understandable string that gives the reason
 	// for the transition into the object's current status.
 	// +required
-	Reason string `json:"reason,omitempty"`
+	Reason string `json:"reason"`
 
 	// Metadata of this event, e.g. apply change set.
 	// +optional
@@ -59,5 +59,9 @@ type Event struct {
 
 	// Name of the controller that emitted this event, e.g. `source-controller`.
 	// +required
-	ReportingController string `json:"reportingController,omitempty"`
+	ReportingController string `json:"reportingController"`
+
+	// ID of the controller instance, e.g. `source-controller-xyzf`.
+	// +optional
+	ReportingInstance string `json:"reportingInstance,omitempty"`
 }

--- a/recorder/recorder.go
+++ b/recorder/recorder.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -98,6 +99,11 @@ func (er *EventRecorder) Eventf(
 		return fmt.Errorf("faild to get object namespace")
 	}
 
+	hostname, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+
 	event := Event{
 		InvolvedObject:      object,
 		Severity:            severity,
@@ -106,6 +112,7 @@ func (er *EventRecorder) Eventf(
 		Reason:              reason,
 		Metadata:            metadata,
 		ReportingController: er.ReportingController,
+		ReportingInstance:   hostname,
 	}
 
 	body, err := json.Marshal(event)


### PR DESCRIPTION
Add reporting instance field to the event struct and set it to hostname in event recorder.