### PR TITLE
Add GitServer method for installing an update hook

### DIFF
--- a/gittestserver/server.go
+++ b/gittestserver/server.go
@@ -76,6 +76,24 @@ func (s *GitServer) KeyDir(dir string) *GitServer {
 	return s
 }
 
+// InstallUpdateHook installs a hook script that will run running
+// _before_ a push is accepted, as described at
+//
+//    https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
+//
+// The provided string is written as an executable script to the hooks
+// directory; start with a hashbang to make sure it'll run, e.g.,
+//
+//     #!/bin/bash
+func (s *GitServer) InstallUpdateHook(script string) *GitServer {
+	if s.config.Hooks == nil {
+		s.config.Hooks = &gitkit.HookScripts{}
+	}
+	s.config.Hooks.Update = script
+	s.config.AutoHooks = true
+	return s
+}
+
 // Auth switches authentication on for both HTTP and SSH servers.
 // It's not possible to switch authentication on for just one of
 // them. The username and password provided are _only_ used for


### PR DESCRIPTION
For testing what a controller does when the git server balks at an operation (e.g., pushing a branch), it's useful to be able to install a service-side git hook in the test git server.

The new method added here is for installing an update hook (runs for each updated ref), which is the one I needed; pre-receive (runs before accepting the push) and post-receive (runs after accepting the push) are trivial adaptations, should they be needed.

NB I have not provided a test for this, because I didn't think the cost of writing out all the steps was worth it to prove that the underlying library (gitkit) does what it says. (I do however rely on it working, in a test for image update automation).