### PR TITLE
feat: make it easier to debug kustomize action failures

### DIFF
--- a/actions/kustomize/action.yml
+++ b/actions/kustomize/action.yml
@@ -23,7 +23,7 @@ runs:
         ARCH=${{ inputs.arch }}
         REPO_URL=https://github.com/kubernetes-sigs/kustomize/releases/download
         BIN_URL="${REPO_URL}/kustomize%2Fv${VERSION}/kustomize_v${VERSION}_linux_${ARCH}.tar.gz"
-        curl -sL ${BIN_URL} -o /tmp/kustomize.tar.gz
+        curl -fL --no-progress-meter ${BIN_URL} -o /tmp/kustomize.tar.gz
         mkdir -p /tmp/kustomize
         tar -C /tmp/kustomize/ -zxvf /tmp/kustomize.tar.gz
         sudo cp /tmp/kustomize/kustomize /usr/local/bin


### PR DESCRIPTION
When curl fails there has been no way to understand why because of the
'silent' flag. Removing the silent flag and just disabling the
progress meter makes it easier to reason about failures when
downloading kustomize.

[This workflow](https://github.com/fluxcd/helm-controller/runs/4224469169?check_suite_focus=true) has failed for an unknown reason, very probably because the download of kustomize failed:

```
  VERSION=4.1.3
  ARCH=amd64
  REPO_URL=https://github.com/kubernetes-sigs/kustomize/releases/download
  BIN_URL="${REPO_URL}/kustomize%2Fv${VERSION}/kustomize_v${VERSION}_linux_${ARCH}.tar.gz"
  curl -sL ${BIN_URL} -o /tmp/kustomize.tar.gz
  mkdir -p /tmp/kustomize
  tar -C /tmp/kustomize/ -zxvf /tmp/kustomize.tar.gz
  sudo cp /tmp/kustomize/kustomize /usr/local/bin
  rm -rf /tmp/kustomize/ /tmp/kustomize.tar.gz
  which kustomize
  kustomize version
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    GOROOT: /opt/hostedtoolcache/go/1.16.10/x64

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
Error: Process completed with exit code 2.
```

Signed-off-by: Max Jonas Werner <mail@makk.es>