### PR TITLE
Add trace event type

### DIFF
--- a/runtime/events/doc.go
+++ b/runtime/events/doc.go
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package events provides a Recorder and additional helpers to record Kubernetes Events on a external HTTP endpoint.
+// Package events provides a Recorder and additional helpers to record Kubernetes Events on an external HTTP endpoint.
 package events

--- a/runtime/events/event.go
+++ b/runtime/events/event.go
@@ -23,6 +23,9 @@ import (
 
 // These constants define valid event severity values.
 const (
+	// EventSeverityTrace represents a trace event, usually
+	// informing about actions taken during reconciliation.
+	EventSeverityTrace string = "trace"
 	// EventSeverityInfo represents an informational event, usually
 	// informing about changes.
 	EventSeverityInfo string = "info"
@@ -38,8 +41,8 @@ type Event struct {
 	// +required
 	InvolvedObject corev1.ObjectReference `json:"involvedObject"`
 
-	// Severity type of this event (info, error)
-	// +kubebuilder:validation:Enum=info;error
+	// Severity type of this event (trace, info, error)
+	// +kubebuilder:validation:Enum=trace,info;error
 	// +required
 	Severity string `json:"severity"`
 

--- a/runtime/events/recorder.go
+++ b/runtime/events/recorder.go
@@ -83,6 +83,13 @@ func (r *Recorder) Eventf(
 	metadata map[string]string,
 	severity, reason string,
 	messageFmt string, args ...interface{}) error {
+
+	// Do not send trace events to notification controller,
+	// traces are persisted as Kubernetes events only.
+	if severity == EventSeverityTrace {
+		return nil
+	}
+
 	if r.Client == nil {
 		return fmt.Errorf("retryable HTTP client has not been initialized")
 	}


### PR DESCRIPTION
Traces are persisted as Kubernetes events only, usually informing about actions taken during reconciliation that are irrelevant to the alerting system.

The GitOps Toolkit reconcilers should send a single `info` event when the reconciliation was successful and only if the reconciliation took actions (fetch new revision, change cluster state, push changes to upstream). For no-op reconciliations, the event type should be set to `trace` to avoid spamming the on-call teams with irrelevant alerts.