### PR TITLE
Use HTTP server to initialize repos on Windows

### DIFF
--- a/git/go.mod
+++ b/git/go.mod
@@ -30,6 +30,7 @@ require (
 require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect

--- a/git/go.sum
+++ b/git/go.sum
@@ -15,6 +15,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
+github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/gittestserver/go.mod
+++ b/gittestserver/go.mod
@@ -3,6 +3,7 @@ module github.com/fluxcd/pkg/gittestserver
 go 1.17
 
 require (
+	github.com/cyphar/filepath-securejoin v0.2.3
 	github.com/fluxcd/gitkit v0.6.0
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2

--- a/gittestserver/go.sum
+++ b/gittestserver/go.sum
@@ -10,6 +10,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
+github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/gittestserver/server.go
+++ b/gittestserver/server.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"time"
 
+	securefilepath "github.com/cyphar/filepath-securejoin"
 	"github.com/fluxcd/gitkit"
 	"github.com/go-git/go-billy/v5/memfs"
 	gogit "github.com/go-git/go-git/v5"
@@ -324,8 +325,12 @@ func (s *GitServer) SSHAddress() string {
 // fixture at the repoPath.
 func (s *GitServer) InitRepo(fixture, branch, repoPath string) error {
 	// Create a bare repo to initialize.
-	localRepo := filepath.Join(s.Root(), repoPath)
-	_, err := gogit.PlainInit(localRepo, true)
+	localRepo, err := securefilepath.SecureJoin(s.Root(), repoPath)
+	if err != nil {
+		return err
+	}
+
+	_, err = gogit.PlainInit(localRepo, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Pushing using the file protocol on Windows is broken for go-git (ref: https://github.com/go-git/go-git/issues/415). This PR adds support for initializing repos for the test server on Windows by using HTTP.

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>