### PR TITLE
ssh: Update PreferredKexAlgos based on golang.org/x/crypto/ssh 

### DIFF
--- a/ssh/go.mod
+++ b/ssh/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 // Fix for CVE-2020-29652: https://github.com/golang/crypto/commit/8b5274cf687fd9316b4108863654cc57385531e8
 // Fix for CVE-2021-43565: https://github.com/golang/crypto/commit/5770296d904e90f15f38f77dfc2e43fdf5efc083
-require golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd
+require golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f
 
 require github.com/onsi/gomega v1.19.0
 

--- a/ssh/go.sum
+++ b/ssh/go.sum
@@ -1,8 +1,8 @@
 github.com/onsi/ginkgo/v2 v2.1.3 h1:e/3Cwtogj0HA+25nMP1jCMDIf8RtRYbGwGGuBIFztkc=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd h1:XcWmESyNjXJMLahc3mqVQJcgSTDxFxhETVlfk9uGc38=
-golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f h1:OeJjE6G4dgCY4PIXvIRQbE8+RX+uXZyGhUy/ksMGJoc=
+golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=

--- a/ssh/kex.go
+++ b/ssh/kex.go
@@ -19,27 +19,30 @@ package ssh
 import "golang.org/x/crypto/ssh"
 
 // These string constants are copied from golang/crypto
-// https://github.com/golang/crypto/blob/0c34fe9e7dc2486962ef9867e3edb3503537209f/ssh/kex.go#L23-L34
+// https://github.com/golang/crypto/blob/5d542ad81a58c89581d596f49d0ba5d435481bcf/ssh/kex.go#L23-L36
 const (
-	kexAlgoDH14SHA1         = "diffie-hellman-group14-sha1"
-	kexAlgoECDH256          = "ecdh-sha2-nistp256"
-	kexAlgoECDH384          = "ecdh-sha2-nistp384"
-	kexAlgoECDH521          = "ecdh-sha2-nistp521"
-	kexAlgoCurve25519SHA256 = "curve25519-sha256@libssh.org"
+	kexAlgoDH14SHA1               = "diffie-hellman-group14-sha1"
+	kexAlgoDH14SHA256             = "diffie-hellman-group14-sha256"
+	kexAlgoECDH256                = "ecdh-sha2-nistp256"
+	kexAlgoECDH384                = "ecdh-sha2-nistp384"
+	kexAlgoECDH521                = "ecdh-sha2-nistp521"
+	kexAlgoCurve25519SHA256       = "curve25519-sha256"
+	kexAlgoCurve25519SHA256LibSSH = "curve25519-sha256@libssh.org"
 
 	// For the following kex only the client half contains a production
 	// ready implementation. The server half only consists of a minimal
 	// implementation to satisfy the automated tests.
-	kexAlgoDHGEXSHA1   = "diffie-hellman-group-exchange-sha1"
 	kexAlgoDHGEXSHA256 = "diffie-hellman-group-exchange-sha256"
 )
 
 // PreferredKeyAlgos is aligned with the preferredKeyAlgos from golang/crypto
-// but includes kexAlgoDHGEXSHA256 as the least preferred option.
+// with the exception of:
+// - No support for diffie-hellman-group1-sha1.
+// - Includes kexAlgoDHGEXSHA256 as the least preferred option.
 var PreferredKexAlgos = []string{
-	kexAlgoCurve25519SHA256,
+	kexAlgoCurve25519SHA256, kexAlgoCurve25519SHA256LibSSH,
 	kexAlgoECDH256, kexAlgoECDH384, kexAlgoECDH521,
-	kexAlgoDH14SHA1,
+	kexAlgoDH14SHA256, kexAlgoDH14SHA1,
 	kexAlgoDHGEXSHA256,
 }
 

--- a/ssh/kex.go
+++ b/ssh/kex.go
@@ -21,7 +21,6 @@ import "golang.org/x/crypto/ssh"
 // These string constants are copied from golang/crypto
 // https://github.com/golang/crypto/blob/0c34fe9e7dc2486962ef9867e3edb3503537209f/ssh/kex.go#L23-L34
 const (
-	kexAlgoDH1SHA1          = "diffie-hellman-group1-sha1"
 	kexAlgoDH14SHA1         = "diffie-hellman-group14-sha1"
 	kexAlgoECDH256          = "ecdh-sha2-nistp256"
 	kexAlgoECDH384          = "ecdh-sha2-nistp384"


### PR DESCRIPTION
Aligns preferred algorithms with upstream golang.org/x/crypto/ssh, resulting in adding support to two new kex algorithms on PreferredKexAlgos:
- curve25519-sha256
- diffie-hellman-group14-sha256

Removes references to unused algorithms that are no longer recommended for use:
- diffie-hellman-group1-sha1
- diffie-hellman-group-exchange-sha1

This code does not seem to be called anywhere. An alternative change may be to simply removing it from the module so we don't need to update it going forwards.