### PR TITLE
Trace log level

### DIFF
--- a/runtime/logger/logger.go
+++ b/runtime/logger/logger.go
@@ -39,6 +39,15 @@ var levelStrings = map[string]zapcore.Level{
 	"error": zapcore.ErrorLevel,
 }
 
+// These are for convenience when doing log.V(...) to log at a
+// particular level. They correspond to the logr equivalents of the
+// zap levels above.
+const (
+	TraceLevel = 2
+	DebugLevel = 1
+	InfoLevel  = 0
+)
+
 var stackLevelStrings = map[string]zapcore.Level{
 	"trace": zapcore.ErrorLevel,
 	"debug": zapcore.ErrorLevel,

--- a/runtime/logger/logger.go
+++ b/runtime/logger/logger.go
@@ -29,12 +29,18 @@ const (
 )
 
 var levelStrings = map[string]zapcore.Level{
+	// zap doesn't include trace level as a const, but it accepts any
+	// int8; logr will convert a log.V(n) to zap's scheme, so e.g.,
+	// V(2) will be custom debug level -2 in zap (i.e., `trace`
+	// below).
+	"trace": zapcore.DebugLevel - 1,
 	"debug": zapcore.DebugLevel,
 	"info":  zapcore.InfoLevel,
 	"error": zapcore.ErrorLevel,
 }
 
 var stackLevelStrings = map[string]zapcore.Level{
+	"trace": zapcore.ErrorLevel,
 	"debug": zapcore.ErrorLevel,
 	"info":  zapcore.PanicLevel,
 	"error": zapcore.PanicLevel,
@@ -52,7 +58,7 @@ func (o *Options) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.LogEncoding, flagLogEncoding, "json",
 		"Log encoding format. Can be 'json' or 'console'.")
 	fs.StringVar(&o.LogLevel, flagLogLevel, "info",
-		"Log verbosity level. Can be one of 'debug', 'info', 'error'.")
+		"Log verbosity level. Can be one of 'trace', 'debug', 'info', 'error'.")
 }
 
 // NewLogger returns a logger configured with the given Options,


### PR DESCRIPTION
Fixes #112, by adding `trace` to the possible log level values.

The underlying logging library, zap, will accept "custom debug levels" (i.e., levels numerically less than debug -- its levels are in ascending order of importance). It logs these with e.g., `LEVEL(-2)`, but there's no way around that. At least the mechanism works.