### PR TITLE
Add unit suffix to reconcile duration metric

### DIFF
--- a/runtime/metrics/recorder.go
+++ b/runtime/metrics/recorder.go
@@ -29,7 +29,7 @@ func NewRecorder() *Recorder {
 		),
 		durationHistogram: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name:    "gotk_reconcile_duration",
+				Name:    "gotk_reconcile_duration_seconds",
 				Help:    "The duration in seconds of a GitOps Toolkit resource reconciliation.",
 				Buckets: prometheus.ExponentialBuckets(10e-9, 10, 10),
 			},


### PR DESCRIPTION
In order to align with the [prometheus metric naming guidelines](https://prometheus.io/docs/practices/naming/) which say
that metric names:

> should have a suffix describing the unit, in plural form.


ref: https://github.com/fluxcd/toolkit/issues/329

Note: a follow up would be needed to update the dashboard added in https://github.com/fluxcd/toolkit/pull/337