### PR TITLE
git: add E2E tests for GitLab and a separate CI workflow for E2E tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,26 @@
+name: e2e
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  git-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Restore Go cache
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/work/_temp/_github_home/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run tests
+        run: cd git/e2e && ./run.sh

--- a/git/e2e/gitkit_test.go
+++ b/git/e2e/gitkit_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2022 The Flux authors
 
@@ -13,6 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package e2e
 
 import (

--- a/git/e2e/gitlab_test.go
+++ b/git/e2e/gitlab_test.go
@@ -1,0 +1,187 @@
+//go:build e2e
+// +build e2e
+
+/*
+// Copyright 2022 The Flux authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/fluxcd/pkg/git"
+	"github.com/fluxcd/pkg/git/gogit"
+)
+
+const (
+	gitlabUsername     = "root"
+	gitlabHTTPHost     = "http://127.0.0.1:8080"
+	gitlabSSHHost      = "ssh://git@127.0.0.1:2222"
+	gitlabPat          = "GITLAB_PAT"
+	gitlabRootPassword = "GITLAB_ROOT_PASSWORD"
+)
+
+var (
+	privateToken string
+	password     string
+)
+
+func TestGitLabE2E(t *testing.T) {
+	privateToken = os.Getenv(gitlabPat)
+	if privateToken == "" {
+		t.Fatalf("could not read gitlab private token")
+	}
+
+	password = os.Getenv(gitlabRootPassword)
+	if password == "" {
+		t.Fatalf("could not read gitlab root password")
+	}
+	password = strings.TrimSpace(password)
+
+	repoInfo := func(repoName string, proto git.TransportType) (*url.URL, *git.AuthOptions, error) {
+		var repoURL *url.URL
+		var authOptions *git.AuthOptions
+		var err error
+
+		if proto == git.SSH {
+			repoURL, err = url.Parse(gitlabSSHHost + "/" + gitlabUsername + "/" + repoName)
+			if err != nil {
+				return nil, nil, err
+			}
+			sshAuth, err := createSSHIdentitySecret(*repoURL)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			sshKeyApiEndpoint, err := url.Parse(fmt.Sprintf("%s/api/v4/user/keys", gitlabHTTPHost))
+			if err != nil {
+				return nil, nil, err
+			}
+
+			form := url.Values{}
+			form.Add("title", randStringRunes(10))
+			form.Add("key", string(sshAuth["identity.pub"]))
+			req, err := http.NewRequest("POST", sshKeyApiEndpoint.String(), strings.NewReader(form.Encode()))
+			if err != nil {
+				return nil, nil, err
+			}
+
+			req.Header = http.Header{
+				"PRIVATE-TOKEN": []string{privateToken},
+				"Content-Type":  []string{"multipart/form-data"},
+			}
+
+			client := http.Client{}
+			resp, err := client.Do(req)
+			if err != nil {
+				return nil, nil, err
+			}
+			if resp.StatusCode != 201 {
+				var body []byte
+				_, err = resp.Body.Read(body)
+				if err != nil {
+					return nil, nil, fmt.Errorf("error reading response body")
+				}
+				return nil, nil, fmt.Errorf("could not register ssh key, resp: %s %s", resp.Status, string(body))
+			}
+
+			authOptions, err = git.NewAuthOptions(*repoURL, sshAuth)
+			if err != nil {
+				return nil, nil, err
+			}
+		} else {
+			repoURL, err = url.Parse(gitlabHTTPHost + "/" + gitlabUsername + "/" + repoName)
+			if err != nil {
+				return nil, nil, err
+			}
+			authOptions, err = git.NewAuthOptions(*repoURL, map[string][]byte{
+				"username": []byte(gitlabUsername),
+				"password": []byte(password),
+			})
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+		return repoURL, authOptions, nil
+	}
+
+	protocols := []git.TransportType{git.SSH, git.HTTP}
+	clients := []string{gogit.ClientName}
+
+	testFunc := func(t *testing.T, proto git.TransportType, c string) {
+		t.Run(fmt.Sprintf("repo created using Clone/%s", proto), func(t *testing.T) {
+			g := NewWithT(t)
+
+			repoName := fmt.Sprintf("gitlab-e2e-checkout-%s-%s", string(proto), randStringRunes(5))
+			repoURL, authOptions, err := repoInfo(repoName, proto)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			upstreamRepoURL := gitlabHTTPHost + "/" + gitlabUsername + "/" + repoName
+			err = initRepo(upstreamRepoURL, "main", "../testdata/git/repo", gitlabUsername, password)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			var client git.RepositoryClient
+			tmp := t.TempDir()
+
+			if c == gogit.ClientName {
+				client, err = gogit.NewClient(tmp, authOptions)
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+
+			testUsingClone(g, client, repoURL, upstreamRepoInfo{
+				url:      upstreamRepoURL,
+				username: gitlabUsername,
+				password: password,
+			})
+		})
+
+		t.Run(fmt.Sprintf("repo created using Init/%s", proto), func(t *testing.T) {
+			g := NewWithT(t)
+
+			repoName := fmt.Sprintf("gitlab-e2e-checkout-%s-%s", string(proto), randStringRunes(5))
+			repoURL, authOptions, err := repoInfo(repoName, proto)
+			g.Expect(err).ToNot(HaveOccurred())
+			upstreamRepoURL := gitlabHTTPHost + "/" + gitlabUsername + "/" + repoName
+
+			var client git.RepositoryClient
+			tmp := t.TempDir()
+
+			if c == gogit.ClientName {
+				client, err = gogit.NewClient(tmp, authOptions)
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+
+			testUsingInit(g, client, repoURL, upstreamRepoInfo{
+				url:      upstreamRepoURL,
+				username: gitlabUsername,
+				password: password,
+			})
+		})
+	}
+
+	for _, client := range clients {
+		for _, protocol := range protocols {
+			testFunc(t, protocol, client)
+		}
+	}
+}

--- a/git/e2e/run.sh
+++ b/git/e2e/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# This script runs e2e tests for pkg/git.
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$DIR"/setup_gitlab.sh
+go test -v -tags e2e ./...
+# cleanup
+docker kill gitlab && docker rm gitlab

--- a/git/e2e/setup_gitlab.sh
+++ b/git/e2e/setup_gitlab.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -o errexit
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Launch a container running GitLab CE.
+docker run --detach \
+  --hostname 127.0.0.1 \
+  --publish 8080:80 --publish 2222:22 \
+  --name gitlab \
+  --shm-size 256m \
+  gitlab/gitlab-ce:15.0.0-ce.0
+
+# Wait for container to be healthy.
+ok=false
+retries=30
+count=0
+until ${ok}; do
+    status=$(docker inspect gitlab -f '{{.State.Health.Status}}')
+    if [[ "$status" = "healthy" ]]; then
+        ok=true
+    fi
+    sleep 10
+    count=$(($count + 1))
+    if [[ ${count} -eq ${retries} ]]; then
+        echo "Timed out waiting for GitLab container to be healthy"
+        exit 1
+    fi
+done
+echo "GitLab container is healthy"
+
+# Grab the root password
+password=$(docker exec gitlab grep 'Password:' /etc/gitlab/initial_root_password | sed "s/Password: //g")
+
+# Register a PAT for the root user.
+TOKEN="flux-gitlab-testing123"
+docker cp "$DIR"/setup_gitlab_pat.rb gitlab:/
+docker exec gitlab gitlab-rails runner /setup_gitlab_pat.rb "${TOKEN}"
+exitCode=$?
+if [[ ${exitCode} -ne 0 ]]; then
+    echo "Error while setting up GitLab PAT"
+    exit ${exitCode}
+fi
+echo "GitLab PAT created successfully"
+
+export GITLAB_PAT="${TOKEN}"
+export GITLAB_ROOT_PASSWORD="${password}"

--- a/git/e2e/setup_gitlab_pat.rb
+++ b/git/e2e/setup_gitlab_pat.rb
@@ -1,0 +1,7 @@
+# This script registers a personal authentication token (PAT) for the root user.
+# This PAT is then used to make GitLab API calls.
+user = User.find_by_username('root')
+pat = user.personal_access_tokens.create(scopes: [:write_repository, :read_repository, :api], name: 'Flux E2E testing')
+token = ARGV[0]
+pat.set_token(token)
+pat.save!

--- a/git/e2e/utils.go
+++ b/git/e2e/utils.go
@@ -1,0 +1,288 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"io/fs"
+	"io/ioutil"
+	"math/rand"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	extgogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	. "github.com/onsi/gomega"
+
+	"github.com/fluxcd/pkg/git"
+	"github.com/fluxcd/pkg/ssh"
+)
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz1234567890")
+
+func testUsingClone(g *WithT, client git.RepositoryClient, repoURL *url.URL, upstreamRepo upstreamRepoInfo) {
+	// clone repo
+	_, err := client.Clone(context.TODO(), repoURL.String(), git.CheckoutOptions{
+		Branch: "main",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// commit and push to origin
+	err = client.WriteFile("test", strings.NewReader(randStringRunes(10)))
+	g.Expect(err).ToNot(HaveOccurred())
+	cc, err := client.Commit(mockCommitInfo(), nil)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = client.Push(context.TODO())
+	g.Expect(err).ToNot(HaveOccurred())
+
+	headCommit, _, err := headCommitWithBranch(upstreamRepo.url, "main", upstreamRepo.username, upstreamRepo.password)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(headCommit).To(Equal(cc))
+
+	// switch to a new branch
+	err = client.SwitchBranch(context.TODO(), "new")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// commit to and push new branch
+	err = client.WriteFile("test", strings.NewReader(randStringRunes(10)))
+	g.Expect(err).ToNot(HaveOccurred())
+	cc, err = client.Commit(mockCommitInfo(), nil)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = client.Push(context.TODO())
+	g.Expect(err).ToNot(HaveOccurred())
+	headCommit, branch, err := headCommitWithBranch(upstreamRepo.url, "new", upstreamRepo.username, upstreamRepo.password)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(headCommit).To(Equal(cc))
+	g.Expect(branch).To(Equal("new"))
+
+	// switch to a branch behind the current branch, commit and push
+	err = client.SwitchBranch(context.TODO(), "main")
+	g.Expect(err).ToNot(HaveOccurred())
+	err = client.WriteFile("test", strings.NewReader(randStringRunes(10)))
+	g.Expect(err).ToNot(HaveOccurred())
+	_, err = client.Commit(mockCommitInfo(), nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	err = client.Push(context.TODO())
+	g.Expect(err).ToNot(HaveOccurred())
+	headCommit, _, err = headCommitWithBranch(upstreamRepo.url, "new", upstreamRepo.username, upstreamRepo.password)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(headCommit).To(Equal(cc))
+}
+
+func testUsingInit(g *WithT, client git.RepositoryClient, repoURL *url.URL, upstreamRepo upstreamRepoInfo) {
+	// Create a new repository
+	err := client.Init(context.TODO(), repoURL.String(), "main")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = client.WriteFile("test", strings.NewReader(randStringRunes(10)))
+	g.Expect(err).ToNot(HaveOccurred())
+	cc, err := client.Commit(mockCommitInfo(), nil)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = client.Push(context.TODO())
+	g.Expect(err).ToNot(HaveOccurred())
+
+	headCommit, _, err := headCommitWithBranch(upstreamRepo.url, "main", upstreamRepo.username, upstreamRepo.password)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(headCommit).To(Equal(cc))
+
+	err = client.SwitchBranch(context.TODO(), "new")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = client.WriteFile("test", strings.NewReader(randStringRunes(10)))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	cc, err = client.Commit(mockCommitInfo(), nil)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = client.Push(context.TODO())
+	g.Expect(err).ToNot(HaveOccurred())
+	headCommit, branch, err := headCommitWithBranch(upstreamRepo.url, "new", upstreamRepo.username, upstreamRepo.password)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(headCommit).To(Equal(cc))
+	g.Expect(branch).To(Equal("new"))
+
+	err = client.SwitchBranch(context.TODO(), "main")
+	g.Expect(err).ToNot(HaveOccurred())
+	err = client.WriteFile("test", strings.NewReader(randStringRunes(10)))
+	g.Expect(err).ToNot(HaveOccurred())
+	_, err = client.Commit(mockCommitInfo(), nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	err = client.Push(context.TODO())
+	g.Expect(err).ToNot(HaveOccurred())
+	headCommit, _, err = headCommitWithBranch(upstreamRepo.url, "new", upstreamRepo.username, upstreamRepo.password)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(headCommit).To(Equal(cc))
+}
+
+func headCommitWithBranch(url, branch, username, password string) (string, string, error) {
+	tmp, err := os.MkdirTemp("", randStringRunes(5))
+	if err != nil {
+		return "", "", err
+	}
+	var auth transport.AuthMethod
+	if username != "" && password != "" {
+		auth = &http.BasicAuth{
+			Username: username,
+			Password: password,
+		}
+	}
+	repo, err := extgogit.PlainClone(tmp, false, &extgogit.CloneOptions{
+		URL:           url,
+		ReferenceName: plumbing.NewBranchReferenceName(branch),
+		Auth:          auth,
+	})
+	if err != nil {
+		return "", "", err
+	}
+	head, err := repo.Head()
+	if err != nil {
+		return "", "", err
+	}
+	return head.Hash().String(), head.Name().Short(), nil
+}
+
+func mockCommitInfo() git.Commit {
+	return git.Commit{
+		Author: git.Signature{
+			Name:  "Test User",
+			Email: "test@example.com",
+		},
+		Message: "testing",
+	}
+}
+
+func createSSHIdentitySecret(repoURL url.URL) (map[string][]byte, error) {
+	knownhosts, err := ssh.ScanHostKey(repoURL.Host, 5*time.Second, []string{}, false)
+	if err != nil {
+		return nil, err
+	}
+	keygen := ssh.NewRSAGenerator(2048)
+	pair, err := keygen.Generate()
+	if err != nil {
+		return nil, err
+	}
+	data := map[string][]byte{
+		"known_hosts":  knownhosts,
+		"identity":     pair.PrivateKey,
+		"identity.pub": pair.PublicKey,
+	}
+	return data, nil
+}
+
+func randStringRunes(n int) string {
+	rand.Seed(time.Now().UnixNano())
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}
+
+type upstreamRepoInfo struct {
+	url      string
+	username string
+	password string
+}
+
+func initRepo(repoURL, branch, fixture, username, password string) error {
+	tmp, err := os.MkdirTemp("", "git-e2e-test")
+	if err != nil {
+		return err
+	}
+
+	repo, err := extgogit.PlainInit(tmp, false)
+	if err != nil {
+		return err
+	}
+
+	if _, err = repo.CreateRemote(&config.RemoteConfig{
+		Name: extgogit.DefaultRemoteName,
+		URLs: []string{repoURL},
+	}); err != nil {
+		return err
+	}
+
+	branchRef := plumbing.NewBranchReferenceName(branch)
+	if err = repo.CreateBranch(&config.Branch{
+		Name:   branch,
+		Remote: extgogit.DefaultRemoteName,
+		Merge:  branchRef,
+	}); err != nil {
+		return err
+	}
+	if err = repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, branchRef)); err != nil {
+		return err
+	}
+
+	_ = filepath.WalkDir(fixture, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		input, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		err = ioutil.WriteFile(filepath.Join(tmp, d.Name()), input, 0644)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		return err
+	}
+
+	info := mockCommitInfo()
+	_, err = wt.Commit(info.Message, &extgogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  info.Author.Name,
+			Email: info.Author.Email,
+			When:  time.Now(),
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	err = repo.Push(&extgogit.PushOptions{
+		RemoteName: git.DefaultRemote,
+		Auth: &http.BasicAuth{
+			Username: username,
+			Password: password,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Refactors the e2e tests to be more cleaner and readable. 
Adds e2e tests for GitLab using https://hub.docker.com/r/gitlab/gitlab-ce/.
Introduces a new CI workflow for e2e tests exclusively. The e2e tests now use build tags to make sure they don't run alongside unit tests.