### PR TITLE
ssa: Allow objects to be excluded from metadata cleanup

### DIFF
--- a/ssa/go.mod
+++ b/ssa/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-cmp v0.5.6
 	k8s.io/api v0.23.2
 	k8s.io/apimachinery v0.23.2
-	sigs.k8s.io/cli-utils v0.28.0
+	sigs.k8s.io/cli-utils v0.29.2
 	sigs.k8s.io/controller-runtime v0.11.1
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1
 	sigs.k8s.io/yaml v1.3.0

--- a/ssa/go.sum
+++ b/ssa/go.sum
@@ -1182,8 +1182,8 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.25/go.mod h1:Mlj9PNLmG9bZ6BHFwFKDo5afkpWyUISkb9Me0GnK66I=
-sigs.k8s.io/cli-utils v0.28.0 h1:gsvwqygoXlW2y8CmKdflQJNZp1Yhi4geATW3/Ei7oYc=
-sigs.k8s.io/cli-utils v0.28.0/go.mod h1:WDVRa5/eQBKntG++uyKdyT+xU7MLdCR4XsgseqL5uX4=
+sigs.k8s.io/cli-utils v0.29.2 h1:SaYo2C1xd0MVv65NQXZ6tIqT1W1iWy8CGmC+VnxQGWs=
+sigs.k8s.io/cli-utils v0.29.2/go.mod h1:WDVRa5/eQBKntG++uyKdyT+xU7MLdCR4XsgseqL5uX4=
 sigs.k8s.io/controller-runtime v0.11.0/go.mod h1:KKwLiTooNGu+JmLZGn9Sl3Gjmfj66eMbCQznLP5zcqA=
 sigs.k8s.io/controller-runtime v0.11.1 h1:7YIHT2QnHJArj/dk9aUkYhfqfK5cIxPOX5gPECfdZLU=
 sigs.k8s.io/controller-runtime v0.11.1/go.mod h1:KKwLiTooNGu+JmLZGn9Sl3Gjmfj66eMbCQznLP5zcqA=


### PR DESCRIPTION
This PR offers an alternative to preventing Flux from overriding kubectl edits. There are cases when setting a different manager for kubectl is not possible (e.g. [EKS CoreDNS](https://fluxcd.io/docs/faq/#how-to-patch-coredns-and-other-pre-installed-addons)), and thus patching existing objects is not possible. With this PR, users can set an annotation to existing objects to hint at Flux that it should skip the kubectl manager takeover.