### PR TITLE
Make SSH server usable for testing

### DIFF
--- a/gittestserver/server.go
+++ b/gittestserver/server.go
@@ -45,7 +45,9 @@ func NewGitServer(docroot string) *GitServer {
 		panic(err)
 	}
 	return &GitServer{
-		config: gitkit.Config{Dir: root},
+		config: gitkit.Config{
+			Dir: root,
+		},
 	}
 }
 
@@ -61,6 +63,13 @@ type GitServer struct {
 // repository on push.
 func (s *GitServer) AutoCreate() *GitServer {
 	s.config.AutoCreate = true
+	return s
+}
+
+// KeyDir sets the SSH key directory in the config. Use before calling
+// StartSSH.
+func (s *GitServer) KeyDir(dir string) *GitServer {
+	s.config.KeyDir = dir
 	return s
 }
 
@@ -111,7 +120,9 @@ func (s *GitServer) StopHTTP() {
 	return
 }
 
-// StartSSH starts a new SSH git server with the current configuration.
+// StartSSH starts a new SSH git server with the current
+// configuration. This returns an error or (unlike StartHTTP[S])
+// blocks until the listener is stopped with `s.StopSSH()`.
 func (s *GitServer) StartSSH() error {
 	_ = s.StopSSH()
 	s.sshServer = gitkit.NewSSH(s.config)

--- a/gittestserver/server_test.go
+++ b/gittestserver/server_test.go
@@ -1,0 +1,26 @@
+package gittestserver
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCreateSSHServer(t *testing.T) {
+	srv, err := NewTempGitServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// without setting the key dir, the SSH server will fail to start
+	srv.KeyDir(srv.Root())
+	errc := make(chan error)
+	go func() {
+		errc <- srv.StartSSH()
+	}()
+	select {
+	case err := <-errc:
+		t.Fatal(err)
+	case <-time.After(time.Second):
+		break
+	}
+	srv.StopSSH()
+}

--- a/gittestserver/server_test.go
+++ b/gittestserver/server_test.go
@@ -1,6 +1,7 @@
 package gittestserver
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -23,4 +24,21 @@ func TestCreateSSHServer(t *testing.T) {
 		break
 	}
 	srv.StopSSH()
+}
+
+func TestListenSSH(t *testing.T) {
+	srv, err := NewTempGitServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.KeyDir(srv.Root())
+	if err = srv.ListenSSH(); err != nil {
+		t.Fatal(err)
+	}
+	defer srv.StopSSH()
+	addr := srv.SSHAddress()
+	// check it's got the right protocol, at least
+	if !strings.HasPrefix(addr, "ssh://") {
+		t.Fatal("URL given for SSH server doesn't start with ssh://")
+	}
 }


### PR DESCRIPTION
The underlying library, gitkit, expects to have a KeyDir supplied in its *Config when running an SSH server. It's uncertain whether StartSSH is used anywhere (and it wouldn't work, if it is); but for the least disruption, I have added a func for supplying the KeyDir value rather than changing the signature of any existing func.

Since StartSSH blocks when it succeeds, the test has to do a kludge with a timer to be able to exit.

`StartSSH()` doesn't return until `StopSSH()` is called (or there's an error). This makes it difficult to use in tests, since you will usually want to know the address to use before proceeding with the rest of the test, but the listener must be created before it can be obtained.

This PR adds a `ListenSSH()`, which creates the SSH server and listener on localhost, then returns. That means you can call `ListenSSH()`, get the address, start a goroutine to run StartSSH(), then complete the test (and `StopSSH()`).

The semantics of how to use SSH server is different now: instead of StartSSH creating a new server (with a new listener), both ListenSSH() and StartSSH() create a server _if it hasn't been created already_. This is necessary because creating a new listener each time invalidates any address obtained from `SSHAddress()` previously, making the test control flow above impossible.

Another change, for testing convenience: `SSHAddress()` now returns a URL you can use with git, like `HTTPAddress()` does.
