### PR TITLE
Add Kubernetes client options (QPS and Burst) to runtime

### DIFF
--- a/runtime/client/client.go
+++ b/runtime/client/client.go
@@ -1,0 +1,40 @@
+package client
+
+import (
+	"github.com/spf13/pflag"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	flagQPS   = "kube-api-qps"
+	flagBurst = "kube-api-burst"
+)
+
+// Options contains the configuration options for the Kubernetes client.
+type Options struct {
+	// QPS indicates the maximum queries-per-second of
+	//requests sent to to the Kubernetes API, defaults to 20.
+	QPS float32
+
+	// Burst indicates the maximum burst queries-per-second of
+	// requests sent to the Kubernetes API, defaults to 50.
+	Burst int
+}
+
+// BindFlags will parse the given flagset for Kubernetes client option flags and
+// set the Options accordingly.
+func (o *Options) BindFlags(fs *pflag.FlagSet) {
+	fs.Float32Var(&o.QPS, flagQPS, 20.0,
+		"The maximum queries-per-second of requests sent to the Kubernetes API.")
+	fs.IntVar(&o.Burst, flagBurst, 50,
+		"The maximum burst queries-per-second of requests sent to the Kubernetes API.")
+}
+
+// GetConfigOrDie wraps ctrl.GetConfigOrDie and sets the QPS and Bust options
+func GetConfigOrDie(opts Options) *rest.Config {
+	restConfig := ctrl.GetConfigOrDie()
+	restConfig.QPS = opts.QPS
+	restConfig.Burst = opts.Burst
+	return restConfig
+}

--- a/runtime/go.mod
+++ b/runtime/go.mod
@@ -5,14 +5,15 @@ go 1.15
 replace github.com/fluxcd/pkg/apis/meta => ../apis/meta
 
 require (
-	github.com/fluxcd/pkg/apis/meta v0.6.0
+	github.com/fluxcd/pkg/apis/meta v0.7.0
 	github.com/go-logr/logr v0.3.0
 	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/prometheus/client_golang v1.7.1
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/zap v1.16.0
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
-	k8s.io/client-go v0.20.2 // indirect
+	k8s.io/client-go v0.20.2
 	sigs.k8s.io/controller-runtime v0.8.0
 )

--- a/runtime/logger/logger.go
+++ b/runtime/logger/logger.go
@@ -17,9 +17,8 @@ limitations under the License.
 package logger
 
 import (
-	"flag"
-
 	"github.com/go-logr/logr"
+	"github.com/spf13/pflag"
 	"go.uber.org/zap/zapcore"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -49,7 +48,7 @@ type Options struct {
 
 // BindFlags will parse the given flagset for logger option flags and
 // set the Options accordingly.
-func (o *Options) BindFlags(fs *flag.FlagSet) {
+func (o *Options) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.LogEncoding, flagLogEncoding, "json",
 		"Log encoding format. Can be 'json' or 'console'.")
 	fs.StringVar(&o.LogLevel, flagLogLevel, "info",


### PR DESCRIPTION
This PR adds helper functions for injecting the `kube-api-qps` and `kube-api-burst` in the GitOps toolkit controllers flags.
The logger flags are now set with `spf13/pflag`.