### PR TITLE
runtime/events: Handle empty webhook address and log event in debug mode

### DIFF
--- a/runtime/events/recorder_test.go
+++ b/runtime/events/recorder_test.go
@@ -120,3 +120,14 @@ func TestEventRecorder_AnnotatedEventf_RateLimited(t *testing.T) {
 	eventRecorder.AnnotatedEventf(obj, nil, corev1.EventTypeNormal, "sync", "sync %s", obj.Name)
 	require.Equal(t, 1, requestCount)
 }
+
+func TestEventRecorder_Webhook(t *testing.T) {
+	_, err := NewRecorder(env, ctrl.Log, "", "test-controller")
+	require.NoError(t, err)
+
+	_, err = NewRecorder(env, ctrl.Log, " http://example.com", "test-controller")
+	require.Error(t, err)
+
+	_, err = NewRecorder(env, ctrl.Log, "http://example.com", "test-controller")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
- Handle empty webhook address passed to the event recorder by skipping attempts to post the event to external event endpoint.
- Log events when debug logs are enabled. This is part of simplifying logs and events by making events as the front-end/go-to option. With this, while debugging, the events are also visible in the logs.