### PR TITLE
Controller helpers

### DIFF
--- a/runtime/controller/doc.go
+++ b/runtime/controller/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controller offers embeddable structs for putting in your
+// controller, to help with conforming to GitOps Toolkit conventions.
+package controller

--- a/runtime/controller/events.go
+++ b/runtime/controller/events.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2020 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kuberecorder "k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/fluxcd/pkg/runtime/events"
+)
+
+// Events is a helper struct that adds the capability of sending
+// events to the Kubernetes API and to the GitOps Toolkit notification
+// controller. You use it by embedding it in your reconciler struct:
+//
+//     type MyTypeReconciler {
+//         client.Client
+//         // ... etc.
+//         controller.Events
+//     }
+//
+//  You initialise a suitable value with MakeEvents(); each reconciler
+//  will probably need its own value, since it's specialised to a
+//  particular controller and log.
+type Events struct {
+	EventRecorder         kuberecorder.EventRecorder
+	ExternalEventRecorder *events.Recorder
+	Log                   logr.Logger
+}
+
+func MakeEvents(mgr ctrl.Manager, controllerName string, ext *events.Recorder, log logr.Logger) Events {
+	return Events{
+		EventRecorder:         mgr.GetEventRecorderFor(controllerName),
+		ExternalEventRecorder: ext,
+		Log:                   log,
+	}
+}
+
+type runtimeAndMetaObject interface {
+	runtime.Object
+	metav1.Object
+}
+
+// Event emits a Kubernetes event, and forwards the event to the
+// notification controller if configured.
+func (e Events) Event(ref *corev1.ObjectReference, obj runtimeAndMetaObject, severity, msg string) {
+	if e.EventRecorder != nil {
+		e.EventRecorder.Event(obj, "Normal", severity, msg)
+	}
+	if e.ExternalEventRecorder != nil {
+		if err := e.ExternalEventRecorder.Eventf(*ref, nil, severity, severity, msg); err != nil {
+			e.Log.WithValues(
+				"request",
+				fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName()),
+			).Error(err, "unable to send event")
+			return
+		}
+	}
+}

