### PR TITLE
ssa: Add read function that validates resources

### DIFF
--- a/ssa/utils.go
+++ b/ssa/utils.go
@@ -140,6 +140,7 @@ func ReadObject(r io.Reader) (*unstructured.Unstructured, error) {
 }
 
 // ReadObjects decodes the YAML or JSON documents from the given reader into unstructured Kubernetes API objects.
+// The documents which do not subscribe to the Kubernetes Object interface, are silently dropped from the result.
 func ReadObjects(r io.Reader) ([]*unstructured.Unstructured, error) {
 	reader := yamlutil.NewYAMLOrJSONDecoder(r, 2048)
 	objects := make([]*unstructured.Unstructured, 0)
@@ -169,6 +170,50 @@ func ReadObjects(r io.Reader) ([]*unstructured.Unstructured, error) {
 
 		if IsKubernetesObject(obj) && !IsKustomization(obj) {
 			objects = append(objects, obj)
+		}
+	}
+
+	return objects, nil
+}
+
+// ReadKubernetesObjects decodes the YAML or JSON documents from the given reader into unstructured Kubernetes API objects.
+// If any of the given resources do not subscribe to the Kubernetes Object interface, an error is returned.
+func ReadKubernetesObjects(r io.Reader) ([]*unstructured.Unstructured, error) {
+	reader := yamlutil.NewYAMLOrJSONDecoder(r, 2048)
+	objects := make([]*unstructured.Unstructured, 0)
+
+	for {
+		obj := &unstructured.Unstructured{}
+		err := reader.Decode(obj)
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+				break
+			}
+			return objects, err
+		}
+
+		if obj.Object == nil {
+			continue
+		}
+
+		if obj.IsList() {
+			err = obj.EachListItem(func(item runtime.Object) error {
+				obj := item.(*unstructured.Unstructured)
+				if !IsKubernetesObject(obj) {
+					return fmt.Errorf("failed to decode Kubernetes object from: %v", obj)
+				}
+				objects = append(objects, obj)
+				return nil
+			})
+			if err != nil {
+				return objects, err
+			}
+			continue
+		}
+
+		if !IsKubernetesObject(obj) {
+			return objects, fmt.Errorf("failed to decode Kubernetes object from: %v", obj)
 		}
 	}
 


### PR DESCRIPTION
This PR adds a function for reading Kubernetes objects from an YAML stream that validates if the given resources conform to the Kubernetes API conventions.

Ref: https://github.com/fluxcd/kustomize-controller/issues/542