### PR TITLE
don't install kubectl as part of kubebuilder tools

### DIFF
--- a/actions/kubebuilder/entrypoint.sh
+++ b/actions/kubebuilder/entrypoint.sh
@@ -6,6 +6,9 @@ VERSION=${1:-2.3.1}
 
 curl -sL https://go.kubebuilder.io/dl/${VERSION}/linux/amd64 | tar -xz -C /tmp/
 
+# remove kubectl as this is supposed to be installed separately
+rm /tmp/kubebuilder_${VERSION}_linux_amd64/kubectl
+
 mkdir -p $GITHUB_WORKSPACE/kubebuilder
 mv /tmp/kubebuilder_${VERSION}_linux_amd64/* $GITHUB_WORKSPACE/kubebuilder/
 ls -lh $GITHUB_WORKSPACE/kubebuilder/bin


### PR DESCRIPTION
While the kubectl action defined in this repo installs a recent
version of kubectl, all action workflows use the kubectl binary
installed from kubebuilder which is very old (v1.16.4 for kubebuilder
tools version 2.3.1).

This is from a recent workflow run:

https://github.com/fluxcd/helm-controller/pull/294/checks?check_run_id=3018781524#step:10:9

```
Client Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.4", ...
```