### PR TITLE
Add action to generate SBOM for container images

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -30,3 +30,9 @@ jobs:
       - uses: ./actions/kustomize
       - uses: ./actions/helm
       - uses: ./actions/kubebuilder
+      - uses: ./actions/sbom
+        with:
+          image: ghcr.io/fluxcd/kustomize-controller:v0.19.1
+      - name: Check SBOM
+        run:
+          cat /tmp/sbom.spdx.json | grep "fluxcd/pkg/ssa"

--- a/actions/sbom/action.yml
+++ b/actions/sbom/action.yml
@@ -1,0 +1,29 @@
+name: Generate SBOM for container images
+description: A GitHub Action for generating SBOM in spdx-json format
+author: Stefan Prodan
+branding:
+  color: blue
+  icon: command
+inputs:
+  version:
+    description: "Syft version"
+    required: false
+  image:
+    description: "container image URL"
+    required: true
+  output:
+    description: "SBOM file path"
+    required: true
+    default: "/tmp/sbom.spdx.json"
+runs:
+  using: composite
+  steps:
+    - name: "Install Anchore Syft"
+      shell: bash
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | \
+          sh -s -- -b /usr/local/bin ${{ inputs.version }}
+    - name: "Generate SBOM"
+      shell: bash
+      run: |
+        syft packages ${{ inputs.image }} --output spdx-json > ${{ inputs.output }}

--- a/actions/sbom/action.yml
+++ b/actions/sbom/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
   image:
     description: "container image URL"
-    required: true
+    required: false
   output:
     description: "SBOM file path"
     required: true
@@ -36,5 +36,6 @@ runs:
         cat "${TMP_FILE}" | sh -s -- -b /usr/local/bin ${{ inputs.version }}
     - name: "Generate SBOM"
       shell: bash
+      if: ${{ inputs.image }}
       run: |
         syft packages ${{ inputs.image }} --output spdx-json > ${{ inputs.output }}


### PR DESCRIPTION
This action should be used in all the GitOps Toolkit controllers, in the release workflow, to publish SBOM to GitHub releases.