### PR TITLE
Fix SSA upstream bugs for Kubernetes < 1.22

### DIFF
--- a/ssa/go.mod
+++ b/ssa/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/google/go-cmp v0.5.6
+	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2
 	// pin cli-utils to avoid kustomize@v2.0.3+incompatible dependency in v0.25.0
 	sigs.k8s.io/cli-utils v0.25.1-0.20210608181808-f3974341173a

--- a/ssa/manager_apply_test.go
+++ b/ssa/manager_apply_test.go
@@ -221,3 +221,29 @@ func TestApply(t *testing.T) {
 		}
 	})
 }
+
+func TestApply_SetNativeKindsDefaults(t *testing.T) {
+	timeout := 10 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	id := generateName("fix")
+	objects, err := readManifest("testdata/test2.yaml", id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	manager.SetOwnerLabels(objects, "app1", "default")
+
+	if err := SetNativeKindsDefaults(objects); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("creates objects", func(t *testing.T) {
+		// create objects
+		_, err := manager.ApplyAllStaged(ctx, objects, false, timeout)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/ssa/testdata/test2.yaml
+++ b/ssa/testdata/test2.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "%[1]s"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "%[1]s"
+  namespace: "%[1]s"
+spec:
+  minReadySeconds: 3
+  revisionHistoryLimit: 5
+  progressDeadlineSeconds: 60
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: "%[1]s"
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9797"
+      labels:
+        app: "%[1]s"
+    spec:
+      containers:
+        - name: podinfod
+          image: ghcr.io/stefanprodan/podinfo:6.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 9898
+              # associative list with keys has an element that omits key field "protocol"
+              #protocol: TCP
+            - name: http-metrics
+              containerPort: 9797
+              #protocol: TCP
+            - name: grpc
+              containerPort: 9999
+              #protocol: TCP
+          command:
+            - ./podinfo
+            - --port=9898
+            - --port-metrics=9797
+            - --grpc-port=9999
+            - --grpc-service-name=podinfo
+            - --level=info
+            - --random-delay=false
+            - --random-error=false
+          env:
+            - name: PODINFO_UI_COLOR
+              value: "#34577c"
+          livenessProbe:
+            exec:
+              command:
+                - podcli
+                - check
+                - http
+                - localhost:9898/healthz
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - podcli
+                - check
+                - http
+                - localhost:9898/readyz
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          resources:
+            limits:
+              # expected string, got &value.valueUnstructured{Value:2}
+              cpu: 2
+              memory: 512Mi
+            requests:
+              cpu: 1
+              memory: 64Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "%[1]s"
+  namespace: "%[1]s"
+spec:
+  type: ClusterIP
+  selector:
+    app: "%[1]s"
+  ports:
+    - name: http
+      port: 9898
+      # .spec.ports: element 0: associative list with keys has an element that omits key field "protocol"
+      #protocol: TCP
+      targetPort: http
+    - port: 9999
+      targetPort: grpc
+      #protocol: TCP
+      name: grpc


### PR DESCRIPTION
 Implements workarounds for server-side apply upstream bugs affecting Kubernetes < 1.22

- ContainerPort missing default TCP proto: https://github.com/kubernetes-sigs/structured-merge-diff/issues/130
- ServicePort missing default TCP proto: https://github.com/kubernetes/kubernetes/pull/98576
- PodSpec resources missing int to string conversion for e.g. 'cpu: 2'

Ref: https://github.com/fluxcd/flux2/issues/1917