### PR TITLE
Update GitHub pkg and implement repo del

### DIFF
--- a/git/go.mod
+++ b/git/go.mod
@@ -4,6 +4,6 @@ go 1.14
 
 require (
 	github.com/go-git/go-git/v5 v5.1.0
-	github.com/google/go-github/v32 v32.0.0
+	github.com/google/go-github/v32 v32.1.0
 	github.com/xanzy/go-gitlab v0.32.1
 )

--- a/git/go.sum
+++ b/git/go.sum
@@ -27,8 +27,8 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-github/v32 v32.0.0 h1:q74KVb22spUq0U5HqZ9VCYqQz8YRuOtL/39ZnfwO+NM=
-github.com/google/go-github/v32 v32.0.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
+github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
+github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=

--- a/git/provider.go
+++ b/git/provider.go
@@ -21,6 +21,7 @@ import "context"
 // Provider is the interface that a git provider should implement
 type Provider interface {
 	CreateRepository(ctx context.Context, r *Repository) (bool, error)
+	DeleteRepository(ctx context.Context, r *Repository) error
 	AddTeam(ctx context.Context, r *Repository, name, permission string) (bool, error)
 	AddDeployKey(ctx context.Context, r *Repository, key, keyName string) (bool, error)
 }

--- a/git/provider_github.go
+++ b/git/provider_github.go
@@ -19,8 +19,9 @@ package git
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v32/github"
 	"strings"
+
+	"github.com/google/go-github/v32/github"
 )
 
 // GithubProvider represents a GitHub API wrapper
@@ -174,4 +175,23 @@ func (p *GithubProvider) AddDeployKey(ctx context.Context, r *Repository, key, k
 	}
 
 	return false, nil
+}
+
+// DeleteRepository deletes the GitHub repository
+func (p *GithubProvider) DeleteRepository(ctx context.Context, r *Repository) error {
+	gh, err := p.newClient(r)
+	if err != nil {
+		return fmt.Errorf("client error: %w", err)
+	}
+
+	org := ""
+	if !p.IsPersonal {
+		org = r.Owner
+	}
+
+	if _, err := gh.Repositories.Delete(ctx, org, r.Name); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/git/provider_gitlab.go
+++ b/git/provider_gitlab.go
@@ -19,6 +19,7 @@ package git
 import (
 	"context"
 	"fmt"
+
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -160,4 +161,9 @@ func (p *GitLabProvider) AddDeployKey(ctx context.Context, r *Repository, key, k
 	}
 
 	return false, nil
+}
+
+// DeleteRepository is not supported by GitLab
+func (p *GitLabProvider) DeleteRepository(ctx context.Context, r *Repository) error {
+	return fmt.Errorf("repository deletion is not supported by the GitLab API")
 }


### PR DESCRIPTION
Changes:
- Update go-github to v32.1.0
- Implement repository delete for GitHub 