### PR TITLE
Bump apis/meta in runtime

### DIFF
--- a/runtime/go.mod
+++ b/runtime/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/fluxcd/pkg/apis/acl v0.0.3
-	github.com/fluxcd/pkg/apis/meta v0.12.0
+	github.com/fluxcd/pkg/apis/meta v0.12.2
 	github.com/go-logr/logr v1.2.2
 	github.com/google/go-cmp v0.5.7
 	github.com/hashicorp/go-retryablehttp v0.7.0


### PR DESCRIPTION
This wasn't done for `apis/meta v0.12.1`. We really need to keep internal deps in sync, maybe some check in GH Actions would help.