### PR TITLE
runtime/conditions: Add merge option with generations

### DIFF
--- a/runtime/conditions/merge_strategies.go
+++ b/runtime/conditions/merge_strategies.go
@@ -42,6 +42,8 @@ type mergeOptions struct {
 	addStepCounterIfOnlyConditionTypes []string
 
 	stepCounter int
+
+	withLatestGeneration bool
 }
 
 // MergeOption defines an option for computing a summary of conditions.
@@ -229,5 +231,13 @@ func getFirstCondition(g conditionGroups, priority []string) *localizedCondition
 			}
 		}
 		return &topGroup.conditions[0]
+	}
+}
+
+// WithLatestGeneration instructs merge to consider the conditions with the
+// latest observed generation only.
+func WithLatestGeneration() MergeOption {
+	return func(c *mergeOptions) {
+		c.withLatestGeneration = true
 	}
 }


### PR DESCRIPTION
Adds merge option `WithGenerations()` to consider the condition's observed
generation while merging. When withGenerations is set, the condition
groups are created based on the generation of the conditions. The
condition groups with the latest generations are grouped together and
sorted based on their merge priority. The condition groups with old
generations don't contain the up-to-date information and hence not
considered.
The merge behavior remains the same when no generation is specified.

Fixes #142 