### PR TITLE
ssa: Remove YAML diff

### DIFF
--- a/ssa/changeset.go
+++ b/ssa/changeset.go
@@ -92,9 +92,6 @@ type ChangeSetEntry struct {
 
 	// Action represents the action type taken by the reconciler for this object.
 	Action string
-
-	// Diff contains the YAML diff resulting from server-side apply dry-run.
-	Diff string
 }
 
 func (e ChangeSetEntry) String() string {


### PR DESCRIPTION
Remove the YAML diff composed with go-cmp as the output is not human readable. The `ssa.Diff` now returns the live object and the merged one (resulted from apply dry-run). Consumers can take the two objects and perform the YAML diff with 3rd party tools like Linux `diff` or  https://github.com/homeport/dyff.
