### PR TITLE
ssa: Detect changes in Secrets and ConfigMaps

### DIFF
--- a/ssa/manager_diff.go
+++ b/ssa/manager_diff.go
@@ -91,7 +91,7 @@ func (m *ResourceManager) hasDrifted(existingObject, dryRunObject *unstructured.
 	}
 
 	var found bool
-	for _, field := range []string{"spec", "webhooks", "rules", "subjects", "roleRef", "subsets"} {
+	for _, field := range []string{"spec", "webhooks", "rules", "subjects", "roleRef", "subsets", "data", "stringData", "immutable"} {
 		if _, ok := existingObject.Object[field]; ok {
 			found = true
 		}

--- a/ssa/testdata/test3.yaml
+++ b/ssa/testdata/test3.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "%[1]s"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "%[1]s"
+  namespace: "%[1]s"
+  creationTimestamp: null
+data: {}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "empty-%[1]s"
+  namespace: "%[1]s"
+  creationTimestamp: null
+  labels:
+    app: some-operator
+data:
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "string-data-%[1]s"
+  namespace: "%[1]s"
+  creationTimestamp: null
+stringData:
+  test: test
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "data-%[1]s"
+  namespace: "%[1]s"
+data: {}

--- a/ssa/utils.go
+++ b/ssa/utils.go
@@ -231,6 +231,8 @@ func SetNativeKindsDefaults(objects []*unstructured.Unstructured) error {
 	}
 
 	for _, u := range objects {
+		unstructured.RemoveNestedField(u.Object, "metadata", "creationTimestamp")
+
 		switch u.GetKind() {
 		case "Pod":
 			var d corev1.Pod


### PR DESCRIPTION
This PR improves the drift detection for Secrets and ConfigMap objects. We also remove the read-only field `creationTimestamp` from all objects to workaround a kubectl bug that sets this field when using `kubectl create -o yaml`.