### PR TITLE
build: enable '-race' for 'go test' 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ generate-%: controller-gen
 # Run tests
 KUBEBUILDER_ASSETS?="$(shell $(ENVTEST) --arch=$(ENVTEST_ARCH) use -i $(ENVTEST_KUBERNETES_VERSION) --bin-dir=$(ENVTEST_ASSETS_DIR) -p path)"
 test-%: tidy-% generate-% fmt-% vet-% install-envtest
-	cd $(subst :,/,$*); KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./... -coverprofile cover.out
+	cd $(subst :,/,$*); KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./... -race -coverprofile cover.out
 
 release-%:
 	$(eval REL_PATH=$(subst :,/,$*))


### PR DESCRIPTION
Enables race condition checks during the execution of tests. This PR also fixes the only occurrency of racy condition found.

May relate to the `TestGitRepositoryReconciler_reconcileSource_authStrategy` [failures](https://github.com/fluxcd/source-controller/runs/5578047164?check_suite_focus=true) in https://github.com/fluxcd/source-controller/pull/615.