### PR TITLE
ssa: Improve drift detection

### DIFF
--- a/ssa/testdata/test3.yaml
+++ b/ssa/testdata/test3.yaml
@@ -19,8 +19,6 @@ metadata:
   creationTimestamp: null
   labels:
     app: some-operator
-data:
-
 ---
 apiVersion: v1
 kind: Secret

--- a/ssa/testdata/test4.yaml
+++ b/ssa/testdata/test4.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "%[1]s"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "%[1]s"
+  namespace: "%[1]s"


### PR DESCRIPTION
Remove server-side generated fields (metadata and status) before checking for semantic equality. Removing the server generated fields means that we no longer have to look for `spec` to properly detect drift.

Thanks @seh for suggesting this in https://github.com/fluxcd/flux2/issues/1934.