### PR TITLE
runtime/events: fix Severity validation marker value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ vet-%:
 	cd $(subst :,/,$*); go vet ./...
 
 generate-%: controller-gen
+	# Run schemapatch to validate all the kubebuilder markers before generation.
+	cd $(subst :,/,$*); $(CONTROLLER_GEN) schemapatch:manifests="./" paths="./..."
 	cd $(subst :,/,$*); $(CONTROLLER_GEN) object:headerFile="$(root_dir)/hack/boilerplate.go.txt" paths="./..."
 
 test-%: generate-% tidy-% fmt-% vet-% setup-envtest

--- a/runtime/events/event.go
+++ b/runtime/events/event.go
@@ -42,7 +42,7 @@ type Event struct {
 	InvolvedObject corev1.ObjectReference `json:"involvedObject"`
 
 	// Severity type of this event (trace, info, error)
-	// +kubebuilder:validation:Enum=trace,info;error
+	// +kubebuilder:validation:Enum=trace;info;error
 	// +required
 	Severity string `json:"severity"`
 


### PR DESCRIPTION
Fix the `Event.Severity` validation marker value.
Also, run `controller-gen schemapatch` to evaluate all the kubebuilder
markers before generating code.

__NOTE__: This was introduced in #147 and wasn't caught by any of the validations.
I tried using controller-gen to evaluate the markers in order to catch such issues in the
future and was able to do so using schemapatcher. Running controller-gen
schemapatch as part of generate now evaluates all the go code with kubebuilder
markers. Tested by introducing invalid marker values in `apis/kustomize` and
`apis/metadata`.