### PR TITLE
Migrate GitHub actions to environment files

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,9 +20,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Setup Go
-        uses: actions/setup-go@v2-beta
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.14.x
+          go-version: 1.15.x
       - name: Run tests
         run: make all
       - name: Check if working tree is dirty
@@ -35,3 +35,4 @@ jobs:
       - uses: ./actions/kubebuilder
       - uses: ./actions/kubectl
       - uses: ./actions/kustomize
+      - run: kubebuilder version

--- a/actions/helm/entrypoint.sh
+++ b/actions/helm/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-VERSION=${1:-3.3.1}
+VERSION=${1:-3.3.4}
 
 helm_url=https://get.helm.sh && \
 curl -sL ${helm_url}/helm-v${VERSION}-linux-amd64.tar.gz | \
@@ -14,5 +14,5 @@ chmod +x $GITHUB_WORKSPACE/bin/helm
 
 $GITHUB_WORKSPACE/bin/helm version
 
-echo "::add-path::$GITHUB_WORKSPACE/bin"
-echo "::add-path::$RUNNER_WORKSPACE/$(basename $GITHUB_REPOSITORY)/bin"
+echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+echo "$RUNNER_WORKSPACE/$(basename $GITHUB_REPOSITORY)/bin" >> $GITHUB_PATH

--- a/actions/kubebuilder/entrypoint.sh
+++ b/actions/kubebuilder/entrypoint.sh
@@ -10,5 +10,5 @@ mkdir -p $GITHUB_WORKSPACE/kubebuilder
 mv /tmp/kubebuilder_${VERSION}_linux_amd64/* $GITHUB_WORKSPACE/kubebuilder/
 ls -lh $GITHUB_WORKSPACE/kubebuilder/bin
 
-echo "::add-path::$GITHUB_WORKSPACE/kubebuilder/bin"
-echo "::add-path::$RUNNER_WORKSPACE/$(basename $GITHUB_REPOSITORY)/kubebuilder/bin"
+echo "$GITHUB_WORKSPACE/kubebuilder/bin" >> $GITHUB_PATH
+echo "$RUNNER_WORKSPACE/$(basename $GITHUB_REPOSITORY)/kubebuilder/bin" >> $GITHUB_PATH

--- a/actions/kubectl/entrypoint.sh
+++ b/actions/kubectl/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-VERSION=${1:-1.19.1}
+VERSION=${1:-1.19.2}
 
 curl -sL https://storage.googleapis.com/kubernetes-release/release/v${VERSION}/bin/linux/amd64/kubectl > kubectl
 
@@ -12,5 +12,5 @@ chmod +x $GITHUB_WORKSPACE/bin/kubectl
 
 $GITHUB_WORKSPACE/bin/kubectl version --client
 
-echo "::add-path::$GITHUB_WORKSPACE/bin"
-echo "::add-path::$RUNNER_WORKSPACE/$(basename $GITHUB_REPOSITORY)/bin"
+echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+echo "$RUNNER_WORKSPACE/$(basename $GITHUB_REPOSITORY)/bin" >> $GITHUB_PATH

--- a/actions/kustomize/entrypoint.sh
+++ b/actions/kustomize/entrypoint.sh
@@ -14,5 +14,5 @@ chmod +x $GITHUB_WORKSPACE/bin/kustomize
 
 $GITHUB_WORKSPACE/bin/kustomize version
 
-echo "::add-path::$GITHUB_WORKSPACE/bin"
-echo "::add-path::$RUNNER_WORKSPACE/$(basename $GITHUB_REPOSITORY)/bin"
+echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+echo "$RUNNER_WORKSPACE/$(basename $GITHUB_REPOSITORY)/bin" >> $GITHUB_PATH


### PR DESCRIPTION
The `add-path` command is deprecated and will be disabled soon.

Switching to using environment files ref: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/