### PR TITLE
Workaround for HPA dry-run metrics duplication

### DIFF
--- a/ssa/testdata/test6.yaml
+++ b/ssa/testdata/test6.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "%[1]s"
+---
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: "%[1]s"
+  namespace: "%[1]s"
+spec:
+  behavior:
+    scaleDown:
+      policies:
+        - periodSeconds: 15
+          type: Percent
+          value: 100
+      selectPolicy: Max
+      stabilizationWindowSeconds: 60
+    scaleUp:
+      policies:
+        - periodSeconds: 15
+          type: Pods
+          value: 4
+        - periodSeconds: 15
+          type: Percent
+          value: 100
+      selectPolicy: Max
+      stabilizationWindowSeconds: 0
+  maxReplicas: 30
+  metrics:
+    - type: Pods
+      pods:
+        metric:
+          name: nginx_http_requests_total
+        target:
+          averageValue: "4"
+          type: AverageValue
+    - type: Pods
+      pods:
+        metric:
+          name: nginx_http_requests_total2
+        target:
+          averageValue: "4"
+          type: AverageValue
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: frontend

--- a/ssa/utils.go
+++ b/ssa/utils.go
@@ -24,9 +24,10 @@ import (
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv1 "k8s.io/api/autoscaling/v2beta1"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	hpav2beta1 "k8s.io/api/autoscaling/v2beta1"
+	hpav2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -350,7 +351,7 @@ func SetNativeKindsDefaults(objects []*unstructured.Unstructured) error {
 		case "HorizontalPodAutoscaler":
 			switch u.GetAPIVersion() {
 			case "autoscaling/v2beta1":
-				var d autoscalingv1.HorizontalPodAutoscaler
+				var d hpav2beta1.HorizontalPodAutoscaler
 				err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &d)
 				if err != nil {
 					return fmt.Errorf("%s validation error: %w", FmtUnstructured(u), err)
@@ -361,7 +362,7 @@ func SetNativeKindsDefaults(objects []*unstructured.Unstructured) error {
 				}
 				u.Object = out
 			case "autoscaling/v2beta2":
-				var d autoscalingv2.HorizontalPodAutoscaler
+				var d hpav2beta2.HorizontalPodAutoscaler
 				err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &d)
 				if err != nil {
 					return fmt.Errorf("%s validation error: %w", FmtUnstructured(u), err)
@@ -371,8 +372,45 @@ func SetNativeKindsDefaults(objects []*unstructured.Unstructured) error {
 					return fmt.Errorf("%s validation error: %w", FmtUnstructured(u), err)
 				}
 				u.Object = out
-
 			}
+		}
+	}
+	return nil
+}
+
+// Fix bug in server-side dry-run apply that duplicates the first item in the metrics array
+// and inserts an empty metric as the last item in the array.
+func fixHorizontalPodAutoscaler(object *unstructured.Unstructured) error {
+	if object.GetKind() == "HorizontalPodAutoscaler" {
+		switch object.GetAPIVersion() {
+		case "autoscaling/v2beta2":
+			var d hpav2beta2.HorizontalPodAutoscaler
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &d)
+			if err != nil {
+				return fmt.Errorf("%s validation error: %w", FmtUnstructured(object), err)
+			}
+
+			var metrics []hpav2beta2.MetricSpec
+			for _, metric := range d.Spec.Metrics {
+				found := false
+				for _, existing := range metrics {
+					if apiequality.Semantic.DeepEqual(metric, existing) {
+						found = true
+						break
+					}
+				}
+				if !found && metric.Type != "" {
+					metrics = append(metrics, metric)
+				}
+			}
+
+			d.Spec.Metrics = metrics
+
+			out, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&d)
+			if err != nil {
+				return fmt.Errorf("%s validation error: %w", FmtUnstructured(object), err)
+			}
+			object.Object = out
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR implements a workaround for a Kubernetes API server-side apply dry-run bug where it duplicates the first item in the metrics array and inserts an empty metric as the last item in the array.

Given:

```yaml
apiVersion: autoscaling/v2beta2
kind: HorizontalPodAutoscaler
metadata:
  name: frontend
  namespace: default
spec:
  behavior:
    scaleDown:
      policies:
        - periodSeconds: 15
          type: Percent
          value: 100
      selectPolicy: Max
      stabilizationWindowSeconds: 60
    scaleUp:
      policies:
        - periodSeconds: 15
          type: Pods
          value: 4
        - periodSeconds: 15
          type: Percent
          value: 100
      selectPolicy: Max
      stabilizationWindowSeconds: 0
  maxReplicas: 30
  metrics:
    - type: Pods
      pods:
        metric:
          name: nginx_http_requests_total
        target:
          averageValue: "4"
          type: AverageValue
  minReplicas: 2
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: frontend
```

The dry-run diff returns bogus data:

```
$ kubectl diff --server-side -f hpa.yaml
@@ -74,6 +97,13 @@
         averageValue: "4"
         type: AverageValue
     type: Pods
+  - pods:
+      metric:
+        name: nginx_http_requests_total
+      target:
+        averageValue: "4"
+        type: AverageValue
+    type: Pods
```

This gets even worse if you have two metrics, now an empty metric is added by the Kubernetes API:

```
$ kubectl diff --server-side -f hpa.yaml
+  - pods:
+      metric:
+        name: nginx_http_requests_total
+      target:
+        averageValue: "4"
+        type: AverageValue
+    type: Pods
+  - type: ""
```

Ref: https://github.com/fluxcd/kustomize-controller/issues/494