### PR TITLE
runtime/conditions: add kstatus condition helpers

### DIFF
--- a/runtime/conditions/getter.go
+++ b/runtime/conditions/getter.go
@@ -57,8 +57,8 @@ func Has(from Getter, t string) bool {
 	return Get(from, t) != nil
 }
 
-// IsTrue is true if the condition with the given type is True, otherwise it return false if the condition is not True
-// or if the condition does not exist (is nil).
+// IsTrue is true if the condition with the given type is True, otherwise it is false if the condition is not True or if
+// the condition does not exist (is nil).
 func IsTrue(from Getter, t string) bool {
 	if c := Get(from, t); c != nil {
 		return c.Status == metav1.ConditionTrue
@@ -66,8 +66,8 @@ func IsTrue(from Getter, t string) bool {
 	return false
 }
 
-// IsFalse is true if the condition with the given type is False, otherwise it return false if the condition is not
-// False or if the condition does not exist (is nil).
+// IsFalse is true if the condition with the given type is False, otherwise it is false if the condition is not False or
+// if the condition does not exist (is nil).
 func IsFalse(from Getter, t string) bool {
 	if c := Get(from, t); c != nil {
 		return c.Status == metav1.ConditionFalse
@@ -81,6 +81,24 @@ func IsUnknown(from Getter, t string) bool {
 		return c.Status == metav1.ConditionUnknown
 	}
 	return true
+}
+
+// IsReady is true if IsStalled and IsReconciling are False, and meta.ReadyCondition is True, otherwise it is false if
+// the condition is not True or if it does not exist (is nil).
+func IsReady(from Getter) bool {
+	return !IsStalled(from) && !IsReconciling(from) && IsTrue(from, meta.ReadyCondition)
+}
+
+// IsStalled is true if meta.StalledCondition is True and meta.ReconcilingCondition is False or does not exist,
+// otherwise it is false.
+func IsStalled(from Getter) bool {
+	return !IsTrue(from, meta.ReconcilingCondition) && IsTrue(from, meta.StalledCondition)
+}
+
+// IsReconciling is true if meta.ReconcilingCondition is True and meta.StalledCondition is False or does not exist,
+// otherwise it is false.
+func IsReconciling(from Getter) bool {
+	return !IsTrue(from, meta.StalledCondition) && IsTrue(from, meta.ReconcilingCondition)
 }
 
 // GetReason returns a nil safe string of Reason for the condition with the given type.

--- a/runtime/conditions/setter.go
+++ b/runtime/conditions/setter.go
@@ -130,6 +130,25 @@ func MarkFalse(to Setter, t, reason, messageFormat string, messageArgs ...interf
 	Set(to, FalseCondition(t, reason, messageFormat, messageArgs...))
 }
 
+// MarkReconciling sets meta.ReconcilingCondition=True with the given reason and message, and deletes the
+// meta.StalledCondition. This is normally called at the beginning of a reconcile run for an object.
+// For more information about the condition types, see the kstatus spec:
+// https://github.com/kubernetes-sigs/cli-utils/blob/e351b2bc43cec2107ba1d874c3dec54fd0956c59/pkg/kstatus/README.md#conditions
+func MarkReconciling(to Setter, reason, messageFormat string, messageArgs ...interface{}) {
+	Delete(to, meta.StalledCondition)
+	MarkTrue(to, meta.ReconcilingCondition, reason, messageFormat, messageArgs...)
+}
+
+// MarkStalled sets meta.StalledCondition=True with the given reason and message, and deletes the
+// meta.ReconcilingCondition. This is normally deferred and conditionally called at the end of a reconcile run for an
+// object. A common approach is to mark the object stalled if the object is not requeued as a reconcile result.
+// For more information about the condition types, see the kstatus spec:
+// https://github.com/kubernetes-sigs/cli-utils/blob/e351b2bc43cec2107ba1d874c3dec54fd0956c59/pkg/kstatus/README.md#conditions
+func MarkStalled(to Setter, reason, messageFormat string, messageArgs ...interface{}) {
+	Delete(to, meta.ReconcilingCondition)
+	MarkTrue(to, meta.StalledCondition, reason, messageFormat, messageArgs...)
+}
+
 // SetSummary creates a new summary condition with the summary of all the conditions existing on an object.
 // If the object does not have other conditions, no summary condition is generated.
 func SetSummary(to Setter, targetCondition string, options ...MergeOption) {

--- a/runtime/conditions/setter_test.go
+++ b/runtime/conditions/setter_test.go
@@ -238,6 +238,28 @@ func TestMarkMethods(t *testing.T) {
 		Reason:  "reasonBaz",
 		Message: "messageBaz",
 	}))
+
+	// test MarkReconciling
+	MarkTrue(obj, meta.StalledCondition, "reasonStalled", "messageStalled")
+	MarkReconciling(obj, "reasonReconciling", "messageReconciling")
+	g.Expect(Get(obj, meta.ReconcilingCondition)).To(HaveSameStateOf(&metav1.Condition{
+		Type:    meta.ReconcilingCondition,
+		Status:  metav1.ConditionTrue,
+		Reason:  "reasonReconciling",
+		Message: "messageReconciling",
+	}))
+	g.Expect(IsUnknown(obj, meta.StalledCondition)).To(BeTrue())
+
+	// test MarkStalled
+	MarkTrue(obj, meta.ReconcilingCondition, "reasonReconciling", "messageReconciling")
+	MarkStalled(obj, "reasonStalled", "messageStalled")
+	g.Expect(Get(obj, meta.StalledCondition)).To(HaveSameStateOf(&metav1.Condition{
+		Type:    meta.StalledCondition,
+		Status:  metav1.ConditionTrue,
+		Reason:  "reasonStalled",
+		Message: "messageStalled",
+	}))
+	g.Expect(IsUnknown(obj, meta.ReconcilingCondition)).To(BeTrue())
 }
 
 func TestSetSummary(t *testing.T) {

--- a/runtime/patch/patch.go
+++ b/runtime/patch/patch.go
@@ -71,7 +71,7 @@ import (
 //					Conditions: []string{
 //						meta.ReadyCondition,
 //						meta.ReconcilingCondition,
-//						meta.ProgressingReason,
+//						meta.StalledCondition,
 //						// any other "owned conditions"
 //					},
 //				},


### PR DESCRIPTION
This commit adds getter and setter helpers to `runtime/conditions` to
make it easier to mark resources with kstatus conditions, and observe
their state.

- The `MarkReconciling` and `MarkStalled` functions delete their
  counterpart condition type while marking the resource with the
  kstatus condition, making it easier to adhere to the kstatus
  standards.
- The `IsReady`, `IsStalled` and `IsReconciling` functions take the
  existence of their counterpart condition types into account, ensuring
  conclusive conditional checks.

`MarkReady` was not taken into consideration, it could technically be
added as syntax sugar, but this would first require a discussion about
a counterpart as you likely want to be able to mark something as "not
ready".

To determine a Ready condition at present, the advice is to compose one
using `SetSummary` based on the defined condition types from your own
API, for example:

```go
conditions.SetSummary(
	&obj,
	meta.ReadyCondition,
	conditions.WithConditions(
		foov1.FooCondition,
		foov1.BarCondition,
		foov1.BazCondition,
	),
)
```