### PR TITLE
Add tar.WithMaxUntarSize

### DIFF
--- a/tar/LICENSE
+++ b/tar/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2017 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tar/go.mod
+++ b/tar/go.mod
@@ -1,0 +1,5 @@
+module github.com/fluxcd/pkg/tar
+
+go 1.18
+
+require github.com/cyphar/filepath-securejoin v0.2.3

--- a/tar/go.sum
+++ b/tar/go.sum
@@ -1,0 +1,2 @@
+github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
+github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=

--- a/tar/tar.go
+++ b/tar/tar.go
@@ -1,0 +1,172 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Copyright 2020 The FluxCD contributors. All rights reserved.
+// Adapted from: golang.org/x/build/internal/untar
+
+// Package tar provides ways to manage tarball files.
+package tar
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	securejoin "github.com/cyphar/filepath-securejoin"
+)
+
+const (
+	// DefaultMaxUntarSize defines the default (100MB) max amount of bytes that Untar will process.
+	DefaultMaxUntarSize = 100 << (10 * 2)
+
+	// UnlimitedUntarSize defines the value which disables untar size checks for maxUntarSize.
+	UnlimitedUntarSize = -1
+)
+
+type tarOpts struct {
+	// maxUntarSize represents the limit size (bytes) for archives being decompressed by Untar.
+	// When max is a negative value the size checks are disabled.
+	maxUntarSize int
+}
+
+// Untar reads the gzip-compressed tar file from r and writes it into dir.
+//
+// If dir is a relative path, it cannot ascend from the current working dir.
+// If dir exists, it must be a directory.
+func Untar(r io.Reader, dir string, inOpts ...TarOption) (err error) {
+	opts := tarOpts{
+		maxUntarSize: DefaultMaxUntarSize,
+	}
+	opts.applyOpts(inOpts...)
+
+	dir = filepath.Clean(dir)
+	if !filepath.IsAbs(dir) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		dir, err = securejoin.SecureJoin(cwd, dir)
+		if err != nil {
+			return err
+		}
+	}
+
+	fi, err := os.Lstat(dir)
+	// Dir does not need to exist, as it can later be created.
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("cannot lstat '%s': %w", dir, err)
+	}
+
+	if err == nil && !fi.IsDir() {
+		return fmt.Errorf("dir '%s' must be a directory", dir)
+	}
+
+	madeDir := map[string]bool{}
+	zr, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("requires gzip-compressed body: %w", err)
+	}
+	tr := tar.NewReader(zr)
+	processedBytes := 0
+	t0 := time.Now()
+
+	for {
+		f, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("tar error: %w", err)
+		}
+		processedBytes += int(f.Size)
+		if opts.maxUntarSize > UnlimitedUntarSize &&
+			processedBytes > opts.maxUntarSize {
+			return fmt.Errorf("tar %q is bigger than max archive size of %d bytes", f.Name, opts.maxUntarSize)
+		}
+		if !validRelPath(f.Name) {
+			return fmt.Errorf("tar contained invalid name error %q", f.Name)
+		}
+		rel := filepath.FromSlash(f.Name)
+		abs := filepath.Join(dir, rel)
+
+		fi := f.FileInfo()
+		mode := fi.Mode()
+
+		switch {
+		case mode.IsRegular():
+			// Make the directory. This is redundant because it should
+			// already be made by a directory entry in the tar
+			// beforehand. Thus, don't check for errors; the next
+			// write will fail with the same error.
+			dir := filepath.Dir(abs)
+			if !madeDir[dir] {
+				if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+					return err
+				}
+				madeDir[dir] = true
+			}
+			if runtime.GOOS == "darwin" && mode&0111 != 0 {
+				// The darwin kernel caches binary signatures
+				// and SIGKILLs binaries with mismatched
+				// signatures. Overwriting a binary with
+				// O_TRUNC does not clear the cache, rendering
+				// the new copy unusable. Removing the original
+				// file first does clear the cache. See #54132.
+				err := os.Remove(abs)
+				if err != nil && !errors.Is(err, fs.ErrNotExist) {
+					return err
+				}
+			}
+			wf, err := os.OpenFile(abs, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode.Perm())
+			if err != nil {
+				return err
+			}
+			n, err := io.Copy(wf, tr)
+			if closeErr := wf.Close(); closeErr != nil && err == nil {
+				err = closeErr
+			}
+			if err != nil {
+				return fmt.Errorf("error writing to %s: %w", abs, err)
+			}
+			if n != f.Size {
+				return fmt.Errorf("only wrote %d bytes to %s; expected %d", n, abs, f.Size)
+			}
+			modTime := f.ModTime
+			if modTime.After(t0) {
+				// Ensures that that files extracted are not newer then the
+				// current system time.
+				modTime = t0
+			}
+			if !modTime.IsZero() {
+				if err = os.Chtimes(abs, modTime, modTime); err != nil {
+					return fmt.Errorf("error changing file time %s: %w", abs, err)
+				}
+			}
+		case mode.IsDir():
+			if err := os.MkdirAll(abs, 0o755); err != nil {
+				return err
+			}
+			madeDir[abs] = true
+		default:
+			return fmt.Errorf("tar file entry %s contained unsupported file type %v", f.Name, mode)
+		}
+	}
+	return nil
+}
+
+func validRelPath(p string) bool {
+	if p == "" || strings.Contains(p, `\`) || strings.HasPrefix(p, "/") || strings.Contains(p, "../") {
+		return false
+	}
+	return true
+}

--- a/tar/tar_opts.go
+++ b/tar/tar_opts.go
@@ -1,8 +1,5 @@
-//go:build gofuzz
-// +build gofuzz
-
 /*
-Copyright 2021 The Flux authors
+Copyright 2022 The Flux authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,22 +13,22 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package untar
 
-import (
-	"bytes"
-	"os"
-)
+package tar
 
-// FuzzUntar implements a fuzzer that targets untar.Untar().
-func FuzzUntar(data []byte) int {
-	r := bytes.NewReader(data)
-	tmpDir, err := os.MkdirTemp("", "dir-")
-	if err != nil {
-		return 0
+// TarOption represents options to be applied to Tar.
+type TarOption func(*tarOpts)
+
+// WithMaxUntarSize sets the limit size for archives being decompressed by Untar.
+// When max is equal or less than 0 disables size checks.
+func WithMaxUntarSize(max int) TarOption {
+	return func(t *tarOpts) {
+		t.maxUntarSize = max
 	}
-	defer os.RemoveAll(tmpDir)
+}
 
-	_, _ = Untar(r, tmpDir)
-	return 1
+func (t *tarOpts) applyOpts(tarOpts ...TarOption) {
+	for _, clientOpt := range tarOpts {
+		clientOpt(t)
+	}
 }

--- a/tar/tar_test.go
+++ b/tar/tar_test.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tar
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/rand"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type untarTestCase struct {
+	name            string
+	targetDir       string
+	secureTargetDir string
+	fileName        string
+	content         []byte
+	wantErr         string
+	maxUntarSize    int
+	allowSymlink    bool
+}
+
+func TestUntar(t *testing.T) {
+	targetDirOutput := filepath.Join(t.TempDir(), "output")
+	symlink := filepath.Join(t.TempDir(), "symlink")
+
+	subdir := filepath.Join(targetDirOutput, "subdir")
+	err := os.MkdirAll(subdir, 0o755)
+	if err != nil {
+		t.Fatalf("cannot create subdir: %v", err)
+	}
+
+	err = os.Symlink(subdir, symlink)
+	if err != nil {
+		t.Fatalf("cannot create symlink: %v", err)
+	}
+
+	cases := []untarTestCase{
+		{
+			name:            "file at root",
+			fileName:        "file1",
+			content:         geRandomContent(256),
+			targetDir:       targetDirOutput,
+			secureTargetDir: targetDirOutput,
+		},
+		{
+			name:            "file at subdir root",
+			fileName:        "abc/fileX",
+			content:         geRandomContent(256),
+			targetDir:       targetDirOutput,
+			secureTargetDir: targetDirOutput,
+		},
+		{
+			name:            "directory traversal parent",
+			fileName:        "../abc/file",
+			content:         geRandomContent(256),
+			wantErr:         `tar contained invalid name error "../abc/file"`,
+			targetDir:       targetDirOutput,
+			secureTargetDir: targetDirOutput,
+		},
+		{
+			name:            "breach max size",
+			fileName:        "big-file",
+			content:         geRandomContent(256),
+			maxUntarSize:    255,
+			wantErr:         `tar "big-file" is bigger than max archive size of 255 bytes`,
+			targetDir:       targetDirOutput,
+			secureTargetDir: targetDirOutput,
+		},
+		{
+			name:            "breach default max untar size",
+			fileName:        "another-big-file",
+			content:         geRandomContent(DefaultMaxUntarSize + 1),
+			wantErr:         `tar "another-big-file" is bigger than max archive size of 104857600 bytes`,
+			targetDir:       targetDirOutput,
+			secureTargetDir: targetDirOutput,
+		},
+		{
+			name:            "disable max size checks",
+			fileName:        "another-big-file",
+			content:         geRandomContent(DefaultMaxUntarSize + 1),
+			maxUntarSize:    -1,
+			targetDir:       targetDirOutput,
+			secureTargetDir: targetDirOutput,
+		},
+		{
+			name:            "existing subdir",
+			fileName:        "subdir/file1",
+			content:         geRandomContent(256),
+			targetDir:       targetDirOutput,
+			secureTargetDir: targetDirOutput,
+		},
+		{
+			name:            "relative target dir",
+			fileName:        "file1",
+			content:         geRandomContent(256),
+			targetDir:       "anydir",
+			secureTargetDir: "./anydir",
+		},
+		{
+			name:            "relative paths can't ascend",
+			fileName:        "file1",
+			content:         geRandomContent(256),
+			targetDir:       "../../../../../../../../tmp/test",
+			secureTargetDir: "./tmp/test",
+		},
+		{
+			name:      "symlink",
+			fileName:  "any-file1",
+			content:   geRandomContent(256),
+			targetDir: symlink,
+			wantErr:   fmt.Sprintf(`dir '%s' must be a directory`, symlink),
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := createTestTar(tt)
+			if err != nil {
+				t.Fatalf("creating test tar: %v", err)
+			}
+			defer os.Remove(f.Name())
+			defer os.RemoveAll(tt.targetDir)
+
+			opts := make([]TarOption, 0)
+			if tt.maxUntarSize != 0 {
+				opts = append(opts, WithMaxUntarSize(tt.maxUntarSize))
+			}
+
+			err = Untar(f, tt.targetDir, opts...)
+			equalError(t, tt.wantErr, err)
+
+			// only assess file if no errors were expected
+			if tt.wantErr == "" {
+				abs := filepath.Join(tt.secureTargetDir, tt.fileName)
+				fi, err := os.Stat(abs)
+				if err != nil {
+					t.Errorf("stat %q: %v", abs, err)
+					return
+				}
+
+				if fi.Size() != int64(len(tt.content)) {
+					t.Errorf("file size wanted: %d got: %d", len(tt.content), fi.Size())
+				}
+			}
+
+			if tt.targetDir != tt.secureTargetDir {
+				os.RemoveAll(tt.secureTargetDir)
+			}
+		})
+	}
+}
+
+func createTestTar(tt untarTestCase) (*os.File, error) {
+	f, err := os.CreateTemp("", "flux-untar-*.tar.gz")
+	if err != nil {
+		return nil, fmt.Errorf("open file: %w", err)
+	}
+
+	gzw := gzip.NewWriter(f)
+	writer := tar.NewWriter(gzw)
+
+	writer.WriteHeader(&tar.Header{
+		Name: tt.fileName,
+		Size: int64(len(tt.content)),
+		Mode: 0o777,
+	})
+
+	writer.Write(tt.content)
+
+	if err = writer.Close(); err != nil {
+		return nil, fmt.Errorf("close tar: %v", err)
+	}
+	if err = gzw.Close(); err != nil {
+		return nil, fmt.Errorf("close gzip: %v", err)
+	}
+
+	name := f.Name()
+	if err = f.Close(); err != nil {
+		return nil, fmt.Errorf("close file: %v", err)
+	}
+	f, err = os.Open(name)
+	if err != nil {
+		return nil, fmt.Errorf("reopen file: %v", err)
+	}
+	return f, nil
+}
+
+func geRandomContent(len int) []byte {
+	content := make([]byte, len)
+	rand.Read(content)
+	return content
+}
+
+func equalError(t *testing.T, wantErr string, gotErr error) {
+	got := ""
+	if gotErr != nil {
+		got = gotErr.Error()
+	}
+	if wantErr != got {
+		t.Errorf("wanted error: '%s' got: '%v'", wantErr, gotErr)
+	}
+
+	if wantErr == "" && gotErr != nil {
+		t.Errorf("unexpected error: %v", gotErr)
+	}
+}

--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -27,7 +27,7 @@ cd "${GO_SRC}"
 cp "${PROJECT_PATH}/tests/fuzz/conditions_fuzzer.go" "${PROJECT_PATH}/runtime/conditions"
 cp "${PROJECT_PATH}/tests/fuzz/events_fuzzer.go" "${PROJECT_PATH}/runtime/events"
 cp "${PROJECT_PATH}/tests/fuzz/tls_fuzzer.go" "${PROJECT_PATH}/runtime/tls"
-cp "${PROJECT_PATH}/tests/fuzz/untar_fuzzer.go" "${PROJECT_PATH}/untar"
+cp "${PROJECT_PATH}/tests/fuzz/tar_fuzzer.go" "${PROJECT_PATH}/tar"
 cp "${PROJECT_PATH}/tests/fuzz/gitutil_fuzzer.go" "${PROJECT_PATH}/gitutil"
 
 
@@ -45,11 +45,11 @@ compile_go_fuzzer "${PROJECT_PATH}/runtime/tls" FuzzTlsConfig fuzz_tls_config
 popd
 
 
-# compile fuzz tests for the untar module
-pushd "${PROJECT_PATH}/untar"
+# compile fuzz tests for the tar module
+pushd "${PROJECT_PATH}/tar"
 
 go get -d github.com/AdaLogics/go-fuzz-headers
-compile_go_fuzzer "${PROJECT_PATH}/untar" FuzzUntar fuzz_untar
+compile_go_fuzzer "${PROJECT_PATH}/tar" FuzzUntar fuzz_untar
 
 popd
 

--- a/tests/fuzz/tar_fuzzer.go
+++ b/tests/fuzz/tar_fuzzer.go
@@ -1,0 +1,38 @@
+//go:build gofuzz
+// +build gofuzz
+
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package tar
+
+import (
+	"bytes"
+	"os"
+)
+
+// FuzzUntar implements a fuzzer that targets untar.Untar().
+func FuzzUntar(data []byte) int {
+	r := bytes.NewReader(data)
+	tmpDir, err := os.MkdirTemp("", "dir-")
+	if err != nil {
+		return 0
+	}
+	defer os.RemoveAll(tmpDir)
+
+	_ = Untar(r, tmpDir)
+
+	return 1
+}


### PR DESCRIPTION
- Add new tar package to make Untar more extensible/testable.
- Set default `maxUntarSize` to `100Mb`.
- Tests core scenarios around `tar.Untar` usage.
- Removes `summary` as this is not used across Flux2.

This PR is to be follow-up by another that either deprecates the use of `untar` or redirects `untar.Untar` to the new pkg.