### PR TITLE
Add pkg for masking token

### DIFF
--- a/masktoken/go.mod
+++ b/masktoken/go.mod
@@ -1,0 +1,3 @@
+module github.com/fluxcd/pkg/masktoken
+
+go 1.17

--- a/masktoken/masktoken.go
+++ b/masktoken/masktoken.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package masktoken
 
 import (

--- a/masktoken/masktoken.go
+++ b/masktoken/masktoken.go
@@ -1,0 +1,22 @@
+package masktoken
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func MaskTokenFromString(log string, token string) string {
+	if token == "" {
+		return log
+	}
+
+	re, compileErr := regexp.Compile(fmt.Sprintf("%s*", regexp.QuoteMeta(token)))
+	if compileErr != nil {
+		newErrStr := fmt.Sprintf("error redacting token from string: %s", compileErr)
+		return newErrStr
+	}
+
+	redacted := re.ReplaceAllString(log, "*****")
+
+	return redacted
+}

--- a/masktoken/masktoken_test.go
+++ b/masktoken/masktoken_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package masktoken
 
 import (

--- a/masktoken/masktoken_test.go
+++ b/masktoken/masktoken_test.go
@@ -1,0 +1,79 @@
+package masktoken
+
+import (
+	"strings"
+	"testing"
+)
+
+func Test_MaskTokenFromError(t *testing.T) {
+	tests := []struct {
+		name           string
+		token          string
+		originalErrStr string
+		expectedErrStr string
+	}{
+		{
+			name:           "no token",
+			token:          "8h0387hdyehbwwa45",
+			originalErrStr: "Cannot post to github",
+			expectedErrStr: "Cannot post to github",
+		},
+		{
+			name:           "empty token",
+			token:          "",
+			originalErrStr: "Cannot post to github",
+			expectedErrStr: "Cannot post to github",
+		},
+		{
+			name:           "exact token",
+			token:          "8h0387hdyehbwwa45",
+			originalErrStr: "Cannot post to github with token 8h0387hdyehbwwa45",
+			expectedErrStr: "Cannot post to github with token *****",
+		},
+		{
+			name:           "non-exact token",
+			token:          "8h0387hdyehbwwa45",
+			originalErrStr: `Cannot post to github with token 8h0387hdyehbwwa45\\n`,
+			expectedErrStr: `Cannot post to github with token *****\\n`,
+		},
+		{
+			name:           "extra text in front token",
+			token:          "8h0387hdyehbwwa45",
+			originalErrStr: `Cannot post to github with token metoo8h0387hdyehbwwa45\\n`,
+			expectedErrStr: `Cannot post to github with token metoo*****\\n`,
+		},
+		{
+			name:           "extra text in front token",
+			token:          "8h0387hdyehbwwa45踙",
+			originalErrStr: `Cannot post to github with token metoo8h0387hdyehbwwa45踙\\n`,
+			expectedErrStr: `Cannot post to github with token metoo*****\\n`,
+		},
+		{
+			name:           "return error on invalid UTF-8 string",
+			token:          "\x18\xd0\xfa\xab\xb2\x93\xbb;\xc0l\xf4\xdc",
+			originalErrStr: `Cannot post to github with token \x18\xd0\xfa\xab\xb2\x93\xbb;\xc0l\xf4\xdc\\n`,
+			expectedErrStr: `error redacting token from error message`,
+		},
+		{
+			name:           "unescaped token",
+			token:          "8h0387hdyehbwwa45\\",
+			originalErrStr: `Cannot post to github with token metoo8h0387hdyehbwwa45\\\n`,
+			expectedErrStr: `Cannot post to github with token metoo*****n`,
+		},
+		{
+			name:           "invalid chars",
+			token:          "8h0387hdyehbwwa45(?!\\/)",
+			originalErrStr: `Cannot post to github`,
+			expectedErrStr: `Cannot post to github`,
+		},
+	}
+
+	for _, tt := range tests {
+		returnedStr := MaskTokenFromString(tt.originalErrStr, tt.token)
+		if !strings.Contains(returnedStr, tt.expectedErrStr) {
+			t.Errorf("expected error string '%s' but got '%s'",
+				tt.expectedErrStr, returnedStr)
+		}
+	}
+
+}

--- a/masktoken/masktoken_test.go
+++ b/masktoken/masktoken_test.go
@@ -52,7 +52,7 @@ func Test_MaskTokenFromError(t *testing.T) {
 			name:           "return error on invalid UTF-8 string",
 			token:          "\x18\xd0\xfa\xab\xb2\x93\xbb;\xc0l\xf4\xdc",
 			originalErrStr: `Cannot post to github with token \x18\xd0\xfa\xab\xb2\x93\xbb;\xc0l\xf4\xdc\\n`,
-			expectedErrStr: `error redacting token from error message`,
+			expectedErrStr: `error redacting token from string`,
 		},
 		{
 			name:           "unescaped token",
@@ -71,8 +71,8 @@ func Test_MaskTokenFromError(t *testing.T) {
 	for _, tt := range tests {
 		returnedStr := MaskTokenFromString(tt.originalErrStr, tt.token)
 		if !strings.Contains(returnedStr, tt.expectedErrStr) {
-			t.Errorf("expected error string '%s' but got '%s'",
-				tt.expectedErrStr, returnedStr)
+			t.Errorf("expected returned string '%s' to contain '%s'",
+				returnedStr, tt.expectedErrStr)
 		}
 	}
 


### PR DESCRIPTION
This pull requests adds a pkg for masking a token in the string.
The code was moved from [the notification-controller](https://github.com/fluxcd/notification-controller/blob/main/internal/server/event_handlers.go#L322) to be used by other controllers.

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>