### PR TITLE
Remove file support from Kustomize Patch type docs

### DIFF
--- a/apis/kustomize/kustomize_types.go
+++ b/apis/kustomize/kustomize_types.go
@@ -83,10 +83,11 @@ type Selector struct {
 	LabelSelector string `json:"labelSelector,omitempty"`
 }
 
-// Patch contains either a StrategicMerge or a JSON6902 patch, either a file or inline, and the target the patch should
+// Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
 // be applied to.
 type Patch struct {
-	// Patch contains the JSON6902 patch document with an array of operation objects.
+	// Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with 
+	// an array of operation objects.
 	// +required
 	Patch string `json:"patch,omitempty"`
 

--- a/apis/kustomize/kustomize_types.go
+++ b/apis/kustomize/kustomize_types.go
@@ -86,7 +86,7 @@ type Selector struct {
 // Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
 // be applied to.
 type Patch struct {
-	// Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with 
+	// Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
 	// an array of operation objects.
 	// +required
 	Patch string `json:"patch,omitempty"`


### PR DESCRIPTION
The Kustomize Patch API type only supports inlined patch
definitions and does not support reading patches from a
file. Updating the godoc comments for the type to remove
any mention of reading patch definitions from a file and
make it clear that only inline patches are supported.