### PR TITLE
Order ReconcilingCondition before ReadyCondition

### DIFF
--- a/runtime/conditions/setter.go
+++ b/runtime/conditions/setter.go
@@ -166,12 +166,10 @@ func Delete(to Setter, t string) {
 }
 
 // conditionWeights defines the weight of condition types that have priority in lexicographicLess.
-// TODO(hidde): given Reconciling is an abnormality-true type, and SHOULD only be present on the
-//  resource if applicable, I think it actually should have a higher priority than Ready.
 var conditionWeights = map[string]int{
 	meta.StalledCondition:     0,
-	meta.ReadyCondition:       1,
-	meta.ReconcilingCondition: 2,
+	meta.ReconcilingCondition: 1,
+	meta.ReadyCondition:       2,
 }
 
 // lexicographicLess returns true if a condition is less than another with regards to the to order of conditions

--- a/runtime/conditions/setter_test.go
+++ b/runtime/conditions/setter_test.go
@@ -88,8 +88,8 @@ func TestLexicographicLess(t *testing.T) {
 	g.Expect(lexicographicLess(stalled, ready)).To(BeTrue())
 	g.Expect(lexicographicLess(ready, stalled)).To(BeFalse())
 
-	g.Expect(lexicographicLess(ready, reconciling)).To(BeTrue())
-	g.Expect(lexicographicLess(reconciling, ready)).To(BeFalse())
+	g.Expect(lexicographicLess(reconciling, ready)).To(BeTrue())
+	g.Expect(lexicographicLess(ready, reconciling)).To(BeFalse())
 
 	g.Expect(lexicographicLess(stalled, reconciling)).To(BeTrue())
 	g.Expect(lexicographicLess(reconciling, stalled)).To(BeFalse())


### PR DESCRIPTION
This is more logical, as both `StalledCondition` and
`ReconcilingCondition` are abnormal-true types, and should thus only be
present on a resource when the condition is True.

