### PR TITLE
oci: Fix broken action

### DIFF
--- a/oci/client/internal/fs/fs_test.go
+++ b/oci/client/internal/fs/fs_test.go
@@ -17,6 +17,39 @@ var (
 	mu sync.Mutex
 )
 
+func TestMain(m *testing.M) {
+	symlinks := []struct {
+		oldPath string
+		newPath string
+	}{
+		{
+			oldPath: "C:/Users/fluxcd/go/src/github.com/golang/dep/internal/fs/testdata/test.file",
+			newPath: "testdata/symlinks/windows-file-symlink",
+		},
+		{
+			"/non/existing/file",
+			"testdata/symlinks/invalid-symlink",
+		},
+	}
+	for _, sl := range symlinks {
+		err := os.Symlink(sl.oldPath, sl.newPath)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	c := m.Run()
+
+	for _, sl := range symlinks {
+		err := os.Remove(sl.newPath)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	os.Exit(c)
+}
+
 func TestRenameWithFallback(t *testing.T) {
 	dir := t.TempDir()
 

--- a/oci/client/internal/fs/testdata/symlinks/invalid-symlink
+++ b/oci/client/internal/fs/testdata/symlinks/invalid-symlink
@@ -1,1 +1,0 @@
-/non/existing/file

--- a/oci/client/internal/fs/testdata/symlinks/windows-file-symlink
+++ b/oci/client/internal/fs/testdata/symlinks/windows-file-symlink
@@ -1,1 +1,0 @@
-C:/Users/ibrahim/go/src/github.com/golang/dep/internal/fs/testdata/test.file


### PR DESCRIPTION
The broken symlinks used for tests broke the use of fluxcd/pkg as a GitHub action, as pointed out in:
https://github.com/fluxcd/flux2/pull/2964\#discussion_r939991220

This creates and removes such symlinks on demand to ensure the tests are still catered for, without impacting the GitHub actions.