### PR TITLE
testenv: Remove klog init flags

### DIFF
--- a/runtime/testenv/testenv.go
+++ b/runtime/testenv/testenv.go
@@ -52,13 +52,6 @@ var (
 	env *envtest.Environment
 )
 
-func init() {
-	klog.InitFlags(nil)
-	logger := klogr.New()
-	log.SetLogger(logger)
-	ctrl.SetLogger(logger)
-}
-
 var (
 	cacheSyncBackoff = wait.Backoff{
 		Duration: 100 * time.Millisecond,
@@ -118,7 +111,32 @@ func WithCRDPath(path ...string) Option {
 //
 // NOTE: This function should be called only once for each package you are running tests within, usually the environment
 // is initialised in a suite_test.go or <package>_test.go file within a `TestMain` function.
+//
+// When a testenv Environment is created, it initializes the
+// controller-runtime's deferred logger with a default logger based on klog. In
+// order to override this behavior, the controller-runtime logger can be
+// initialized before creating testenv Environment.
+//
+//  import (
+//      "testing"
+//
+//      "github.com/fluxcd/pkg/runtime/testenv"
+//      ctrl "sigs.k8s.io/controller-runtime"
+//      "sigs.k8s.io/controller-runtime/pkg/log/zap"
+//  }
+//
+//  func TestMain(m *testing.M) {
+//      zlog := zap.New(zap.UseDevMode(true))
+//      ctrl.SetLogger(zlog)
+//
+//      testEnv = testenv.New()
+//      ...
+//  }
+//
 func New(o ...Option) *Environment {
+	// Set a default logger if not set already.
+	log.SetLogger(klogr.New())
+
 	opts := options{}
 	for _, apply := range o {
 		apply(&opts)


### PR DESCRIPTION
This change allows test environments with glog to work with testenv.

### Background

image-reflector-controller uses badger for database. [dgraph-io/badger](https://github.com/dgraph-io/badger) go package depends on  [dgraph-io/ristretto](https://github.com/dgraph-io/ristretto), which depends on glog. When glog is used, it sets `log_dir` flag, [refer](https://github.com/golang/glog/blob/23def4e6c14b4da8ac2ed8007337bc5eb5007998/glog_file.go#L41) .
Due to the glog transitive dependency of badger, when badger is used in testenv based tests, the testenv package init() initialization of the klog flags and badger set the glog flags conflict, resulting in some redefined flags.

This can be reproduced by adding the following in `TestMain()`:

```golang
    badgerDir, err := ioutil.TempDir(os.TempDir(), "badger")
    if err != nil {
        panic(fmt.Sprintf("Failed to create temporary directory for badger: %v", err))
    }

    badgerDB, err := badger.Open(badger.DefaultOptions(badgerDir))
    if err != nil {
        panic(fmt.Sprintf("Failed to create new Badger database: %v", err))
    }
```
with `"github.com/dgraph-io/badger/v3"` import.

Failure output:
```console
/tmp/go-build1837318169/b001/controllers.test flag redefined: log_dir
panic: /tmp/go-build1837318169/b001/controllers.test flag redefined: log_dir

goroutine 1 [running]:
flag.(*FlagSet).Var(0xc00003c240, {0x19d5ad8, 0x26f5090}, {0x17b67fd, 0x7}, {0x17f2153, 0x2f})
        ~/.gimme/versions/go1.17.1.linux.amd64/src/flag/flag.go:879 +0x2f4
flag.(*FlagSet).StringVar(...)
        ~/.gimme/versions/go1.17.1.linux.amd64/src/flag/flag.go:762
k8s.io/klog/v2.InitFlags(0x1494a27)
        ~/go/pkg/mod/k8s.io/klog/v2@v2.8.0/klog.go:427 +0x55
github.com/fluxcd/pkg/runtime/testenv.init.0()
        ~/go/pkg/mod/github.com/fluxcd/pkg/runtime@v0.13.0-rc.2/testenv/testenv.go:56 +0x1b
FAIL    github.com/fluxcd/image-reflector-controller/controllers        0.027s
FAIL
```

Based on an [example](https://github.com/kubernetes/klog/blob/f8e668dbaa5f6f0e6a5c24ffd7667263840d79ae/examples/coexist_glog/coexist_glog.go) in klog repo, glog and klog can coexist with separate FlagSets.

With this change, the image-reflector-controller is able to use testenv.