### PR TITLE
Add kubeconfig into `runtime/client`

### DIFF
--- a/runtime/client/kubeconfig.go
+++ b/runtime/client/kubeconfig.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"time"
+
+	"github.com/spf13/pflag"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	flagInsecureKubeConfigExec = "insecure-kubeconfig-exec"
+	flagInsecureKubeConfigTLS  = "insecure-kubeconfig-tls"
+)
+
+// KubeConfigOptions defines options for KubeConfig sanitization.
+type KubeConfigOptions struct {
+	// InsecureExecProvider enables the use of ExecProviders in kubeconfig.
+	// To use this feature securely, it is recommended the use of restrictive
+	// AppArmor and SELinux profiles to restrict what binaries can be executed.
+	InsecureExecProvider bool
+
+	// InsecureTLS disables TLS certificate verification. This is insecure and
+	// should be used for testing purposes only.
+	InsecureTLS bool
+
+	// UserAgent defines a string to identify the caller.
+	UserAgent string
+
+	// Timeout defines the maximum length of time to wait before giving up on a server request.
+	// A value of zero means no timeout.
+	//
+	// If not provided, it will be set to 30 seconds.
+	Timeout *time.Duration
+}
+
+func (opts KubeConfigOptions) withDefaults() KubeConfigOptions {
+	if opts.Timeout == nil {
+		t := 30 * time.Second
+		opts.Timeout = &t
+	}
+	return opts
+}
+
+// BindFlags will parse the given pflag.FlagSet for Kubernetes client option flags and set the Options accordingly.
+func (o *KubeConfigOptions) BindFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&o.InsecureExecProvider, flagInsecureKubeConfigExec, false,
+		"Allow use of the user.exec section in kubeconfigs provided for remote apply.")
+	fs.BoolVar(&o.InsecureTLS, flagInsecureKubeConfigTLS, false,
+		"Allow that kubeconfigs provided for remote apply can disable TLS verification.")
+}
+
+// KubeConfig sanitises a kubeconfig represented as *rest.Config using
+// KubeConfigOptions to inform the transformation decisions.
+func KubeConfig(in *rest.Config, opts KubeConfigOptions) *rest.Config {
+	var out *rest.Config
+
+	if in != nil {
+		opts = opts.withDefaults()
+		out = &rest.Config{
+			UserAgent: opts.UserAgent,
+		}
+
+		if opts.Timeout != nil {
+			out.Timeout = *opts.Timeout
+		}
+
+		out.Host = in.Host
+		out.APIPath = in.APIPath
+		out.DisableCompression = in.DisableCompression
+
+		out.TLSClientConfig = rest.TLSClientConfig{
+			ServerName: in.TLSClientConfig.ServerName,
+			CAData:     in.TLSClientConfig.CAData,
+			CertData:   in.TLSClientConfig.CertData,
+			KeyData:    in.TLSClientConfig.KeyData,
+		}
+
+		out.Username = in.Username
+		out.Password = in.Password
+		out.BearerToken = in.BearerToken
+
+		if opts.InsecureTLS {
+			out.TLSClientConfig.Insecure = in.TLSClientConfig.Insecure
+		}
+
+		if opts.InsecureExecProvider {
+			out.ExecProvider = in.ExecProvider
+		}
+	}
+
+	return out
+}

--- a/runtime/client/kubeconfig_test.go
+++ b/runtime/client/kubeconfig_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestKubeConfig(t *testing.T) {
+	tests := []struct {
+		description string
+		in          *rest.Config
+		opts        KubeConfigOptions
+		expected    *rest.Config
+	}{
+		{
+			description: "ignore nil configs",
+			in:          nil,
+			expected:    nil,
+		},
+		{
+			description: "ignore ExecProvider by default",
+			in: &rest.Config{
+				ExecProvider: &api.ExecConfig{
+					Command: "any-command",
+				},
+			},
+			opts:     KubeConfigOptions{Timeout: duration(0)},
+			expected: &rest.Config{},
+		},
+		{
+			description: "copy ExecProvider settings when enabled on kubeconfigOptions",
+			in: &rest.Config{
+				ExecProvider: &api.ExecConfig{
+					Command: "any-command",
+				},
+			},
+			opts: KubeConfigOptions{
+				InsecureExecProvider: true,
+				Timeout:              duration(0),
+			},
+			expected: &rest.Config{
+				ExecProvider: &api.ExecConfig{
+					Command: "any-command",
+				},
+			},
+		},
+		{
+			description: "ignore TLSClientConfig.Insecure by default",
+			in: &rest.Config{
+				TLSClientConfig: rest.TLSClientConfig{
+					Insecure: true,
+				},
+			},
+			opts:     KubeConfigOptions{Timeout: duration(0)},
+			expected: &rest.Config{},
+		},
+		{
+			description: "copy TLSClientConfig.Insecure value when enabled on kubeconfigOptions",
+			in: &rest.Config{
+				TLSClientConfig: rest.TLSClientConfig{
+					Insecure: true,
+				},
+			},
+			opts: KubeConfigOptions{
+				InsecureTLS: true,
+				Timeout:     duration(0),
+			},
+			expected: &rest.Config{
+				TLSClientConfig: rest.TLSClientConfig{
+					Insecure: true,
+				},
+			},
+		},
+		{
+			description: "core values should not be changed",
+			in: &rest.Config{
+				Host:               "host",
+				APIPath:            "api-path",
+				DisableCompression: true,
+				Username:           "username",
+				Password:           "password",
+				BearerToken:        "beartoken",
+
+				TLSClientConfig: rest.TLSClientConfig{
+					ServerName: "server-name",
+					CAData:     []byte("CA-data"),
+					CertData:   []byte("cert-data"),
+					KeyData:    []byte("key-data"),
+				},
+			},
+			opts: KubeConfigOptions{Timeout: duration(0)},
+			expected: &rest.Config{
+				Host:               "host",
+				APIPath:            "api-path",
+				DisableCompression: true,
+				Username:           "username",
+				Password:           "password",
+				BearerToken:        "beartoken",
+
+				TLSClientConfig: rest.TLSClientConfig{
+					ServerName: "server-name",
+					CAData:     []byte("CA-data"),
+					CertData:   []byte("cert-data"),
+					KeyData:    []byte("key-data"),
+				},
+			},
+		},
+		{
+			description: "useragent and timeout cannot be overwriten",
+			in: &rest.Config{
+				UserAgent: "Kubernetes Kubernetes Kubernetes",
+				Timeout:   9999 * time.Second,
+			},
+			opts: KubeConfigOptions{
+				UserAgent: "Flux Remote Apply",
+				Timeout:   duration(30 * time.Second),
+			},
+			expected: &rest.Config{
+				UserAgent: "Flux Remote Apply",
+				Timeout:   30 * time.Second,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		got := KubeConfig(tt.in, tt.opts)
+		if !reflect.DeepEqual(tt.expected, got) {
+			t.Error(tt.description)
+		}
+	}
+}
+
+func duration(d time.Duration) *time.Duration {
+	return &d
+}


### PR DESCRIPTION
Adds kubeconfig sanitisation for kubeconfig values, making it easier to enforce what features to enabled/disable.