### PR TITLE
Uses suspendGuage in RecordSuspend

### DIFF
--- a/runtime/metrics/recorder.go
+++ b/runtime/metrics/recorder.go
@@ -74,7 +74,7 @@ func (r *Recorder) RecordSuspend(ref corev1.ObjectReference, suspend bool) {
 		value = 1
 	}
 
-	r.conditionGauge.WithLabelValues(ref.Kind, ref.Name, ref.Namespace).Set(value)
+	r.suspendGauge.WithLabelValues(ref.Kind, ref.Name, ref.Namespace).Set(value)
 }
 
 func (r *Recorder) RecordDuration(ref corev1.ObjectReference, start time.Time) {


### PR DESCRIPTION
This fix sets the correct gauge in RecordSuspend.

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>