### PR TITLE
Ensure correct group is gotten from gitlab search

### DIFF
--- a/git/provider.go
+++ b/git/provider.go
@@ -21,7 +21,6 @@ import "context"
 // Provider is the interface that a git provider should implement
 type Provider interface {
 	CreateRepository(ctx context.Context, r *Repository) (bool, error)
-	GetRepositoryOwner(ctx context.Context, owner string) (string, error)
 	DeleteRepository(ctx context.Context, r *Repository) error
 	AddTeam(ctx context.Context, r *Repository, name, permission string) (bool, error)
 	AddDeployKey(ctx context.Context, r *Repository, key, keyName string) (bool, error)

--- a/git/provider.go
+++ b/git/provider.go
@@ -21,6 +21,7 @@ import "context"
 // Provider is the interface that a git provider should implement
 type Provider interface {
 	CreateRepository(ctx context.Context, r *Repository) (bool, error)
+	GetRepositoryOwner(ctx context.Context, owner string) (string, error)
 	DeleteRepository(ctx context.Context, r *Repository) error
 	AddTeam(ctx context.Context, r *Repository, name, permission string) (bool, error)
 	AddDeployKey(ctx context.Context, r *Repository, key, keyName string) (bool, error)

--- a/git/provider_github.go
+++ b/git/provider_github.go
@@ -86,6 +86,14 @@ func (p *GithubProvider) CreateRepository(ctx context.Context, r *Repository) (b
 	return false, nil
 }
 
+// Deprecated, this has become obsolete due to changes in getProjects
+//
+// GetRepositoryOwner returns the actual path owner. This is need for Gitlab where the name of a group might differ
+// from its path
+func (p *GithubProvider) GetRepositoryOwner(ctx context.Context, token string, owner string) (string, error) {
+	return owner, nil
+}
+
 // AddTeam returns false if the team is already assigned to the repository
 func (p *GithubProvider) AddTeam(ctx context.Context, r *Repository, name, permission string) (bool, error) {
 	gh, err := p.newClient(r)

--- a/git/provider_github.go
+++ b/git/provider_github.go
@@ -86,12 +86,6 @@ func (p *GithubProvider) CreateRepository(ctx context.Context, r *Repository) (b
 	return false, nil
 }
 
-// GetRepositoryOwner returns the actual path owner. This is need for Gitlab where the name of a group might differ
-// from its path
-func (p *GithubProvider) GetRepositoryOwner(ctx context.Context, token string, owner string) (string, error) {
-	return owner, nil
-}
-
 // AddTeam returns false if the team is already assigned to the repository
 func (p *GithubProvider) AddTeam(ctx context.Context, r *Repository, name, permission string) (bool, error) {
 	gh, err := p.newClient(r)

--- a/git/provider_gitlab.go
+++ b/git/provider_gitlab.go
@@ -84,6 +84,33 @@ func (p *GitLabProvider) CreateRepository(ctx context.Context, r *Repository) (b
 	return true, nil
 }
 
+// Deprecated, this has become obsolete due to changes in getProjects
+//
+// GetRepositoryOwner returns the actual path owner. This is need for Gitlab where the name of a group might differ
+// from its path
+func (p *GitLabProvider) GetRepositoryOwner(ctx context.Context, token string, owner string) (string, error) {
+	gl, err := gitlab.NewClient(token)
+	if err != nil {
+		return "", fmt.Errorf("client error: %w", err)
+	}
+
+	groupName := strings.Split(owner, "/")[0]
+	lgo := &gitlab.ListGroupsOptions{
+		Search:         gitlab.String(groupName),
+		MinAccessLevel: gitlab.AccessLevel(gitlab.GuestPermissions),
+	}
+	groups, _, err := gl.Groups.ListGroups(lgo, gitlab.WithContext(ctx))
+	if err != nil {
+		return "", fmt.Errorf("failed to list groups, error: %w", err)
+	}
+
+	if len(groups) == 0 {
+		return "", fmt.Errorf("failed to find group named '%s'", groupName)
+	}
+
+	return groups[0].Path, nil
+}
+
 // AddTeam returns false if the team is already assigned to the repository
 func (p *GitLabProvider) AddTeam(ctx context.Context, r *Repository, name, permission string) (bool, error) {
 	return false, nil


### PR DESCRIPTION
This PR 
1. ensures that the group and subgroup gotten from the GitLab search is the same specified by the user
2. sets the correct gitlab path in the `getProjects` function and removes `getRepositoryOwner` from the interface.

I tested these changes on a self-hosted GitLab instance and I confirm that I fixed the regression bug introduced in [flux#681](https://github.com/fluxcd/flux2/pull/681) that prevented users from using a custom hostname instead of gitlab.com

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>