--- a/runtime/controller/events.go
+++ b/runtime/controller/events.go
@@ -65,13 +65,13 @@ type runtimeAndMetaObject interface {
 
 // Event emits a Kubernetes event, and forwards the event to the
 // notification controller if configured.
-func (e Events) Event(ctx context.Context, obj runtimeAndMetaObject, severity, reason, msg string) {
-	e.Eventf(ctx, obj, severity, reason, msg)
+func (e Events) Event(ctx context.Context, obj runtimeAndMetaObject, metadata map[string]string, severity, reason, msg string) {
+	e.Eventf(ctx, obj, metadata, severity, reason, msg)
 }
 
 // Eventf emits a Kubernetes event, and forwards the event to the
 // notification controller if configured.
-func (e Events) Eventf(ctx context.Context, obj runtimeAndMetaObject, severity, reason, msgFmt string, args ...interface{}) {
+func (e Events) Eventf(ctx context.Context, obj runtimeAndMetaObject, metadata map[string]string, severity, reason, msgFmt string, args ...interface{}) {
 	if e.EventRecorder != nil {
 		e.EventRecorder.Eventf(obj, severityToEventType(severity), reason, msgFmt, args...)
 	}
@@ -81,7 +81,7 @@ func (e Events) Eventf(ctx context.Context, obj runtimeAndMetaObject, severity, 
 			logr.FromContextOrDiscard(ctx).Error(err, "unable to get object reference to send event")
 			return
 		}
-		if err := e.ExternalEventRecorder.Eventf(*ref, nil, severity, reason, msgFmt, args...); err != nil {
+		if err := e.ExternalEventRecorder.Eventf(*ref, metadata, severity, reason, msgFmt, args...); err != nil {
 			logr.FromContextOrDiscard(ctx).Error(err, "unable to send event")
 			return
 		}

--- a/runtime/controller/metrics.go
+++ b/runtime/controller/metrics.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2020 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	crtlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	"github.com/fluxcd/pkg/runtime/metrics"
+)
+
+// Metrics adds the capability for recording GOTK-standard metrics to
+// a reconciler. Use by embedding into the reconciler struct:
+//
+//     type MyTypeReconciler struct {
+//       client.Client
+//       // ...
+//       controller.Metrics
+//     }
+//
+// then you can call either or both of `RecordDuration` and
+// `RecordReadinessMetric`. API types used in GOTK will usually
+// already be suitable for passing (as a pointer) as the second
+// argument to `RecordReadinessMetric`.
+//
+// When initialising controllers in main.go, use `MustMakeMetrics` to
+// create a working Metrics value; you can supply the same value to
+// all reconcilers.
+type Metrics struct {
+	MetricsRecorder *metrics.Recorder
+}
+
+func MustMakeMetrics() Metrics {
+	metricsRecorder := metrics.NewRecorder()
+	crtlmetrics.Registry.MustRegister(metricsRecorder.Collectors()...)
+	return Metrics{MetricsRecorder: metricsRecorder}
+}
+
+func (m Metrics) RecordDuration(ref *corev1.ObjectReference, startTime time.Time) {
+	if m.MetricsRecorder != nil {
+		m.MetricsRecorder.RecordDuration(*ref, startTime)
+	}
+}
+
+type readinessMetricsable interface {
+	metav1.Object
+	meta.ObjectWithStatusConditions
+}
+
+func (m Metrics) RecordReadinessMetric(ref *corev1.ObjectReference, obj readinessMetricsable) {
+	if m.MetricsRecorder == nil {
+		return
+	}
+	if rc := apimeta.FindStatusCondition(*obj.GetStatusConditions(), meta.ReadyCondition); rc != nil {
+		m.MetricsRecorder.RecordCondition(*ref, *rc, !obj.GetDeletionTimestamp().IsZero())
+	} else {
+		m.MetricsRecorder.RecordCondition(*ref, metav1.Condition{
+			Type:   meta.ReadyCondition,
+			Status: metav1.ConditionUnknown,
+		}, !obj.GetDeletionTimestamp().IsZero())
+	}
+}

--- a/runtime/events/event.go
+++ b/runtime/events/event.go
@@ -23,9 +23,11 @@ import (
 
 // Valid values for event severity.
 const (
-	// Information only and will not cause any problems.
+	// EventSeverityInfo represents an informational event, usually
+	// informing about changes.
 	EventSeverityInfo string = "info"
-	// These events are to warn that something might go wrong.
+	// EventSeverityError represent an error event, usually a warning
+	// that something goes wrong.
 	EventSeverityError string = "error"
 )
 
@@ -37,6 +39,7 @@ type Event struct {
 	InvolvedObject corev1.ObjectReference `json:"involvedObject"`
 
 	// Severity type of this event (info, error)
+	// +kubebuilder:validation:Enum=info;error
 	// +required
 	Severity string `json:"severity"`
 
@@ -45,7 +48,8 @@ type Event struct {
 	Timestamp metav1.Time `json:"timestamp"`
 
 	// A human-readable description of this event.
-	// Maximum length 39,000 characters
+	// Maximum length 39,000 characters.
+	// +kubebuilder:validation:MaxLength=39000
 	// +required
 	Message string `json:"message"`
 


### PR DESCRIPTION
This is an experimental PR to see if some of the bits common to all the GOTK controllers can be factored out into embeddable structs.

Among other things, this will

 - reduce duplication
 - standardise how these common bits are done

It is a bit rough around the edges:

**You have to supply an ObjectReference to both the metrics and the events methods**. This is because all the constituent bits calculated this for themselves, and had different ways of dealing with errors. This way, the error handling is done once, up front, and the ref only has to be calculated once. But it would be nice to do this behind the scenes, in some way.

**You have to pass logs in to the Events helper**. This is a bit awkward, as getting logs to funcs always is. It'd be nice if the setup could just do this for you.
