### PR TITLE
Add helpers to parse knownhosts and match against them

### DIFF
--- a/ssh/knownhosts/known_key.go
+++ b/ssh/knownhosts/known_key.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package knownhosts
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"hash"
+	"io"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+)
+
+type KnownKey struct {
+	hosts []string
+	key   ssh.PublicKey
+}
+
+// ParseKnownHosts takes a string with the contents of known_hosts, parses it
+// and returns a slice of KnownKey
+func ParseKnownHosts(s string) ([]KnownKey, error) {
+	var knownHosts []KnownKey
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	for scanner.Scan() {
+		_, hosts, pubKey, _, _, err := ssh.ParseKnownHosts(scanner.Bytes())
+		if err != nil {
+			// Lines that aren't host public key result in EOF, like a comment
+			// line. Continue parsing the other lines.
+			if err == io.EOF {
+				continue
+			}
+			return []KnownKey{}, err
+		}
+
+		knownHost := KnownKey{
+			hosts: hosts,
+			key:   pubKey,
+		}
+		knownHosts = append(knownHosts, knownHost)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return []KnownKey{}, err
+	}
+
+	return knownHosts, nil
+}
+
+// Matches checks if the specified host is present and if the fingerprint matches
+// the present public key key.
+func (k KnownKey) Matches(host string, fingerprint []byte, hasher hash.Hash) bool {
+	if !containsHost(k.hosts, host) {
+		return false
+	}
+	hasher.Write(k.key.Marshal())
+	return bytes.Equal(hasher.Sum(nil), fingerprint)
+}
+
+func containsHost(hosts []string, host string) bool {
+	for _, kh := range hosts {
+		// hashed host must start with a pipe
+		if kh[0] == '|' {
+			match, _ := matchHashedHost(kh, host)
+			if match {
+				return true
+			}
+
+		} else if kh == host { // unhashed host check
+			return true
+		}
+	}
+	return false
+}
+
+// matchHashedHost tries to match a hashed known host (kh) to
+// host.
+//
+// Note that host is not hashed, but it is rather hashed during
+// the matching process using the same salt used when hashing
+// the known host.
+func matchHashedHost(kh, host string) (bool, error) {
+	if kh == "" || kh[0] != '|' {
+		return false, fmt.Errorf("hashed known host must begin with '|': '%s'", kh)
+	}
+
+	components := strings.Split(kh, "|")
+	if len(components) != 4 {
+		return false, fmt.Errorf("invalid format for hashed known host: '%s'", kh)
+	}
+
+	if components[1] != "1" {
+		return false, fmt.Errorf("unsupported hash type '%s'", components[1])
+	}
+
+	hkSalt, err := base64.StdEncoding.DecodeString(components[2])
+	if err != nil {
+		return false, fmt.Errorf("cannot decode hashed known host: '%w'", err)
+	}
+
+	hkHash, err := base64.StdEncoding.DecodeString(components[3])
+	if err != nil {
+		return false, fmt.Errorf("cannot decode hashed known host: '%w'", err)
+	}
+
+	mac := hmac.New(sha1.New, hkSalt)
+	mac.Write([]byte(host))
+	hostHash := mac.Sum(nil)
+
+	return bytes.Equal(hostHash, hkHash), nil
+}

--- a/ssh/knownhosts/known_key_test.go
+++ b/ssh/knownhosts/known_key_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package knownhosts
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_matchHashedHost(t *testing.T) {
+	tests := []struct {
+		name       string
+		hashedHost string
+		host       string
+		match      bool
+		wantErr    string
+	}{
+		{
+			name:       "match valid known host",
+			hashedHost: "|1|vApZG0Ybr4rHfTb69+cjjFIGIv0=|M5sSXen14encOvQAy0gseRahnJw=",
+			host:       "[127.0.0.1]:44167",
+			match:      true,
+		},
+		{
+			name:    "empty known host errors",
+			wantErr: "hashed known host must begin with '|'",
+		},
+		{
+			name:       "unhashed known host errors",
+			hashedHost: "[127.0.0.1]:44167",
+			wantErr:    "hashed known host must begin with '|'",
+		},
+		{
+			name:       "invalid known host format errors",
+			hashedHost: "|1M5sSXen14encOvQAy0gseRahnJw=",
+			wantErr:    "invalid format for hashed known host",
+		},
+		{
+			name:       "invalid hash type errors",
+			hashedHost: "|2|vApZG0Ybr4rHfTb69+cjjFIGIv0=|M5sSXen14encOvQAy0gseRahnJw=",
+			wantErr:    "unsupported hash type",
+		},
+		{
+			name:       "invalid base64 component[2] errors",
+			hashedHost: "|1|azz|M5sSXen14encOvQAy0gseRahnJw=",
+			wantErr:    "cannot decode hashed known host",
+		},
+		{
+			name:       "invalid base64 component[3] errors",
+			hashedHost: "|1|M5sSXen14encOvQAy0gseRahnJw=|azz",
+			wantErr:    "cannot decode hashed known host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			matched, err := matchHashedHost(tt.hashedHost, tt.host)
+
+			if tt.wantErr == "" {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(matched).To(Equal(tt.match))
+			} else {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.wantErr))
+			}
+		})
+	}
+}
+
+func TestParseKnownHosts(t *testing.T) {
+	known_host := "11.101.41.142 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLBfOI4ma6GtSaWssT8pqJ7kVxuMfcYhTIs5p0TiiY7Wz8WVArUzzQjoKUJ60HT5CqHmOMb8ux6nDIXNRamf+VE="
+
+	kk, err := ParseKnownHosts(known_host)
+	g := NewWithT(t)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(len(kk)).To(Equal(1))
+	known_host = known_host + "invalidbase"
+
+	kk, err = ParseKnownHosts(known_host)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(len(kk)).To(Equal(0))
+}


### PR DESCRIPTION
This PR refactors the known hosts parsing and matching logic from the source-controller into pkg, for easier usage.

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>