### PR TITLE
Share maintainers from fluxcd/flux2

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2,7 +2,7 @@ The maintainers are generally available in Slack at
 https://cloud-native.slack.com in #flux (https://cloud-native.slack.com/messages/CLAJ40HV3)
 (obtain an invitation at https://slack.cncf.io/).
 
-In alphabetical order:
+This project shares maintainers from the main Flux v2 git repository,
+as listed in
 
-Hidde Beydals, Weaveworks <hidde@weave.works> (github: @hiddeco, slack: hidde)
-Stefan Prodan, Weaveworks <stefan@weave.works> (github: @stefanprodan, slack: stefanprodan)
+    https://github.com/fluxcd/flux2/blob/main/MAINTAINERS


### PR DESCRIPTION
See https://github.com/fluxcd/flux2/discussions/515.

(NB this one has no maintainers that are not already flux2 maintainers, hence different wording.)