### PR TITLE
Change the metric bucket into a more useful range.

### DIFF
--- a/runtime/metrics/recorder.go
+++ b/runtime/metrics/recorder.go
@@ -57,10 +57,10 @@ func NewRecorder() *Recorder {
 		),
 		durationHistogram: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name:    "gotk_reconcile_duration_seconds",
-				Help:    "The duration in seconds of a GitOps Toolkit resource reconciliation.",
+				Name: "gotk_reconcile_duration_seconds",
+				Help: "The duration in seconds of a GitOps Toolkit resource reconciliation.",
 				// Use a histogram with 10 count buckets between 1ms - 1hour
-				Buckets: prometheus.ExponentialBucketsRange(10e-3, 3600, 10),
+				Buckets: prometheus.ExponentialBucketsRange(10e-3, 1800, 10),
 			},
 			[]string{"kind", "name", "namespace"},
 		),

--- a/runtime/metrics/recorder.go
+++ b/runtime/metrics/recorder.go
@@ -59,7 +59,8 @@ func NewRecorder() *Recorder {
 			prometheus.HistogramOpts{
 				Name:    "gotk_reconcile_duration_seconds",
 				Help:    "The duration in seconds of a GitOps Toolkit resource reconciliation.",
-				Buckets: prometheus.ExponentialBuckets(10e-9, 10, 10),
+				// Use a histogram with 10 count buckets between 1ms - 1hour
+				Buckets: prometheus.ExponentialBucketsRange(10e-3, 3600, 10),
 			},
 			[]string{"kind", "name", "namespace"},
 		),


### PR DESCRIPTION
We encountered a delay in reconciliation which end up taking to more than 15 minutes. The current histogram metrics configuration doesn't help us to see the actual value.

This change will set the minimum range from 1nanoseconds, to 1millisecond. This is assuming 1 millisecond is blazingly fast that we don't care anything beyond that.

It'll also change the maximum range from 10s, to 1 hour. It's assuming 1 hour is terribly slow, and we don't care anything beyond that.

Ideally, this configuration should be configurable by user, as each company have their own preferences.