### PR TITLE
Centralise GitHub Actions definitions used in *-controller builds

### DIFF
--- a/actions/helm/Dockerfile
+++ b/actions/helm/Dockerfile
@@ -1,0 +1,6 @@
+FROM stefanprodan/alpine-base:latest
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/actions/helm/action.yml
+++ b/actions/helm/action.yml
@@ -1,0 +1,9 @@
+name: 'helm'
+description: 'A GitHub Action to run Helm commands'
+author: 'Hidde Beydals'
+branding:
+  icon: 'command'
+  color: 'blue'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/actions/helm/entrypoint.sh
+++ b/actions/helm/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+helm_ver=3.2.4 && \
+helm_url=https://get.helm.sh && \
+curl -sL ${helm_url}/helm-v${helm_ver}-linux-amd64.tar.gz | \
+tar xz
+
+mkdir -p $GITHUB_WORKSPACE/bin
+cp ./linux-amd64/helm $GITHUB_WORKSPACE/bin
+chmod +x $GITHUB_WORKSPACE/bin/helm
+
+$GITHUB_WORKSPACE/bin/helm version
+
+echo "::add-path::$GITHUB_WORKSPACE/bin"
+echo "::add-path::$RUNNER_WORKSPACE/$(basename $GITHUB_REPOSITORY)/bin"

--- a/actions/helm/entrypoint.sh
+++ b/actions/helm/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+
+set -eu
 
 helm_ver=3.2.4 && \
 helm_url=https://get.helm.sh && \

--- a/actions/kubebuilder/Dockerfile
+++ b/actions/kubebuilder/Dockerfile
@@ -1,0 +1,6 @@
+FROM giantswarm/tiny-tools
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/actions/kubebuilder/Dockerfile
+++ b/actions/kubebuilder/Dockerfile
@@ -1,4 +1,4 @@
-FROM giantswarm/tiny-tools
+FROM stefanprodan/alpine-base:latest
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/actions/kubebuilder/action.yml
+++ b/actions/kubebuilder/action.yml
@@ -1,0 +1,9 @@
+name: 'kubebuilder'
+description: 'A GitHub Action to run kubebuilder commands'
+author: 'Stefan Prodan'
+branding:
+  icon: 'command'
+  color: 'blue'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/actions/kubebuilder/entrypoint.sh
+++ b/actions/kubebuilder/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -l
+
+VERSION=2.3.1
+
+curl -sL https://go.kubebuilder.io/dl/${VERSION}/linux/amd64 | tar -xz -C /tmp/
+
+mkdir -p $GITHUB_WORKSPACE/kubebuilder
+mv /tmp/kubebuilder_${VERSION}_linux_amd64/* $GITHUB_WORKSPACE/kubebuilder/
+ls -lh $GITHUB_WORKSPACE/kubebuilder/bin
+
+echo "::add-path::$GITHUB_WORKSPACE/kubebuilder/bin"
+echo "::add-path::$RUNNER_WORKSPACE/$(basename $GITHUB_REPOSITORY)/kubebuilder/bin"

--- a/actions/kubebuilder/entrypoint.sh
+++ b/actions/kubebuilder/entrypoint.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -l
+#!/bin/bash
+
+set -eu
 
 VERSION=2.3.1
 

--- a/actions/kubectl/Dockerfile
+++ b/actions/kubectl/Dockerfile
@@ -1,0 +1,6 @@
+FROM stefanprodan/alpine-base:latest
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/actions/kubectl/action.yml
+++ b/actions/kubectl/action.yml
@@ -1,0 +1,9 @@
+name: 'kubectl'
+description: 'A GitHub Action to run kubectl commands'
+author: 'Stefan Prodan'
+branding:
+  icon: 'command'
+  color: 'blue'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/actions/kubectl/entrypoint.sh
+++ b/actions/kubectl/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+kubectl_ver=1.18.3 && \
+curl -sL https://storage.googleapis.com/kubernetes-release/release/v${kubectl_ver}/bin/linux/amd64/kubectl > kubectl
+
+mkdir -p $GITHUB_WORKSPACE/bin
+cp ./kubectl $GITHUB_WORKSPACE/bin
+chmod +x $GITHUB_WORKSPACE/bin/kubectl
+
+$GITHUB_WORKSPACE/bin/kubectl version --client
+
+echo "::add-path::$GITHUB_WORKSPACE/bin"
+echo "::add-path::$RUNNER_WORKSPACE/$(basename $GITHUB_REPOSITORY)/bin"

--- a/actions/kubectl/entrypoint.sh
+++ b/actions/kubectl/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+
+set -eu
 
 kubectl_ver=1.18.3 && \
 curl -sL https://storage.googleapis.com/kubernetes-release/release/v${kubectl_ver}/bin/linux/amd64/kubectl > kubectl

--- a/actions/kustomize/Dockerfile
+++ b/actions/kustomize/Dockerfile
@@ -1,0 +1,6 @@
+FROM stefanprodan/alpine-base:latest
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/actions/kustomize/action.yml
+++ b/actions/kustomize/action.yml
@@ -1,0 +1,9 @@
+name: 'kustomize'
+description: 'A GitHub Action to run kustomize commands'
+author: 'Stefan Prodan'
+branding:
+  icon: 'command'
+  color: 'blue'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/actions/kustomize/entrypoint.sh
+++ b/actions/kustomize/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+kustomize_ver=3.8.0 && \
+kustomize_url=https://github.com/kubernetes-sigs/kustomize/releases/download && \
+curl -sL ${kustomize_url}/kustomize%2Fv${kustomize_ver}/kustomize_v${kustomize_ver}_linux_amd64.tar.gz | \
+tar xz
+
+mkdir -p $GITHUB_WORKSPACE/bin
+cp ./kustomize $GITHUB_WORKSPACE/bin
+chmod +x $GITHUB_WORKSPACE/bin/kustomize
+
+$GITHUB_WORKSPACE/bin/kustomize version
+
+echo "::add-path::$GITHUB_WORKSPACE/bin"
+echo "::add-path::$RUNNER_WORKSPACE/$(basename $GITHUB_REPOSITORY)/bin"

--- a/actions/kustomize/entrypoint.sh
+++ b/actions/kustomize/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+
+set -eu
 
 kustomize_ver=3.8.0 && \
 kustomize_url=https://github.com/kubernetes-sigs/kustomize/releases/download && \


### PR DESCRIPTION
{kustomize,helm,source}-controller use almost the same set of actions in their builds. Before we make more copies, this PR centralises the union of the actions here (and subsequent PRs will update the individual repos).

This also standardises the Dockerfiles and entrypoints a little.