### PR TITLE
ssa: Transfer the ownership of managed fields from others managers

### DIFF
--- a/ssa/go.mod
+++ b/ssa/go.mod
@@ -8,6 +8,7 @@ require (
 	k8s.io/apimachinery v0.23.1
 	sigs.k8s.io/cli-utils v0.27.0
 	sigs.k8s.io/controller-runtime v0.11.0
+	sigs.k8s.io/structured-merge-diff/v4 v4.2.0
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -75,5 +76,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 	sigs.k8s.io/kustomize/api v0.10.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v4 v4.2.0 // indirect
 )

--- a/ssa/manager_apply.go
+++ b/ssa/manager_apply.go
@@ -248,7 +248,11 @@ func (m *ResourceManager) cleanupMetadata(ctx context.Context, object *unstructu
 	}
 
 	if len(opts.FieldManagers) > 0 {
-		patches = append(patches, patchReplaceFieldsManagers(existingObject, opts.FieldManagers, m.owner.Field)...)
+		managedFieldPatch, err := patchReplaceFieldsManagers(existingObject, opts.FieldManagers, m.owner.Field)
+		if err != nil {
+			return false, err
+		}
+		patches = append(patches, managedFieldPatch...)
 	}
 
 	// no patching is needed exit early

--- a/ssa/testdata/test8.yaml
+++ b/ssa/testdata/test8.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "%[1]s"
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "%[1]s"
+  namespace: "%[1]s"
+  labels:
+    app: test
+spec:
+  ingressClassName: internal
+  rules:
+    - host: host1.internal
+      http:
+        paths:
+          - backend:
+              service:
+                name: podinfo
+                port:
+                  name: http
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - tls.internal
+      secretName: test

--- a/ssa/testdata/test9.yaml
+++ b/ssa/testdata/test9.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "%[1]s"
+  namespace: "%[1]s"
+  labels:
+    app: test
+spec:
+  ingressClassName: internal
+  rules:
+    - host: host1.internal
+      http:
+        paths:
+          - backend:
+              service:
+                name: podinfo
+                port:
+                  name: http
+            path: /
+            pathType: Prefix
+    - host: host2.internal
+      http:
+        paths:
+          - backend:
+              service:
+                name: podinfo
+                port:
+                  name: http
+            path: /
+            pathType: Prefix


### PR DESCRIPTION
This pull request allows the designated manager to transfer ownership of fields from others managers to itself. Instead of replacing a 3rd party manager, we merge the fields into our manager allowing it to take ownership of fields that it previously didn't owned.

Ref:  [#fluxcd/kustomize-controller](https://github.com/fluxcd/kustomize-controller/issues/558).