### PR TITLE
gittestserver: Cleanup the test git repo dir

### DIFF
--- a/gittestserver/server_test.go
+++ b/gittestserver/server_test.go
@@ -1,6 +1,7 @@
 package gittestserver
 
 import (
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ func TestCreateSSHServer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer os.RemoveAll(srv.Root())
 	// without setting the key dir, the SSH server will fail to start
 	srv.KeyDir(srv.Root())
 	errc := make(chan error)
@@ -31,6 +33,7 @@ func TestListenSSH(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer os.RemoveAll(srv.Root())
 	srv.KeyDir(srv.Root())
 	if err = srv.ListenSSH(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Cleanup the temporary directories created by the gittestserver tests.

The tests used to leave behind the test git repo directories:

```console
$ ls /tmp/git-server-test-
git-server-test-032134880/ git-server-test-047540379/ git-server-test-391635912/ git-server-test-715720328/ git-server-test-845366975/
git-server-test-033305159/ git-server-test-093962088/ git-server-test-576842540/ git-server-test-772416423/ git-server-test-939106439/
```