### PR TITLE
Fix false negatives from reconcile-at predicate

### DIFF
--- a/runtime/predicates/reconcile_at_changed.go
+++ b/runtime/predicates/reconcile_at_changed.go
@@ -46,8 +46,8 @@ func (ReconcilateAtChangedPredicate) Update(e event.UpdateEvent) bool {
 		return false
 	}
 
-	if val, ok := metav1.ReconcileAnnotationValue(e.ObjectOld.GetAnnotations()); ok {
-		if valOld, okOld := metav1.ReconcileAnnotationValue(e.ObjectNew.GetAnnotations()); okOld {
+	if val, ok := metav1.ReconcileAnnotationValue(e.ObjectNew.GetAnnotations()); ok {
+		if valOld, okOld := metav1.ReconcileAnnotationValue(e.ObjectOld.GetAnnotations()); okOld {
 			return val != valOld
 		}
 		return true


### PR DESCRIPTION
The logic of the (newly separated) ReconcileAtChanged predicate should
be:

    if new object has reconcileAt annotation
      if old obj has different or no annotation -> true
    else -> false

However the old and new object were swapped around, leading to

    if old object has reconcileAt annotation
    ...

which results in `false` when the annotation has just been applied,
when it should be `true`.

Signed-off-by: Michael Bridgen <michael@weave.works>