### PR TITLE
runtime/patch: Make ToUnstructured() public

### DIFF
--- a/runtime/patch/patch.go
+++ b/runtime/patch/patch.go
@@ -146,7 +146,7 @@ func NewHelper(obj client.Object, crClient client.Client) (*Helper, error) {
 	}
 
 	// Convert the object to unstructured to compare against our before copy.
-	unstructuredObj, err := toUnstructured(obj)
+	unstructuredObj, err := ToUnstructured(obj)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func (h *Helper) Patch(ctx context.Context, obj client.Object, opts ...Option) e
 	}
 
 	// Convert the object to unstructured to compare against our before copy.
-	h.after, err = toUnstructured(obj)
+	h.after, err = ToUnstructured(obj)
 	if err != nil {
 		return err
 	}

--- a/runtime/patch/utils.go
+++ b/runtime/patch/utils.go
@@ -52,7 +52,8 @@ func unstructuredHasStatus(u *unstructured.Unstructured) bool {
 	return ok
 }
 
-func toUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
+// ToUnstructured converts a runtime.Object into an Unstructured object.
+func ToUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
 	// If the incoming object is already unstructured, perform a deep copy first
 	// otherwise DefaultUnstructuredConverter ends up returning the inner map without
 	// making a copy.

--- a/runtime/patch/utils_test.go
+++ b/runtime/patch/utils_test.go
@@ -43,7 +43,7 @@ func TestToUnstructured(t *testing.T) {
 				"configmap": "true",
 			},
 		}
-		newObj, err := toUnstructured(obj)
+		newObj, err := ToUnstructured(obj)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(newObj.GetName()).To(Equal(obj.Name))
 		g.Expect(newObj.GetNamespace()).To(Equal(obj.Namespace))
@@ -69,7 +69,7 @@ func TestToUnstructured(t *testing.T) {
 			},
 		}
 
-		newObj, err := toUnstructured(obj)
+		newObj, err := ToUnstructured(obj)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(newObj.GetName()).To(Equal(obj.GetName()))
 		g.Expect(newObj.GetNamespace()).To(Equal(obj.GetNamespace()))


### PR DESCRIPTION
`ToUnstructured()` is useful for others controllers, especially for use
in tests.