### PR TITLE
Exclude the status subresouce from the applied resource

### DIFF
--- a/ssa/utils.go
+++ b/ssa/utils.go
@@ -288,8 +288,6 @@ func SetNativeKindsDefaults(objects []*unstructured.Unstructured) error {
 	}
 
 	for _, u := range objects {
-		unstructured.RemoveNestedField(u.Object, "metadata", "creationTimestamp")
-
 		switch u.GetAPIVersion() {
 		case "v1":
 			switch u.GetKind() {
@@ -417,6 +415,10 @@ func SetNativeKindsDefaults(objects []*unstructured.Unstructured) error {
 				u.Object = out
 			}
 		}
+
+		// remove fields that are not supposed to be present in manifests
+		unstructured.RemoveNestedField(u.Object, "metadata", "creationTimestamp")
+		unstructured.RemoveNestedField(u.Object, "status")
 	}
 	return nil
 }


### PR DESCRIPTION
We need to exclude the status sub-resource before server-side apply because the dry-run fails on older Kubernetes versions. Ref: https://github.com/fluxcd/kustomize-controller/issues/532