### PR TITLE
actions/envtest: Update to docker container action

### DIFF
--- a/actions/envtest/Dockerfile
+++ b/actions/envtest/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:1.16-buster
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/actions/envtest/action.yml
+++ b/actions/envtest/action.yml
@@ -1,6 +1,6 @@
 name: Setup envtest
 description: A GitHub Action for setting up controller-runtime envtest
-author: Stefan Prodan
+author: Flux project
 branding:
   color: blue
   icon: command
@@ -10,15 +10,7 @@ inputs:
     required: false
     default: "latest"
 runs:
-  using: composite
-  steps:
-    - name: "Install setup-envtest"
-      shell: bash
-      run: |
-        go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-    - name: "Download envtest binaries and set KUBEBUILDER_ASSETS"
-      shell: bash
-      run: |
-        setup-envtest use ${{ inputs.version }}
-        ENVTEST_DIR=$(setup-envtest use -i ${{ inputs.version }} -p path)
-        echo "KUBEBUILDER_ASSETS=$ENVTEST_DIR" >> $GITHUB_ENV
+  using: docker
+  image: Dockerfile
+  args:
+    - ${{ inputs.version }}

--- a/actions/envtest/entrypoint.sh
+++ b/actions/envtest/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -eu
+
+# Unset any $GOROOT passed in from the host.
+unset GOROOT
+
+# envtest kubernetes version.
+VERSION=${1:-latest}
+
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+setup-envtest use $VERSION
+
+ENVTEST_DIR=$(setup-envtest use -i $VERSION -p path)
+SETUP_ENVTEST_PATH=$(which setup-envtest)
+ENVTEST_WORKSPACE_PATH=$RUNNER_WORKSPACE/$(basename $GITHUB_REPOSITORY)/envtest
+
+mkdir -p $GITHUB_WORKSPACE/envtest
+mv $ENVTEST_DIR/* $GITHUB_WORKSPACE/envtest
+mv $SETUP_ENVTEST_PATH $GITHUB_WORKSPACE/envtest
+ls -lh $GITHUB_WORKSPACE/envtest
+
+echo "$GITHUB_WORKSPACE/envtest" >> $GITHUB_PATH
+echo "$ENVTEST_WORKSPACE_PATH" >> $GITHUB_PATH
+echo "KUBEBUILDER_ASSETS=$ENVTEST_WORKSPACE_PATH" >> $GITHUB_ENV
+
+# Cleanup cache to avoid affecting other builds. Some go builds may get
+# affected by this cache populated in the above operations.
+rm -rf /github/home/.cache


### PR DESCRIPTION
Update action/envtest to be a docker container action. This helps
install envtest binaries without Go installed on the host.

Refer: https://github.com/fluxcd/source-controller/pull/404 