### PR TITLE
runtime/conditions: Update observed gen on Set()

### DIFF
--- a/runtime/conditions/setter.go
+++ b/runtime/conditions/setter.go
@@ -82,7 +82,7 @@ func Set(to Setter, condition *metav1.Condition) {
 		conditions = append(conditions, *condition)
 	}
 
-	// Sorts conditions for convenience of the consumer, i.e. kubectl.
+	// Sort conditions for convenience of the consumer, i.e. kubectl.
 	sort.Slice(conditions, func(i, j int) bool {
 		return lexicographicLess(&conditions[i], &conditions[j])
 	})
@@ -196,9 +196,10 @@ var conditionWeights = map[string]int{
 	meta.ReadyCondition:       2,
 }
 
-// lexicographicLess returns true if a condition is less than another with regards to the to order of conditions
+// lexicographicLess returns true if a condition is less than another in regard to the to order of conditions
 // designed for convenience of the consumer, i.e. kubectl. The condition types in conditionWeights always go first,
-// sorted by their defined weight, followed by all the other conditions sorted lexicographically by Type.
+// sorted by their defined weight, followed by all the other conditions sorted by highest observedGeneration and
+// lexicographically by Type.
 func lexicographicLess(i, j *metav1.Condition) bool {
 	w1, ok1 := conditionWeights[i.Type]
 	w2, ok2 := conditionWeights[j.Type]
@@ -208,7 +209,7 @@ func lexicographicLess(i, j *metav1.Condition) bool {
 	case ok1, ok2:
 		return !ok2
 	default:
-		return i.Type < j.Type
+		return i.ObservedGeneration >= j.ObservedGeneration && i.Type < j.Type
 	}
 }
 

--- a/runtime/conditions/setter.go
+++ b/runtime/conditions/setter.go
@@ -65,6 +65,11 @@ func Set(to Setter, condition *metav1.Condition) {
 				break
 			}
 			condition.LastTransitionTime = existingCondition.LastTransitionTime
+			// For new observed generations, update the condition to have the
+			// new generation, preserving the last transition time.
+			if existingCondition.ObservedGeneration != condition.ObservedGeneration {
+				conditions[i] = *condition
+			}
 			break
 		}
 	}

--- a/runtime/conditions/setter_test.go
+++ b/runtime/conditions/setter_test.go
@@ -81,6 +81,25 @@ func TestLexicographicLess(t *testing.T) {
 	b = TrueCondition("A", "", "")
 	g.Expect(lexicographicLess(a, b)).To(BeFalse())
 
+	// observed generation is respected
+	a = TrueCondition("A", "", "")
+	a.ObservedGeneration = 2
+	b = TrueCondition("B", "", "")
+	b.ObservedGeneration = 2
+	g.Expect(lexicographicLess(a, b)).To(BeTrue())
+
+	a = TrueCondition("A", "", "")
+	a.ObservedGeneration = 1
+	b = TrueCondition("B", "", "")
+	b.ObservedGeneration = 2
+	g.Expect(lexicographicLess(a, b)).To(BeFalse())
+
+	a = TrueCondition("A", "", "")
+	a.ObservedGeneration = 1
+	b = TrueCondition("B", "", "")
+	b.ObservedGeneration = 0
+	g.Expect(lexicographicLess(a, b)).To(BeTrue())
+
 	// Stalled, Ready, and Reconciling conditions are threaded as an
 	// exception and always go first.
 	stalled := TrueCondition(meta.StalledCondition, "", "")
@@ -98,6 +117,10 @@ func TestLexicographicLess(t *testing.T) {
 
 	g.Expect(lexicographicLess(ready, b)).To(BeTrue())
 	g.Expect(lexicographicLess(b, ready)).To(BeFalse())
+
+	ready.ObservedGeneration = 1
+	b.ObservedGeneration = 2
+	g.Expect(lexicographicLess(ready, b)).To(BeTrue())
 }
 
 func TestSet(t *testing.T) {


### PR DESCRIPTION
Conditions `Set()` should update the observed generation of the condition
to the latest object version to reflect the observation on the latest
generation of the object.