### PR TITLE
Reconcile request annotation and helpers

### DIFF
--- a/apis/meta/annotations.go
+++ b/apis/meta/annotations.go
@@ -47,3 +47,27 @@ func ReconcileAnnotationValue(annotations map[string]string) (string, bool) {
 	// used each time, this caveat won't matter.
 	return reconcileAt + requestedAt, ok1 || ok2
 }
+
+// ReconcileRequestStatus is a struct to embed in the status type, so
+// that all types using the mechanism have the same field. Use it like
+// this:
+//
+// ```
+// type WhateverStatus struct {
+//   meta.ReconcileRequestStatus `json:",inline"`
+//   // other status fields...
+// }
+// ```
+type ReconcileRequestStatus struct {
+	// LastHandledReconcileAt holds the value of the most recent
+	// reconcile request value, so a change can be detected.
+	LastHandledReconcileAt string `json:"lastHandledReconcileAt,omitempty"`
+}
+
+func (rs ReconcileRequestStatus) GetLastHandledReconcileRequest() string {
+	return rs.LastHandledReconcileAt
+}
+
+func (rs *ReconcileRequestStatus) SetLastHandledReconcileRequest(token string) {
+	rs.LastHandledReconcileAt = token
+}

--- a/apis/meta/annotations.go
+++ b/apis/meta/annotations.go
@@ -21,6 +21,7 @@ const (
 	// outside of the defined schedule. Despite the name, the value is not
 	// interpreted as a timestamp, and any change in value shall trigger a
 	// reconciliation.
+	// DEPRECATED: has been replaced by ReconcileRequestAnnotation.
 	ReconcileAtAnnotation string = "fluxcd.io/reconcileAt"
 
 	// ReconcileRequestAnnotation is the new ReconcileAtAnnotation,

--- a/apis/meta/annotations.go
+++ b/apis/meta/annotations.go
@@ -22,4 +22,28 @@ const (
 	// interpreted as a timestamp, and any change in value shall trigger a
 	// reconciliation.
 	ReconcileAtAnnotation string = "fluxcd.io/reconcileAt"
+
+	// ReconcileRequestAnnotation is the new ReconcileAtAnnotation,
+	// with a better name. For backward-compatibility, use
+	// ReconcileAnnotationValue, which will account for both
+	// annotations.
+	ReconcileRequestAnnotation string = "reconcile.fluxcd.io/requestedAt"
 )
+
+// ReconcileAnnotationValue returns a value for the reconciliation
+// request annotations, which can be used to detect changes; and, a
+// boolean indicating whether either annotation was set.
+func ReconcileAnnotationValue(annotations map[string]string) (string, bool) {
+	reconcileAt, ok1 := annotations[ReconcileAtAnnotation]
+	requestedAt, ok2 := annotations[ReconcileRequestAnnotation]
+	// the values are concatenated; this means
+	// - a change in either will be detectable*, and
+	// - if one is set, the value will be just that; and,
+	// - if neither is set, it's a zero value.
+	//
+	// *unless the change is to shift a substring across the
+	// interstice between the strings; e.g., by swapping the value
+	// from one annotation to the other. Assuming a fresh timestamp is
+	// used each time, this caveat won't matter.
+	return reconcileAt + requestedAt, ok1 || ok2
+}

--- a/apis/meta/annotations_test.go
+++ b/apis/meta/annotations_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 The Flux CD contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meta
+
+import (
+	"testing"
+	"time"
+)
+
+type WhateverStatus struct {
+	ReconcileRequestStatus `json:",inline"`
+}
+
+type Whatever struct {
+	Annotations map[string]string
+	Status      WhateverStatus `json:"status,omitempty"`
+}
+
+func TestGetAnnotationValue(t *testing.T) {
+	obj := Whatever{
+		Annotations: map[string]string{},
+	}
+
+	val, ok := ReconcileAnnotationValue(obj.Annotations)
+	if val != "" || ok {
+		t.Error("expected ReconcileAnnotationValue to return zero value and false when no annotations")
+	}
+	obj.Status.SetLastHandledReconcileRequest(val)
+
+	// set one annotation: should detect a change
+	obj.Annotations[ReconcileAtAnnotation] = time.Now().Format(time.RFC3339Nano)
+	val, ok = ReconcileAnnotationValue(obj.Annotations)
+	if !ok {
+		t.Error("expected ReconcileAnnotationValue to return true when an annotation is set")
+	}
+
+	if val == obj.Status.GetLastHandledReconcileRequest() {
+		t.Error("expected to detect change in annotation value")
+	}
+
+	obj.Status.SetLastHandledReconcileRequest(val)
+
+	// set the other annotation; should detect a change
+	obj.Annotations[ReconcileRequestAnnotation] = time.Now().Format(time.RFC3339Nano)
+	val, ok = ReconcileAnnotationValue(obj.Annotations)
+	if !ok {
+		t.Error("expected ReconcileAnnotationValue to return true when an annotation is set")
+	}
+
+	if val == obj.Status.GetLastHandledReconcileRequest() {
+		t.Error("expected to detect change in annotation value")
+	}
+}

--- a/runtime/predicates/changed.go
+++ b/runtime/predicates/changed.go
@@ -40,15 +40,11 @@ func (ChangePredicate) Update(e event.UpdateEvent) bool {
 	}
 
 	// handle force sync
-	if val, ok := e.MetaNew.GetAnnotations()[metav1.ReconcileAtAnnotation]; ok {
-		if valOld, okOld := e.MetaOld.GetAnnotations()[metav1.ReconcileAtAnnotation]; okOld {
-			if val != valOld {
-				return true
-			}
-		} else {
-			return true
+	if val, ok := metav1.ReconcileAnnotationValue(e.MetaNew.GetAnnotations()); ok {
+		if valOld, okOld := metav1.ReconcileAnnotationValue(e.MetaOld.GetAnnotations()); okOld {
+			return val != valOld
 		}
+		return true
 	}
-
 	return false
 }


### PR DESCRIPTION
This adds a new annotation name, as proposed in https://github.com/fluxcd/toolkit/discussions/363, and provides some helpers for

 - getting the value in a backward-compatible way
 - recording the value in a CRD status field (so as to detect changes).
