### PR TITLE
Drop required access level when listing groups using the GitLab API

### DIFF
--- a/git/provider_gitlab.go
+++ b/git/provider_gitlab.go
@@ -193,8 +193,7 @@ func (p *GitLabProvider) getProjects(ctx context.Context, gl *gitlab.Client, r *
 	if !p.IsPersonal {
 		groupAndSubGroups := strings.Split(r.Owner, "/")
 		lgo := &gitlab.ListGroupsOptions{
-			Search:         gitlab.String(groupAndSubGroups[0]),
-			MinAccessLevel: gitlab.AccessLevel(gitlab.GuestPermissions),
+			Search: gitlab.String(groupAndSubGroups[0]),
 		}
 
 		groups, _, err := gl.Groups.ListGroups(lgo, gitlab.WithContext(ctx))
@@ -220,8 +219,7 @@ func (p *GitLabProvider) getProjects(ctx context.Context, gl *gitlab.Client, r *
 		if len(groupAndSubGroups) > 1 {
 			lastSubGroup := groupAndSubGroups[len(groupAndSubGroups)-1]
 			ldgo := &gitlab.ListDescendantGroupsOptions{
-				Search:         gitlab.String(lastSubGroup),
-				MinAccessLevel: gitlab.AccessLevel(gitlab.GuestPermissions),
+				Search: gitlab.String(lastSubGroup),
 			}
 			subGroups, _, err := gl.Groups.ListDescendantGroups(*gid, ldgo, gitlab.WithContext(ctx))
 			subGroup := findGroupByName(subGroups, lastSubGroup)


### PR DESCRIPTION
Resolves #75 

I did run a small test vs our local gitlab instance without any issues:
![image](https://user-images.githubusercontent.com/3579167/105355537-967e3980-5bf2-11eb-92cc-b4093258f6b7.png)
