### PR TITLE
Update `KnownKey.Matches` to initialize it's own hasher

### DIFF
--- a/ssh/knownhosts/known_key.go
+++ b/ssh/knownhosts/known_key.go
@@ -21,9 +21,9 @@ import (
 	"bytes"
 	"crypto/hmac"
 	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
-	"hash"
 	"io"
 	"strings"
 
@@ -67,10 +67,11 @@ func ParseKnownHosts(s string) ([]KnownKey, error) {
 
 // Matches checks if the specified host is present and if the fingerprint matches
 // the present public key key.
-func (k KnownKey) Matches(host string, fingerprint []byte, hasher hash.Hash) bool {
+func (k KnownKey) Matches(host string, fingerprint []byte) bool {
 	if !containsHost(k.hosts, host) {
 		return false
 	}
+	hasher := sha256.New()
 	hasher.Write(k.key.Marshal())
 	return bytes.Equal(hasher.Sum(nil), fingerprint)
 }

--- a/ssh/knownhosts/known_key_test.go
+++ b/ssh/knownhosts/known_key_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package knownhosts
 
 import (
-	"crypto/sha256"
 	"encoding/base64"
 	"testing"
 
@@ -91,7 +90,6 @@ func Test_matchHashedHost(t *testing.T) {
 }
 
 func Test_parseKnownHosts_matches(t *testing.T) {
-	hasher := sha256.New()
 	tests := []struct {
 		name        string
 		fingerprint []byte
@@ -117,7 +115,7 @@ func Test_parseKnownHosts_matches(t *testing.T) {
 				t.Error(err)
 				return
 			}
-			matches := knownKeys[0].Matches("github.com", tt.fingerprint, hasher)
+			matches := knownKeys[0].Matches("github.com", tt.fingerprint)
 			g.Expect(matches).To(Equal(tt.wantMatches))
 		})
 	}


### PR DESCRIPTION
Previously, `KnownKey.Matches()` accepted a SHA256 hasher as an argument,
which could lead to unintended bugs when calling it in a loop. This
eliminates that, by intializing a new hasher itself instead of relying
on the caller for the same.
Enables us to fix a regression in the source-controller: https://github.com/fluxcd/image-automation-controller/issues/378

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>