### PR TITLE
Add leader election config to runtime

### DIFF
--- a/runtime/leaderelection/leaderelection.go
+++ b/runtime/leaderelection/leaderelection.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+const (
+	flagEnable          = "enable-leader-election"
+	flagReleaseOnCancel = "leader-election-release-on-cancel"
+	flagLeaseDuration   = "leader-election-lease-duration"
+	flagRenewDeadline   = "leader-election-renew-deadline"
+	flagRetryPeriod     = "leader-election-retry-period"
+)
+
+// Options contains the configuration options for the leader election.
+type Options struct {
+	// Enable determines whether or not to use leader election when
+	// starting the manager.
+	Enable bool
+
+	// ReleaseOnCancel defines if the leader should step down voluntarily
+	// when the Manager ends. This requires the binary to immediately end when the
+	// Manager is stopped, otherwise this setting is unsafe. Setting this significantly
+	// speeds up voluntary leader transitions as the new leader doesn't have to wait
+	// LeaseDuration time first.
+	ReleaseOnCancel bool
+
+	// LeaseDuration is the duration that non-leader candidates will
+	// wait to force acquire leadership. This is measured against time of
+	// last observed ack. Default is 30 seconds.
+	LeaseDuration time.Duration
+
+	// RenewDeadline is the duration that the acting controlplane will retry
+	// refreshing leadership before giving up. Default is 60 seconds.
+	RenewDeadline time.Duration
+
+	// RetryPeriod is the duration the LeaderElector clients should wait
+	// between tries of actions. Default is 5 seconds.
+	RetryPeriod time.Duration
+}
+
+// BindFlags will parse the given flagset for leader election option flags
+// and set the Options accordingly.
+func (o *Options) BindFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&o.Enable, flagEnable, false,
+		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	fs.BoolVar(&o.ReleaseOnCancel, flagReleaseOnCancel, true,
+		"Defines if the leader should step down voluntarily on controller manager shutdown.")
+	fs.DurationVar(&o.LeaseDuration, flagLeaseDuration, 30*time.Second,
+		"Interval at which non-leader candidates will wait to force acquire leadership (duration string).")
+	fs.DurationVar(&o.RenewDeadline, flagRenewDeadline, 60*time.Second,
+		"Duration that the leading controller manager will retry refreshing leadership before giving up (duration string).")
+	fs.DurationVar(&o.RetryPeriod, flagRetryPeriod, 5*time.Second,
+		"Duration the LeaderElector clients should wait between tries of actions (duration string).")
+}


### PR DESCRIPTION
This PR adds cmd flags for fine tuning the controller-runtime leader election. To make the leader election more tolerant to transient Kubernetes API outages (rate limits, CNI upgrade, control plane upgrades, etc) the renewal deadline was increased from 10 seconds to one minute and the retry interval was bumped to 5 seconds.