### PR TITLE
gittestserver: Add http middleware support

### DIFF
--- a/runtime/acl/acl_test.go
+++ b/runtime/acl/acl_test.go
@@ -38,6 +38,7 @@ func TestAclAuthorization(t *testing.T) {
 			panic(fmt.Sprintf("Failed to start the testenv: %v", err))
 		}
 	}()
+	<-testEnv.Manager.Elected()
 	defer testEnv.Stop()
 
 	aclAuth := NewAuthorization(testEnv.Client)


### PR DESCRIPTION
Add http middleware support to be able to change the behavior of the
git server. Usage could be for returning certain response and error or
introducing some delay in the server, etc.
The middlewares can be chained together based on the needs.

Helper middlewares can be added in the future for certain behaviors
frequently needed in tests.