### PR TITLE
Return messages from kstatus result

### DIFF
--- a/oci/client/internal/fs/fs_test.go
+++ b/oci/client/internal/fs/fs_test.go
@@ -41,7 +41,6 @@ func TestMain(m *testing.M) {
 	}
 
 	os.MkdirAll("testdata/symlinks", 0o755)
-	defer os.RemoveAll("testdata/symlinks")
 
 	for _, sl := range symlinks {
 		err := os.Symlink(sl.oldPath, sl.newPath)
@@ -50,7 +49,13 @@ func TestMain(m *testing.M) {
 		}
 	}
 
-	os.Exit(m.Run())
+	code := m.Run()
+
+	err := os.RemoveAll("testdata/symlinks")
+	if err != nil {
+		panic(fmt.Errorf("unable to remove symlink directory: %v", err))
+	}
+	os.Exit(code)
 }
 
 func TestRenameWithFallback(t *testing.T) {

--- a/ssa/manager_apply.go
+++ b/ssa/manager_apply.go
@@ -204,7 +204,7 @@ func (m *ResourceManager) ApplyAllStaged(ctx context.Context, objects []*unstruc
 		}
 		changeSet.Append(cs.Entries)
 
-		if err := m.Wait(stageOne, WaitOptions{2 * time.Second, opts.WaitTimeout}); err != nil {
+		if _, err := m.Wait(stageOne, WaitOptions{2 * time.Second, opts.WaitTimeout}); err != nil {
 			return nil, err
 		}
 	}

--- a/ssa/manager_wait_test.go
+++ b/ssa/manager_wait_test.go
@@ -19,6 +19,7 @@ package ssa
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -50,7 +51,7 @@ func TestWaitForSet(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := manager.WaitForSet([]object.ObjMetadata{cs.ObjMetadata}, DefaultWaitOptions()); err != nil {
+		if _, err := manager.WaitForSet([]object.ObjMetadata{cs.ObjMetadata}, DefaultWaitOptions()); err != nil {
 			t.Errorf("wait failed for CRD: %v", err)
 		}
 
@@ -59,8 +60,13 @@ func TestWaitForSet(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := manager.WaitForSet(changeSet.ToObjMetadataSet(), WaitOptions{time.Second, 3 * time.Second}); err == nil {
+		msg, err := manager.WaitForSet(changeSet.ToObjMetadataSet(), WaitOptions{time.Second, 3 * time.Second})
+		if err == nil {
 			t.Error("wanted wait error due to observedGeneration < generation")
+		}
+		expectedStr := "generation is 1, but latest observed generation is -1"
+		if !strings.Contains(msg, expectedStr) {
+			t.Errorf("expected msg to contain %s but got %s", expectedStr, msg)
 		}
 
 		clusterCR := &unstructured.Unstructured{}
@@ -88,7 +94,7 @@ func TestWaitForSet(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := manager.WaitForSet(changeSet.ToObjMetadataSet(), DefaultWaitOptions()); err != nil {
+		if _, err := manager.WaitForSet(changeSet.ToObjMetadataSet(), DefaultWaitOptions()); err != nil {
 			t.Errorf("wait error: %v", err)
 		}
 	})


### PR DESCRIPTION
This pull request returns the message from kstatus result.
This message could helpful in figuring out why a resource might not be considered ready by kstatus.

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>