### PR TITLE
ssa: Preserve the status field on CRDs

### DIFF
--- a/ssa/utils.go
+++ b/ssa/utils.go
@@ -419,7 +419,12 @@ func SetNativeKindsDefaults(objects []*unstructured.Unstructured) error {
 
 		// remove fields that are not supposed to be present in manifests
 		unstructured.RemoveNestedField(u.Object, "metadata", "creationTimestamp")
-		unstructured.RemoveNestedField(u.Object, "status")
+
+		// remove status but for CRDs (kstatus wait doesn't work with empty status fields)
+		if u.GetKind() != "CustomResourceDefinition" {
+			unstructured.RemoveNestedField(u.Object, "status")
+		}
+
 	}
 	return nil
 }


### PR DESCRIPTION
We can't remove the status sub-resource from CRDs because `kstatus` wait doesn't work with empty status fields 😢 

Ref: https://github.com/fluxcd/flux2/issues/2351