### PR TITLE
GitLab: Check both the name and the path when searching for groups

### DIFF
--- a/git/provider_gitlab.go
+++ b/git/provider_gitlab.go
@@ -202,7 +202,13 @@ func (p *GitLabProvider) getProjects(ctx context.Context, gl *gitlab.Client, r *
 			return nil, nil, fmt.Errorf("failed to list groups, error: %w", err)
 		}
 
-		group := findGroupByName(groups, groupAndSubGroups[0])
+		var group *gitlab.Group
+		if foundGroup := findGroupByName(groups, groupAndSubGroups[0]); foundGroup == nil {
+			group = findGroupByPath(groups, groupAndSubGroups[0])
+		} else {
+			group = foundGroup
+		}
+
 		if len(groups) == 0 || group == nil {
 			return nil, nil, fmt.Errorf("failed to find group named '%s'", r.Owner)
 		}


### PR DESCRIPTION
This pull-request checks for the name or the path when finding the group from the search returned by GitLab.
Currently, users of flux v0.6.1, due to this pull request #67, get a `failed to find group` error because we check only the name. In v0.6.next, they will be able to.
Issue ref: [flux2#727](https://github.com/fluxcd/flux2/issues/727)

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>