### PR TITLE
Remove use of deprecated io/ioutil package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ meeting](https://docs.google.com/document/d/1l_M0om0qUEN_NNiGgpqJ2tvsF2iioHkaARD
 You can run the unit tests by simply doing
 
 ```bash
-make test
+make all
 ```
 
 ## Acceptance policy

--- a/gittestserver/server.go
+++ b/gittestserver/server.go
@@ -19,9 +19,9 @@ package gittestserver
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 
 	"github.com/sosedoff/gitkit"
@@ -30,7 +30,7 @@ import (
 // NewTempGitServer returns a GitServer with a newly created temp
 // dir as repository docroot.
 func NewTempGitServer() (*GitServer, error) {
-	tmpDir, err := ioutil.TempDir("", "git-server-test-")
+	tmpDir, err := os.MkdirTemp("", "git-server-test-")
 	if err != nil {
 		return nil, err
 	}

--- a/gittestserver/server_test.go
+++ b/gittestserver/server_test.go
@@ -2,7 +2,6 @@ package gittestserver
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -83,15 +82,15 @@ func TestHTTPSServer(t *testing.T) {
 	}
 	defer os.RemoveAll(srv.Root())
 
-	examplePublicKey, err := ioutil.ReadFile("../testdata/certs/server.pem")
+	examplePublicKey, err := os.ReadFile("../testdata/certs/server.pem")
 	if err != nil {
 		t.Fatal(err)
 	}
-	examplePrivateKey, err := ioutil.ReadFile("../testdata/certs/server-key.pem")
+	examplePrivateKey, err := os.ReadFile("../testdata/certs/server-key.pem")
 	if err != nil {
 		t.Fatal(err)
 	}
-	exampleCA, err := ioutil.ReadFile("../testdata/certs/ca.pem")
+	exampleCA, err := os.ReadFile("../testdata/certs/ca.pem")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/helmtestserver/server.go
+++ b/helmtestserver/server.go
@@ -17,7 +17,7 @@ limitations under the License.
 package helmtestserver
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"helm.sh/helm/v3/pkg/action"
@@ -30,7 +30,7 @@ import (
 // NewTempHelmServer returns a HTTP HelmServer with a newly created
 // temp dir as repository docroot.
 func NewTempHelmServer() (*HelmServer, error) {
-	tmpDir, err := ioutil.TempDir("", "helm-test-")
+	tmpDir, err := os.MkdirTemp("", "helm-test-")
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func (s *HelmServer) GenerateIndex() error {
 		return err
 	}
 	f := filepath.Join(s.HTTPServer.Root(), "index.yaml")
-	return ioutil.WriteFile(f, d, 0644)
+	return os.WriteFile(f, d, 0644)
 }
 
 // PackageChart attempts to package the chart at the given path, to be served

--- a/lockedfile/lockedfile.go
+++ b/lockedfile/lockedfile.go
@@ -9,7 +9,6 @@ package lockedfile
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 )
@@ -103,7 +102,7 @@ func Read(name string) ([]byte, error) {
 	}
 	defer f.Close()
 
-	return ioutil.ReadAll(f)
+	return io.ReadAll(f)
 }
 
 // Write opens the named file (creating it with the given permissions if needed),
@@ -135,7 +134,7 @@ func Transform(name string, t func([]byte) ([]byte, error)) (err error) {
 	}
 	defer f.Close()
 
-	old, err := ioutil.ReadAll(f)
+	old, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}

--- a/runtime/events/recorder_test.go
+++ b/runtime/events/recorder_test.go
@@ -18,7 +18,7 @@ package events
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -29,7 +29,7 @@ import (
 
 func TestEventRecorder_Eventf(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 
 		var payload Event
@@ -63,7 +63,7 @@ func TestEventRecorder_Eventf(t *testing.T) {
 
 func TestEventRecorder_Eventf_Retry(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 
 		var payload Event
@@ -90,7 +90,7 @@ func TestEventRecorder_Eventf_Retry(t *testing.T) {
 
 func TestEventRecorder_Eventf_RateLimited(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 
 		var payload Event

--- a/testserver/artifact.go
+++ b/testserver/artifact.go
@@ -22,7 +22,6 @@ import (
 	"crypto/sha1"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -30,7 +29,7 @@ import (
 // NewTempArtifactServer returns an ArtifactServer with a newly created temp
 // dir as the artifact docroot.
 func NewTempArtifactServer() (*ArtifactServer, error) {
-	tmpDir, err := ioutil.TempDir("", "artifact-test-")
+	tmpDir, err := os.MkdirTemp("", "artifact-test-")
 	if err != nil {
 		return nil, err
 	}

--- a/testserver/http.go
+++ b/testserver/http.go
@@ -19,16 +19,16 @@ package testserver
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 )
 
 // NewTempHTTPServer returns a HTTPServer with a newly created temp
 // dir as the docroot.
 func NewTempHTTPServer() (*HTTPServer, error) {
-	tmpDir, err := ioutil.TempDir("", "http-test-")
+	tmpDir, err := os.MkdirTemp("", "http-test-")
 	if err != nil {
 		return nil, err
 	}

--- a/testserver/http_test.go
+++ b/testserver/http_test.go
@@ -19,7 +19,7 @@ package testserver
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -44,7 +44,7 @@ func testMiddlewareResult(t *testing.T, client *http.Client, addr string, want s
 		t.Errorf("failed to GET %s: %v", addr, err)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Error(err)
 	}
@@ -79,19 +79,19 @@ func TestHTTPSServer(t *testing.T) {
 	}
 	defer os.RemoveAll(srv.Root())
 
-	examplePublicKey, err := ioutil.ReadFile("../testdata/certs/server.pem")
+	examplePublicKey, err := os.ReadFile("../testdata/certs/server.pem")
 	if err != nil {
 		t.Fatal(err)
 	}
-	examplePrivateKey, err := ioutil.ReadFile("../testdata/certs/server-key.pem")
+	examplePrivateKey, err := os.ReadFile("../testdata/certs/server-key.pem")
 	if err != nil {
 		t.Fatal(err)
 	}
-	exampleCA, err := ioutil.ReadFile("../testdata/certs/ca.pem")
+	exampleCA, err := os.ReadFile("../testdata/certs/ca.pem")
 	if err != nil {
 		t.Fatal(err)
 	}
-	caCert, err := ioutil.ReadFile("../testdata/certs/ca.pem")
+	caCert, err := os.ReadFile("../testdata/certs/ca.pem")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Remove deprecated calls and replace with suggestions from the deprecation notice.

Update test instructions since `make test` doesn't work. Now uses `make all`, which runs tests for all targets in all subdirectories.

Issue: https://github.com/fluxcd/flux2/issues/1658