### PR TITLE
Add `org.opencontainers.image.created` to OCI meta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ release-%:
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 .PHONY: controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0)
+	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2)
 
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 ENVTEST_KUBERNETES_VERSION?=latest

--- a/oci/client/list.go
+++ b/oci/client/list.go
@@ -60,6 +60,7 @@ func (c *Client) List(ctx context.Context, url string) ([]Metadata, error) {
 		if m, err := MetadataFromAnnotations(manifest.Annotations); err == nil {
 			meta.Revision = m.Revision
 			meta.Source = m.Source
+			meta.Created = m.Created
 		}
 
 		digest, err := crane.Digest(meta.URL, c.optionsWithContext(ctx)...)

--- a/oci/client/list_test.go
+++ b/oci/client/list_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -37,9 +38,11 @@ func Test_List(t *testing.T) {
 	tags := []string{"v0.0.1", "v0.0.2", "v0.0.3"}
 	source := "github.com/fluxcd/fluxv2"
 	rev := "rev"
+	ct := time.Now()
 	m := Metadata{
 		Source:   source,
 		Revision: rev,
+		Created:  ct.Format(time.RFC3339),
 	}
 
 	for _, tag := range tags {

--- a/oci/client/meta.go
+++ b/oci/client/meta.go
@@ -23,16 +23,19 @@ import (
 )
 
 // Metadata holds the upstream information about on artifact's source.
+// https://github.com/opencontainers/image-spec/blob/main/annotations.md
 type Metadata struct {
+	Created  string `json:"created"`
 	Source   string `json:"source_url"`
 	Revision string `json:"source_revision"`
 	Digest   string `json:"digest"`
 	URL      string `json:"url"`
 }
 
-// ToAnnotations returns the OpenContainers source and revision map.
+// ToAnnotations returns the OpenContainers annotations map.
 func (m *Metadata) ToAnnotations() map[string]string {
 	annotations := map[string]string{
+		oci.CreatedAnnotation:  m.Created,
 		oci.SourceAnnotation:   m.Source,
 		oci.RevisionAnnotation: m.Revision,
 	}
@@ -42,6 +45,11 @@ func (m *Metadata) ToAnnotations() map[string]string {
 
 // MetadataFromAnnotations parses the OpenContainers annotations and returns a Metadata object.
 func MetadataFromAnnotations(annotations map[string]string) (*Metadata, error) {
+	created, ok := annotations[oci.CreatedAnnotation]
+	if !ok {
+		return nil, fmt.Errorf("'%s' annotation not found", oci.CreatedAnnotation)
+	}
+
 	source, ok := annotations[oci.SourceAnnotation]
 	if !ok {
 		return nil, fmt.Errorf("'%s' annotation not found", oci.SourceAnnotation)
@@ -53,6 +61,7 @@ func MetadataFromAnnotations(annotations map[string]string) (*Metadata, error) {
 	}
 
 	m := Metadata{
+		Created:  created,
 		Source:   source,
 		Revision: revision,
 	}

--- a/oci/client/push.go
+++ b/oci/client/push.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -54,6 +55,8 @@ func (c *Client) Push(ctx context.Context, url, sourceDir string, meta Metadata)
 		return "", fmt.Errorf("appeding content to artifact failed: %w", err)
 	}
 
+	ct := time.Now()
+	meta.Created = ct.Format(time.RFC3339)
 	img = mutate.Annotations(img, meta.ToAnnotations()).(gcrv1.Image)
 
 	if err := crane.Push(img, url, c.optionsWithContext(ctx)...); err != nil {

--- a/oci/client/push_pull_test.go
+++ b/oci/client/push_pull_test.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	. "github.com/onsi/gomega"
+
+	"github.com/fluxcd/pkg/oci"
 )
 
 func Test_Push_Pull(t *testing.T) {
@@ -40,7 +42,6 @@ func Test_Push_Pull(t *testing.T) {
 		Source:   "github.com/fluxcd/flux2",
 		Revision: "rev",
 	}
-	annotations := metadata.ToAnnotations()
 
 	testDir := "testdata/artifact"
 	_, err := c.Push(ctx, url, testDir, metadata)
@@ -55,7 +56,10 @@ func Test_Push_Pull(t *testing.T) {
 
 	manifest, err := image.Manifest()
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(manifest.Annotations).To(BeEquivalentTo(annotations))
+
+	g.Expect(manifest.Annotations[oci.CreatedAnnotation]).ToNot(BeEmpty())
+	g.Expect(manifest.Annotations[oci.SourceAnnotation]).ToNot(BeEmpty())
+	g.Expect(manifest.Annotations[oci.RevisionAnnotation]).ToNot(BeEmpty())
 
 	tmpDir := t.TempDir()
 	_, err = c.Pull(ctx, url, tmpDir)

--- a/oci/constants.go
+++ b/oci/constants.go
@@ -45,6 +45,10 @@ const (
 	// the upstream source revision of an OCI artifact.
 	RevisionAnnotation = "org.opencontainers.image.revision"
 
+	// CreatedAnnotation is the OpenContainers annotation for specifying
+	// the date and time on which the OCI artifact was built (RFC 3339).
+	CreatedAnnotation = "org.opencontainers.image.created"
+
 	// OCIRepositoryPrefix is the prefix used for OCIRepository URLs.
 	OCIRepositoryPrefix = "oci://"
 


### PR DESCRIPTION
Set the created date annotations when pushing OCI artifacts.