### PR TITLE
Rationalise the return value of ACL checks

### DIFF
--- a/runtime/acl/acl_test.go
+++ b/runtime/acl/acl_test.go
@@ -105,14 +105,12 @@ func TestAclAuthorization(t *testing.T) {
 			g := NewWithT(t)
 			g.Expect(testEnv.CreateAndWait(ctx, tt.namespace)).ToNot(HaveOccurred())
 
-			hasAccess, err := aclAuth.HasAccessToRef(ctx, tt.object, tt.reference, tt.referenceAcl)
+			err := aclAuth.HasAccessToRef(ctx, tt.object, tt.reference, tt.referenceAcl)
 			if tt.wantErr {
-				g.Expect(err).To(HaveOccurred())
-				g.Expect(hasAccess).To(BeFalse())
+				g.Expect(IsAccessDenied(err)).To(BeTrue())
 				return
 			}
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(hasAccess).To(BeTrue())
 		})
 	}
 }


### PR DESCRIPTION
The return type of HasAccessToRef() is `(bool, error)`, but the error is used to signal both a negative result (no access!) and a failure to complete the check (client request failed), leaving the `bool` redundant.

As a result, it's not clear to the caller whether it should report that access was denied, or that there was some (probably transitory) problem.

~Instead, use the bool to signal whether access was possible, and only return an error when there was an error while checking.~

EDIT: return a special type of error for access denied, and remove the bool return value.