### PR TITLE
Add SetResourceCondition func to apis/meta

### DIFF
--- a/apis/meta/conditions.go
+++ b/apis/meta/conditions.go
@@ -58,7 +58,6 @@ func InReadyCondition(conditions []metav1.Condition) bool {
 // ObjectWithStatusConditions is an interface that describes kubernetes resource
 // type structs with Status Conditions
 type ObjectWithStatusConditions interface {
-	metav1.Object
 	GetStatusConditions() *[]metav1.Condition
 }
 
@@ -66,14 +65,12 @@ type ObjectWithStatusConditions interface {
 // reason and message on a resource.
 func SetResourceCondition(obj ObjectWithStatusConditions, condition string, status metav1.ConditionStatus, reason, message string) {
 	conditions := obj.GetStatusConditions()
-	gen := obj.GetGeneration()
 
 	newCondition := metav1.Condition{
-		Type:               condition,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: gen,
+		Type:    condition,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
 	}
 
 	apimeta.SetStatusCondition(conditions, newCondition)

--- a/apis/meta/conditions.go
+++ b/apis/meta/conditions.go
@@ -54,3 +54,27 @@ const (
 func InReadyCondition(conditions []metav1.Condition) bool {
 	return apimeta.IsStatusConditionTrue(conditions, ReadyCondition)
 }
+
+// ObjectWithStatusConditions is an interface that describes kubernetes resource
+// type structs with Status Conditions
+type ObjectWithStatusConditions interface {
+	metav1.Object
+	GetStatusConditions() *[]metav1.Condition
+}
+
+// SetResourceCondition sets the given condition with the given status,
+// reason and message on a resource.
+func SetResourceCondition(obj ObjectWithStatusConditions, condition string, status metav1.ConditionStatus, reason, message string) {
+	conditions := obj.GetStatusConditions()
+	gen := obj.GetGeneration()
+
+	newCondition := metav1.Condition{
+		Type:               condition,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: gen,
+	}
+
+	apimeta.SetStatusCondition(conditions, newCondition)
+}


### PR DESCRIPTION
Handle setting `Status.Conditions` for any resource implementing the `v1.Object` interface. This is common in all flux api types.

According to suggestion in: https://github.com/fluxcd/pkg/pull/48#issuecomment-723154919