### PR TITLE
runtime: Add reconcile result finalizer

### DIFF
--- a/runtime/conditions/testdata/crds/fake.toolkit.fluxcd.io_fakes.yaml
+++ b/runtime/conditions/testdata/crds/fake.toolkit.fluxcd.io_fakes.yaml
@@ -31,10 +31,14 @@ spec:
             type: object
           spec:
             properties:
+              interval:
+                type: string
               suspend:
                 type: boolean
               value:
                 type: string
+            required:
+            - interval
             type: object
           status:
             properties:
@@ -81,6 +85,9 @@ spec:
                   - type
                   type: object
                 type: array
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change of the annotation value can be detected.
+                type: string
               observedGeneration:
                 format: int64
                 type: integer

--- a/runtime/conditions/testdata/fake.go
+++ b/runtime/conditions/testdata/fake.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testdata
 
 import (
+	"github.com/fluxcd/pkg/apis/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -44,14 +45,16 @@ var (
 )
 
 type FakeSpec struct {
-	Suspend bool   `json:"suspend,omitempty"`
-	Value   string `json:"value,omitempty"`
+	Suspend  bool            `json:"suspend,omitempty"`
+	Value    string          `json:"value,omitempty"`
+	Interval metav1.Duration `json:"interval"`
 }
 
 type FakeStatus struct {
-	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
-	Conditions         []metav1.Condition `json:"conditions,omitempty"`
-	ObservedValue      string `json:"observedValue,omitempty"`
+	ObservedGeneration          int64              `json:"observedGeneration,omitempty"`
+	Conditions                  []metav1.Condition `json:"conditions,omitempty"`
+	ObservedValue               string             `json:"observedValue,omitempty"`
+	meta.ReconcileRequestStatus `json:",inline"`
 }
 
 func (f Fake) GetConditions() []metav1.Condition {
@@ -168,7 +171,6 @@ type FakeList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Fake `json:"items"`
 }
-
 
 func init() {
 	FakeSchemeBuilder.Register(&Fake{}, &FakeList{})

--- a/runtime/object/doc.go
+++ b/runtime/object/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package object provides helpers for interacting with GitOps Toolkit objects
+// using unstructured types. The helpers assist in reading and writing certain
+// attributes of the objects without converting them to their original types.
+package object

--- a/runtime/object/object.go
+++ b/runtime/object/object.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"errors"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	ErrObservedGenerationNotFound     = errors.New("observed generation not found")
+	ErrLastHandledReconcileAtNotFound = errors.New("last handled reconcile at not found")
+	ErrRequeueIntervalNotFound        = errors.New("requeue interval not found")
+)
+
+// toUnstructured converts a runtime object into Unstructured.
+// Based on https://github.com/fluxcd/pkg/blob/b4a14854c75753ea9431693b39c4be672f246552/runtime/patch/utils.go#L55.
+func toUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
+	// If the incoming object is already unstructured, perform a deep copy first
+	// otherwise DefaultUnstructuredConverter ends up returning the inner map without
+	// making a copy.
+	if _, ok := obj.(runtime.Unstructured); ok {
+		obj = obj.DeepCopyObject()
+	}
+	rawMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: rawMap}, nil
+}
+
+// GetStatusLastHandledReconcileAt returns the status.lastHandledReconcileAt
+// value of a given runtime object, if present.
+func GetStatusLastHandledReconcileAt(obj runtime.Object) (string, error) {
+	u, err := toUnstructured(obj)
+	if err != nil {
+		return "", err
+	}
+	ra, found, err := unstructured.NestedString(u.Object, "status", "lastHandledReconcileAt")
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return "", ErrLastHandledReconcileAtNotFound
+	}
+	return ra, nil
+}
+
+// SetStatusLastHandledReconcileAt sets the status.lastHandledReconcileAt value
+// of a given runtime object.
+func SetStatusLastHandledReconcileAt(obj runtime.Object, val string) error {
+	content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return err
+	}
+	u := unstructured.Unstructured{}
+	u.SetUnstructuredContent(content)
+	if err := unstructured.SetNestedField(u.Object, val, "status", "lastHandledReconcileAt"); err != nil {
+		return err
+	}
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, obj)
+}
+
+// GetStatusObservedGeneration returns the status.observedGeneration of a given
+// runtime object.
+func GetStatusObservedGeneration(obj runtime.Object) (int64, error) {
+	u, err := toUnstructured(obj)
+	if err != nil {
+		return 0, err
+	}
+	og, found, err := unstructured.NestedInt64(u.Object, "status", "observedGeneration")
+	if err != nil {
+		return 0, err
+	}
+	if !found {
+		return 0, ErrObservedGenerationNotFound
+	}
+	return og, nil
+}
+
+// GetRequeueInterval returns the spec.interval of a given runtime object, if
+// present.
+func GetRequeueInterval(obj runtime.Object) (time.Duration, error) {
+	period := time.Second
+	u, err := toUnstructured(obj)
+	if err != nil {
+		return period, err
+	}
+	interval, found, err := unstructured.NestedString(u.Object, "spec", "interval")
+	if err != nil {
+		return period, err
+	}
+	if !found {
+		return period, ErrRequeueIntervalNotFound
+	}
+	return time.ParseDuration(interval)
+}

--- a/runtime/object/object_test.go
+++ b/runtime/object/object_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fluxcd/pkg/runtime/conditions/testdata"
+)
+
+func TestGetStatusLastHandledReconcileAt(t *testing.T) {
+	g := NewWithT(t)
+
+	// Get unset status lastHandledReconcileAt.
+	obj := &testdata.Fake{}
+	_, err := GetStatusLastHandledReconcileAt(obj)
+	g.Expect(err).To(Equal(ErrLastHandledReconcileAtNotFound))
+
+	// Get set status lastHandledReconcileAt.
+	obj.Status.LastHandledReconcileAt = "foo"
+	ra, err := GetStatusLastHandledReconcileAt(obj)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ra).To(Equal("foo"))
+}
+
+func TestSetStatusLastHandledReconcileAt(t *testing.T) {
+	g := NewWithT(t)
+
+	obj := &testdata.Fake{}
+	err := SetStatusLastHandledReconcileAt(obj, "now")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(obj.Status.LastHandledReconcileAt).To(Equal("now"))
+}
+
+func TestGetStatusObservedGeneration(t *testing.T) {
+	g := NewWithT(t)
+
+	// Get unset status observedGeneration.
+	obj := &testdata.Fake{}
+	_, err := GetStatusObservedGeneration(obj)
+	g.Expect(err).To(Equal(ErrObservedGenerationNotFound))
+
+	// Get set status observedGeneration.
+	obj.Status.ObservedGeneration = 7
+	og, err := GetStatusObservedGeneration(obj)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(og).To(Equal(int64(7)))
+}
+
+func TestGetRequeueInterval(t *testing.T) {
+	g := NewWithT(t)
+
+	// Get empty requeue interval value.
+	obj := &testdata.Fake{}
+	pd, err := GetRequeueInterval(obj)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(pd).To(Equal(time.Duration(0)))
+
+	// Get set requeue interval value.
+	obj.Spec.Interval = metav1.Duration{Duration: 3 * time.Second}
+	pd, err = GetRequeueInterval(obj)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(pd).To(Equal(3 * time.Second))
+
+	// Get non-existent requeue interval value.
+	obj2 := &corev1.Secret{}
+	_, err = GetRequeueInterval(obj2)
+	g.Expect(err).To(Equal(ErrRequeueIntervalNotFound))
+}

--- a/runtime/reconcile/doc.go
+++ b/runtime/reconcile/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package reconcile provides helpers for the reconciliation. They help finalize
+// the results of a reconciliation and also create patch helper options based
+// on the finalized results that can be used with the patch helper during the
+// reconciliation.
+package reconcile

--- a/runtime/reconcile/result.go
+++ b/runtime/reconcile/result.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcile
+
+import (
+	"errors"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	"github.com/fluxcd/pkg/runtime/conditions"
+	"github.com/fluxcd/pkg/runtime/object"
+	"github.com/fluxcd/pkg/runtime/patch"
+)
+
+// Conditions contains all the conditions information needed to summarize the
+// target condition.
+type Conditions struct {
+	// Target is the target condition (e.g. Ready).
+	Target string
+	// Owned conditions are the conditions owned by the reconciler for this
+	// target condition.
+	Owned []string
+	// Summarize conditions are the conditions that the target condition depends
+	// on.
+	Summarize []string
+	// NegativePolarity conditions are the conditions in Summarize with negative
+	// polarity.
+	NegativePolarity []string
+}
+
+// IsResultSuccess defines if a given ctrl.Result and error result in a
+// successful reconciliation result.
+type IsResultSuccess func(ctrl.Result, error) bool
+
+// ResultFinalizer finalizes the results of reconciliation to provide a kstatus
+// compliant object status and appropriate runtime results based on the status
+// observations.
+type ResultFinalizer struct {
+	isSuccess       IsResultSuccess
+	readySuccessMsg string
+	conditions      []Conditions
+}
+
+// NewResultFinalizer returns a new ResultFinalizer.
+func NewResultFinalizer(isSuccess IsResultSuccess, readySuccessMsg string, conditions ...Conditions) *ResultFinalizer {
+	return &ResultFinalizer{
+		isSuccess:       isSuccess,
+		readySuccessMsg: readySuccessMsg,
+		conditions:      conditions,
+	}
+}
+
+// Finalize computes the result of reconciliation. It takes ctrl.Result, error from
+// the reconciliation, and a conditions.Setter with conditions, and analyzes
+// them to return a reconciliation error. It mutates the object status
+// conditions based on the input to ensure the conditions are compliant with
+// kstatus. If conditions are passed for summarization, it summarizes the status
+// conditions such that the result is kstatus compliant. It also checks for any
+// reconcile annotation in the object metadata and adds it to the status as
+// LastHandledReconcileAt.
+func (rs ResultFinalizer) Finalize(obj conditions.Setter, res ctrl.Result, recErr error) error {
+	// Store the success result of the reconciliation taking the error value in
+	// consideration.
+	successResult := rs.isSuccess(res, recErr)
+
+	// If reconcile error isn't nil, a retry needs to be attempted. Since
+	// it's not stalled situation, ensure Stalled condition is removed.
+	if recErr != nil {
+		conditions.Delete(obj, meta.StalledCondition)
+	}
+
+	if !successResult {
+		// ctrl.Result is expected to be zero when stalled. If the result isn't
+		// zero and not success even without considering the error value, a
+		// requeue is requested in the ctrl.Result, it is not a stalled
+		// situation. Ensure Stalled condition is removed.
+		if !res.IsZero() && !rs.isSuccess(res, nil) {
+			conditions.Delete(obj, meta.StalledCondition)
+		}
+		// If it's still Stalled and Ready is unset or True, ensure Ready value
+		// matches with Stalled.
+		overwriteReady := conditions.IsUnknown(obj, meta.ReadyCondition) || conditions.IsTrue(obj, meta.ReadyCondition)
+		if conditions.IsTrue(obj, meta.StalledCondition) && overwriteReady {
+			sc := conditions.Get(obj, meta.StalledCondition)
+			conditions.MarkFalse(obj, meta.ReadyCondition, sc.Reason, sc.Message)
+		}
+	}
+
+	// If it's a successful result or Stalled=True, ensure Reconciling is
+	// removed.
+	if successResult || conditions.IsTrue(obj, meta.StalledCondition) {
+		conditions.Delete(obj, meta.ReconcilingCondition)
+	}
+
+	// Since conditions.IsReady() depends on the values of Stalled and
+	// Reconciling conditions, after resolving their values above, update Ready
+	// condition based on the reconcile error.
+	// If there's a reconcile error and Ready=True or Ready is unknown, mark
+	// Ready=False with the reconcile error. If Ready is already False with a
+	// reason, preserve the value.
+	if recErr != nil {
+		if conditions.IsUnknown(obj, meta.ReadyCondition) || conditions.IsReady(obj) {
+			conditions.MarkFalse(obj, meta.ReadyCondition, meta.FailedReason, recErr.Error())
+		}
+	}
+
+	// If custom conditions are provided, summarize them with the Reconciling
+	// and Stalled condition changes above.
+	for _, c := range rs.conditions {
+		conditions.SetSummary(obj,
+			c.Target,
+			conditions.WithConditions(c.Summarize...),
+			conditions.WithNegativePolarityConditions(c.NegativePolarity...),
+		)
+	}
+
+	// If the result is success, but Ready is explicitly False (not unknown,
+	// with not Ready condition message), and it's not Stalled, set error value
+	// to be the Ready failure message.
+	if successResult && !conditions.IsUnknown(obj, meta.ReadyCondition) && conditions.IsFalse(obj, meta.ReadyCondition) && !conditions.IsStalled(obj) {
+		recErr = errors.New(conditions.GetMessage(obj, meta.ReadyCondition))
+	}
+
+	// After the above, if Ready condition is not set, it's still a successful
+	// reconciliation and it's not reconciling or stalled, mark Ready=True.
+	// This tries to preserve any Ready value set previously.
+	if conditions.IsUnknown(obj, meta.ReadyCondition) && rs.isSuccess(res, recErr) && !conditions.IsReconciling(obj) && !conditions.IsStalled(obj) {
+		conditions.MarkTrue(obj, meta.ReadyCondition, meta.SucceededReason, rs.readySuccessMsg)
+	}
+
+	// TODO: When the Result requests a requeue and no Ready condition value
+	// is set, the status condition won't have any Ready condition value.
+	// It's difficult to assign a Ready condition value without an error or
+	// an existing Reconciling condition.
+	// Maybe add a default Ready=False value for safeguard in case this
+	// situation becomes common.
+
+	// If a reconcile annotation value is found, set it in the object status as
+	// status.lastHandledReconcileAt.
+	if v, ok := meta.ReconcileAnnotationValue(obj.GetAnnotations()); ok {
+		object.SetStatusLastHandledReconcileAt(obj, v)
+	}
+
+	return recErr
+}
+
+// AddPatchOptions adds patch options to a given patch option based on the
+// passed conditions.Setter, ownedConditions and fieldOwner, and returns the
+// patch options.
+// This must be run on a kstatus compliant status. Non-kstatus compliant status
+// may result in unexpected patch option result.
+func AddPatchOptions(obj conditions.Setter, opts []patch.Option, ownedConditions []string, fieldOwner string) []patch.Option {
+	opts = append(opts,
+		patch.WithOwnedConditions{Conditions: ownedConditions},
+		patch.WithFieldOwner(fieldOwner),
+	)
+	// Set status observed generation option if the object is stalled, or
+	// if the object is ready, i.e. success result.
+	if conditions.IsStalled(obj) || conditions.IsReady(obj) {
+		opts = append(opts, patch.WithStatusObservedGeneration{})
+	}
+	return opts
+}

--- a/runtime/reconcile/result_test.go
+++ b/runtime/reconcile/result_test.go
@@ -77,7 +77,7 @@ func TestResultFinalizer(t *testing.T) {
 	// Success is no error, no immediate or arbitrary requeue in the result.
 	// Only requeue at the success interval.
 	isSuccess := func(res ctrl.Result, err error) bool {
-		if err != nil || res.RequeueAfter != successInterval || res.Requeue == true {
+		if err != nil || res.RequeueAfter != successInterval || res.Requeue {
 			return false
 		}
 		return true
@@ -274,7 +274,7 @@ func TestResultFinalizer(t *testing.T) {
 			},
 		},
 		{
-			name: "success results but not ready, Ready=False",
+			name: "success results but not ready, Ready=False, return error",
 			beforeFunc: func(obj conditions.Setter) {
 				conditions.MarkFalse(obj, meta.ReadyCondition, meta.FailedReason, "fail-msg")
 			},
@@ -446,6 +446,113 @@ func TestResultFinalizer(t *testing.T) {
 	}
 }
 
+// Same as the above test but for SuccessNoRequest type reconciler.
+func TestResultFinalizer_successNoRequeue(t *testing.T) {
+	readySuccessMsg := "Success"
+	resultSuccess := ctrl.Result{}
+	resultStalled := ctrl.Result{}
+
+	isSuccess := func(r ctrl.Result, err error) bool {
+		if err != nil || r.RequeueAfter != 0 || r.Requeue {
+			return false
+		}
+		return true
+	}
+
+	tests := []struct {
+		name                       string
+		beforeFunc                 func(obj conditions.Setter)
+		result                     ctrl.Result
+		recErr                     error
+		statusObservedGen          int64
+		wantErr                    bool
+		wantLastHandledReconcileAt string
+		assertConditions           []metav1.Condition
+	}{
+		{
+			name: "result with error and stalled",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkStalled(obj, "SomeReasonX", "some msg X")
+			},
+			result:  resultStalled,
+			recErr:  errors.New("foo failed"),
+			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.FalseCondition(meta.ReadyCondition, meta.FailedReason, "foo failed"),
+			},
+		},
+		{
+			name: "stalled, Ready=True, overwrite ready",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkStalled(obj, "SomeReasonX", "some msg X")
+			},
+			result:  resultStalled,
+			wantErr: false,
+			assertConditions: []metav1.Condition{
+				*conditions.FalseCondition(meta.ReadyCondition, "SomeReasonX", "some msg X"),
+				*conditions.TrueCondition(meta.StalledCondition, "SomeReasonX", "some msg X"),
+			},
+		},
+		{
+			name: "success result",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkTrue(obj, meta.ReadyCondition, meta.SucceededReason, "some msg X")
+			},
+			result:            resultSuccess,
+			statusObservedGen: 1,
+			wantErr:           false,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(meta.ReadyCondition, meta.SucceededReason, "some msg X"),
+			},
+		},
+		{
+			name: "success result but not ready, Ready=False, no error",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkFalse(obj, meta.ReadyCondition, meta.FailedReason, "fail-msg")
+			},
+			result:  resultSuccess,
+			recErr:  nil,
+			wantErr: false,
+			assertConditions: []metav1.Condition{
+				*conditions.FalseCondition(meta.ReadyCondition, meta.FailedReason, "fail-msg"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			condns := &conditionscheck.Conditions{
+				NegativePolarity: []string{
+					meta.StalledCondition,
+					meta.ReconcilingCondition,
+				},
+			}
+			checker := conditionscheck.NewChecker(fakeclient.NewClientBuilder().Build(), condns)
+			checker.DisableFetch = true
+
+			obj := &testdata.Fake{}
+			obj.ObjectMeta.Generation = 1
+			obj.Status.ObservedGeneration = tt.statusObservedGen
+
+			if tt.beforeFunc != nil {
+				tt.beforeFunc(obj)
+			}
+
+			rf := NewResultFinalizer(isSuccess, readySuccessMsg)
+			gotErr := rf.Finalize(obj, tt.result, tt.recErr)
+			g.Expect(gotErr != nil).To(Equal(tt.wantErr))
+			g.Expect(obj.Status.Conditions).To(conditions.MatchConditions(tt.assertConditions))
+			if tt.wantLastHandledReconcileAt != "" {
+				g.Expect(obj.Status.LastHandledReconcileAt).To(Equal(tt.wantLastHandledReconcileAt))
+			}
+			// kstatus comformance check.
+			checker.CheckErr(context.TODO(), obj)
+		})
+	}
+}
+
 func TestAddPatchOptions(t *testing.T) {
 	tests := []struct {
 		name                         string
@@ -527,6 +634,46 @@ func TestAddPatchOptions(t *testing.T) {
 			g.Expect(helperOpts.FieldOwner).To(Equal(tt.wantFieldOwner))
 			g.Expect(helperOpts.OwnedConditions).To(Equal(tt.wantOwnedConditions))
 			g.Expect(helperOpts.IncludeStatusObservedGeneration).To(Equal(tt.wantIncludeStatusObservedGen))
+		})
+	}
+}
+
+func TestDetermineSuccessType(t *testing.T) {
+	testRequeuePeriod := time.Minute
+
+	tests := []struct {
+		name      string
+		isSuccess IsResultSuccess
+		want      SuccessType
+	}{
+		{
+			name: "requeuing reconciler",
+			isSuccess: func(r ctrl.Result, err error) bool {
+				if err != nil || r.RequeueAfter != testRequeuePeriod || r.Requeue {
+					return false
+				}
+				return true
+			},
+			want: SuccessWithRequeue,
+		},
+		{
+			name: "no requeue reconciler",
+			isSuccess: func(r ctrl.Result, err error) bool {
+				if err != nil || r.RequeueAfter != 0 || r.Requeue {
+					return false
+				}
+				return true
+			},
+			want: SuccessNoRequeue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			result := determineSuccessType(tt.isSuccess)
+			g.Expect(result).To(Equal(tt.want))
 		})
 	}
 }

--- a/runtime/reconcile/result_test.go
+++ b/runtime/reconcile/result_test.go
@@ -1,0 +1,532 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcile
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	"github.com/fluxcd/pkg/runtime/conditions"
+	conditionscheck "github.com/fluxcd/pkg/runtime/conditions/check"
+	"github.com/fluxcd/pkg/runtime/conditions/testdata"
+	"github.com/fluxcd/pkg/runtime/patch"
+)
+
+const (
+	fetchFailedCondition       = "FetchFailed"
+	artifactOutdatedCondition  = "ArtifactOutdated"
+	artifactInStorageCondition = "ArtifactInStorage"
+)
+
+func TestResultFinalizer(t *testing.T) {
+	readySuccessMsg := "Success"
+	successInterval := time.Minute
+	arbitraryInterval := 5 * time.Second
+	resultSuccess := ctrl.Result{RequeueAfter: successInterval}
+	resultStalled := ctrl.Result{}
+	resultFailed := ctrl.Result{}
+	resultRequeue := ctrl.Result{Requeue: true}
+
+	summarizeReadyConditions := Conditions{
+		Target: meta.ReadyCondition,
+		Owned: []string{
+			fetchFailedCondition,
+			artifactOutdatedCondition,
+			artifactInStorageCondition,
+			meta.ReadyCondition,
+			meta.ReconcilingCondition,
+			meta.StalledCondition,
+		},
+		Summarize: []string{
+			fetchFailedCondition,
+			artifactOutdatedCondition,
+			artifactInStorageCondition,
+			meta.StalledCondition,
+			meta.ReconcilingCondition,
+		},
+		NegativePolarity: []string{
+			fetchFailedCondition,
+			artifactOutdatedCondition,
+			meta.StalledCondition,
+			meta.ReconcilingCondition,
+		},
+	}
+
+	// Success is no error, no immediate or arbitrary requeue in the result.
+	// Only requeue at the success interval.
+	isSuccess := func(res ctrl.Result, err error) bool {
+		if err != nil || res.RequeueAfter != successInterval || res.Requeue == true {
+			return false
+		}
+		return true
+	}
+
+	tests := []struct {
+		name                       string
+		summarizeConditions        []Conditions
+		beforeFunc                 func(obj conditions.Setter)
+		result                     ctrl.Result
+		recErr                     error
+		statusObservedGen          int64
+		wantErr                    bool
+		wantLastHandledReconcileAt string
+		assertConditions           []metav1.Condition
+	}{
+		{
+			name: "result with error and stalled",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkStalled(obj, "SomeReasonX", "some msg X")
+			},
+			result:  resultStalled,
+			recErr:  errors.New("foo failed"),
+			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.FalseCondition(meta.ReadyCondition, meta.FailedReason, "foo failed"),
+			},
+		},
+		{
+			name: "result with error, reconciling and stalled",
+			beforeFunc: func(obj conditions.Setter) {
+				// Since MarkStalled() removes existing Reconciling condition,
+				// use MarkTrue instead for setting Reconciling and Stalled.
+				conditions.MarkTrue(obj, meta.ReconcilingCondition, "SomeReasonX", "some msg X")
+				conditions.MarkTrue(obj, meta.StalledCondition, "SomeReasonY", "some msg Y")
+			},
+			result:  resultStalled,
+			recErr:  errors.New("foo failed"),
+			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(meta.ReconcilingCondition, "SomeReasonX", "some msg X"),
+				*conditions.FalseCondition(meta.ReadyCondition, meta.FailedReason, "foo failed"),
+			},
+		},
+		{
+			name:       "result with error, no ready value, set ready value",
+			beforeFunc: func(obj conditions.Setter) {},
+			result:     resultFailed,
+			recErr:     errors.New("foo failed"),
+			wantErr:    true,
+			assertConditions: []metav1.Condition{
+				*conditions.FalseCondition(meta.ReadyCondition, meta.FailedReason, "foo failed"),
+			},
+		},
+		{
+			name: "result with error, false ready value, no overwrite",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkFalse(obj, meta.ReadyCondition, "SomeReasonX", "fail-msg")
+			},
+			result:  resultFailed,
+			recErr:  errors.New("foo failed"),
+			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.FalseCondition(meta.ReadyCondition, "SomeReasonX", "fail-msg"),
+			},
+		},
+		{
+			name: "result with error, true ready value, overwrite",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkTrue(obj, meta.ReadyCondition, meta.SucceededReason, readySuccessMsg)
+			},
+			result:  resultFailed,
+			recErr:  errors.New("foo failed"),
+			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.FalseCondition(meta.ReadyCondition, meta.FailedReason, "foo failed"),
+			},
+		},
+		{
+			name: "result with error, not ready and reconciling, no change",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkReconciling(obj, "SomeReasonX", "some msg X")
+				conditions.MarkFalse(obj, meta.ReadyCondition, "SomeReasonY", "some msg Y")
+			},
+			result:  resultFailed,
+			recErr:  errors.New("foo failed"),
+			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.FalseCondition(meta.ReadyCondition, "SomeReasonY", "some msg Y"),
+				*conditions.TrueCondition(meta.ReconcilingCondition, "SomeReasonX", "some msg X"),
+			},
+		},
+		{
+			name: "stalled and reconciling, Ready=False, remove reconciling, retain ready",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkTrue(obj, meta.ReconcilingCondition, "SomeReasonX", "some msg X")
+				conditions.MarkTrue(obj, meta.StalledCondition, "SomeReasonY", "some msg Y")
+				conditions.MarkFalse(obj, meta.ReadyCondition, "SomeReasonZ", "some msg Z")
+			},
+			result: resultStalled,
+			recErr: nil,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(meta.StalledCondition, "SomeReasonY", "some msg Y"),
+				*conditions.FalseCondition(meta.ReadyCondition, "SomeReasonZ", "some msg Z"),
+			},
+		},
+		{
+			name: "stalled and reconciling, empty ready, remove reconciling, set ready",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkTrue(obj, meta.ReconcilingCondition, "SomeReasonX", "some msg X")
+				conditions.MarkTrue(obj, meta.StalledCondition, "SomeReasonY", "some msg Y")
+			},
+			result: resultStalled,
+			recErr: nil,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(meta.StalledCondition, "SomeReasonY", "some msg Y"),
+				*conditions.FalseCondition(meta.ReadyCondition, "SomeReasonY", "some msg Y"),
+			},
+		},
+		{
+			name: "stalled and reconciling, Ready=True, remove reconciling, overwrite ready",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkTrue(obj, meta.ReconcilingCondition, "SomeReasonX", "some msg X")
+				conditions.MarkTrue(obj, meta.StalledCondition, "SomeReasonY", "some msg Y")
+				conditions.MarkTrue(obj, meta.ReadyCondition, "SomeReasonZ", "some msg Z")
+			},
+			result: resultStalled,
+			recErr: nil,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(meta.StalledCondition, "SomeReasonY", "some msg Y"),
+				*conditions.FalseCondition(meta.ReadyCondition, "SomeReasonY", "some msg Y"),
+			},
+		},
+		{
+			name: "not success result due to requeue, remove stalled",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkStalled(obj, "SomeReasonX", "some msg X")
+				conditions.MarkFalse(obj, meta.ReadyCondition, "SomeReasonY", "some msg Y")
+			},
+			result: resultRequeue,
+			recErr: nil,
+			assertConditions: []metav1.Condition{
+				*conditions.FalseCondition(meta.ReadyCondition, "SomeReasonY", "some msg Y"),
+			},
+		},
+		{
+			name: "not success result due to arbitrary requeueAfter, remove stalled",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkStalled(obj, "SomeReasonX", "some msg X")
+				conditions.MarkFalse(obj, meta.ReadyCondition, "SomeReasonY", "some msg Y")
+			},
+			result: ctrl.Result{RequeueAfter: arbitraryInterval},
+			recErr: nil,
+			assertConditions: []metav1.Condition{
+				*conditions.FalseCondition(meta.ReadyCondition, "SomeReasonY", "some msg Y"),
+			},
+		},
+		{
+			name: "not success result and explicit no requeue, keep stalled, add Ready=False",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkStalled(obj, "SomeReasonX", "some msg X")
+			},
+			result: ctrl.Result{Requeue: false},
+			recErr: nil,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(meta.StalledCondition, "SomeReasonX", "some msg X"),
+				*conditions.FalseCondition(meta.ReadyCondition, "SomeReasonX", "some msg X"),
+			},
+		},
+		{
+			name: "stalled and different Ready=False values",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkStalled(obj, "SomeReasonX", "some msg X")
+				conditions.MarkFalse(obj, meta.ReadyCondition, "SomeReasonY", "some msg Y")
+			},
+			result: resultStalled,
+			recErr: nil,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(meta.StalledCondition, "SomeReasonX", "some msg X"),
+				*conditions.FalseCondition(meta.ReadyCondition, "SomeReasonY", "some msg Y"),
+			},
+		},
+		{
+			name: "success result with reconciling and ready, remove reconciling, Ready=True",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkReconciling(obj, "SomeReasonX", "some msg X")
+			},
+			result:            resultSuccess,
+			recErr:            nil,
+			statusObservedGen: 1,
+			wantErr:           false,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(meta.ReadyCondition, meta.SucceededReason, readySuccessMsg),
+			},
+		},
+		{
+			name: "success results but not ready, Ready=False",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkFalse(obj, meta.ReadyCondition, meta.FailedReason, "fail-msg")
+			},
+			result:  resultSuccess,
+			recErr:  nil,
+			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.FalseCondition(meta.ReadyCondition, meta.FailedReason, "fail-msg"),
+			},
+		},
+		{
+			name:              "success no other conditions, Ready=True",
+			beforeFunc:        func(obj conditions.Setter) {},
+			result:            resultSuccess,
+			recErr:            nil,
+			statusObservedGen: 1,
+			wantErr:           false,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(meta.ReadyCondition, meta.SucceededReason, readySuccessMsg),
+			},
+		},
+		{
+			name: "reconcile annotation",
+			beforeFunc: func(obj conditions.Setter) {
+				obj.SetAnnotations(map[string]string{meta.ReconcileRequestAnnotation: "foo"})
+				conditions.MarkTrue(obj, meta.ReadyCondition, meta.SucceededReason, readySuccessMsg)
+			},
+			result:                     resultSuccess,
+			recErr:                     nil,
+			statusObservedGen:          1,
+			wantErr:                    false,
+			wantLastHandledReconcileAt: "foo",
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(meta.ReadyCondition, meta.SucceededReason, readySuccessMsg),
+			},
+		},
+		// NOTE: The following is a situation in which no Ready condition is
+		// present in the status after result computation.
+		// {
+		// 	name:             "no ready condition",
+		// 	result:           resultRequeue,
+		// 	recErr:           nil,
+		// 	assertConditions: []metav1.Condition{},
+		// },
+		{
+			name:                "success with summarize conditions",
+			summarizeConditions: []Conditions{summarizeReadyConditions},
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkTrue(obj, artifactInStorageCondition, meta.SucceededReason, "stored artifact")
+			},
+			result:            resultSuccess,
+			recErr:            nil,
+			statusObservedGen: 1,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(meta.ReadyCondition, meta.SucceededReason, "stored artifact"),
+				*conditions.TrueCondition(artifactInStorageCondition, meta.SucceededReason, "stored artifact"),
+			},
+		},
+		{
+			name:                "failure with negative polarity conditions summary",
+			summarizeConditions: []Conditions{summarizeReadyConditions},
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkTrue(obj, fetchFailedCondition, meta.FailedReason, "auth failed")
+			},
+			result:  resultFailed,
+			recErr:  errors.New("secret not found"),
+			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.FalseCondition(meta.ReadyCondition, meta.FailedReason, "auth failed"),
+				*conditions.TrueCondition(fetchFailedCondition, meta.FailedReason, "auth failed"),
+			},
+		},
+		{
+			name:                "reconciling and positive polarity conditions summary",
+			summarizeConditions: []Conditions{summarizeReadyConditions},
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkReconciling(obj, "NewArtifact", "new artifact")
+				conditions.MarkTrue(obj, artifactInStorageCondition, meta.SucceededReason, "stored artifact")
+			},
+			result:            resultSuccess,
+			recErr:            nil,
+			statusObservedGen: 1,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(meta.ReadyCondition, meta.SucceededReason, "stored artifact"),
+				*conditions.TrueCondition(artifactInStorageCondition, meta.SucceededReason, "stored artifact"),
+			},
+		},
+		{
+			name:                "stalled with artifact in storage summary",
+			summarizeConditions: []Conditions{summarizeReadyConditions},
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkStalled(obj, "InvalidURL", "invalid URL")
+				conditions.MarkTrue(obj, artifactInStorageCondition, meta.SucceededReason, "stored artifact")
+			},
+			result:            resultStalled,
+			recErr:            nil,
+			statusObservedGen: 1,
+			assertConditions: []metav1.Condition{
+				*conditions.FalseCondition(meta.ReadyCondition, "InvalidURL", "invalid URL"),
+				*conditions.TrueCondition(meta.StalledCondition, "InvalidURL", "invalid URL"),
+				*conditions.TrueCondition(artifactInStorageCondition, meta.SucceededReason, "stored artifact"),
+			},
+		},
+		{
+			name:                "reconciling, stalled with conditions summary",
+			summarizeConditions: []Conditions{summarizeReadyConditions},
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkTrue(obj, meta.ReconcilingCondition, "SomeReasonX", "some msg X")
+				conditions.MarkTrue(obj, meta.StalledCondition, "SomeReasonY", "some msg Y")
+			},
+			result:            resultStalled,
+			recErr:            nil,
+			statusObservedGen: 1,
+			assertConditions: []metav1.Condition{
+				*conditions.FalseCondition(meta.ReadyCondition, "SomeReasonY", "some msg Y"),
+				*conditions.TrueCondition(meta.StalledCondition, "SomeReasonY", "some msg Y"),
+			},
+		},
+		{
+			name:                "not ready after summarize and result is success, should set error",
+			summarizeConditions: []Conditions{summarizeReadyConditions},
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkTrue(obj, artifactOutdatedCondition, meta.FailedReason, "outdated")
+			},
+			result:  resultSuccess,
+			recErr:  nil,
+			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.FalseCondition(meta.ReadyCondition, meta.FailedReason, "outdated"),
+				*conditions.TrueCondition(artifactOutdatedCondition, meta.FailedReason, "outdated"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			condns := &conditionscheck.Conditions{
+				NegativePolarity: []string{
+					meta.StalledCondition,
+					meta.ReconcilingCondition,
+				},
+			}
+			checker := conditionscheck.NewChecker(fakeclient.NewClientBuilder().Build(), condns)
+			checker.DisableFetch = true
+
+			obj := &testdata.Fake{}
+			// Set non-zero generation in order to set valid observed
+			// generation in status root and conditions.
+			obj.ObjectMeta.Generation = 1
+			// Set status.observedGeneration for valid kstatus result.
+			obj.Status.ObservedGeneration = tt.statusObservedGen
+
+			if tt.beforeFunc != nil {
+				tt.beforeFunc(obj)
+			}
+
+			rf := NewResultFinalizer(isSuccess, readySuccessMsg, tt.summarizeConditions...)
+			gotErr := rf.Finalize(obj, tt.result, tt.recErr)
+			g.Expect(gotErr != nil).To(Equal(tt.wantErr))
+			g.Expect(obj.Status.Conditions).To(conditions.MatchConditions(tt.assertConditions))
+			if tt.wantLastHandledReconcileAt != "" {
+				g.Expect(obj.Status.LastHandledReconcileAt).To(Equal(tt.wantLastHandledReconcileAt))
+			}
+			// kstatus comformance check.
+			checker.CheckErr(context.TODO(), obj)
+		})
+	}
+}
+
+func TestAddPatchOptions(t *testing.T) {
+	tests := []struct {
+		name                         string
+		beforeFunc                   func(obj conditions.Setter)
+		fieldOwner                   string
+		ownedConditions              []string
+		wantFieldOwner               string
+		wantOwnedConditions          []string
+		wantIncludeStatusObservedGen bool
+	}{
+		{
+			name:                         "no conditions, no field owner",
+			wantFieldOwner:               "",
+			wantOwnedConditions:          nil,
+			wantIncludeStatusObservedGen: false,
+		},
+		{
+			name:                "owned conditions and field owner",
+			fieldOwner:          "foo-ctrl",
+			ownedConditions:     []string{"A", "B"},
+			wantFieldOwner:      "foo-ctrl",
+			wantOwnedConditions: []string{"A", "B"},
+		},
+		{
+			name: "reconciling=True, Ready=False status conditions",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkReconciling(obj, "SomeReasonX", "some msg X")
+				conditions.MarkFalse(obj, meta.ReadyCondition, "SomeReasonY", "some msg Y")
+			},
+			wantIncludeStatusObservedGen: false,
+		},
+		{
+			name: "stalled=True, Ready=False status conditions",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkStalled(obj, "SomeReasonX", "some msg X")
+				conditions.MarkFalse(obj, meta.ReadyCondition, "SomeReasonY", "some msg Y")
+			},
+			wantIncludeStatusObservedGen: true,
+		},
+		{
+			name: "Ready=True, no other status condition",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkTrue(obj, meta.ReadyCondition, meta.SucceededReason, "success")
+			},
+			wantIncludeStatusObservedGen: true,
+		},
+		{
+			name: "owned conditions, field owner and Stalled=True, Ready=False",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkStalled(obj, "SomeReasonX", "some msg X")
+				conditions.MarkFalse(obj, meta.ReadyCondition, "SomeReasonY", "some msg Y")
+			},
+			fieldOwner:                   "foo-ctrl",
+			ownedConditions:              []string{meta.StalledCondition, meta.ReadyCondition},
+			wantFieldOwner:               "foo-ctrl",
+			wantOwnedConditions:          []string{meta.StalledCondition, meta.ReadyCondition},
+			wantIncludeStatusObservedGen: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			obj := &testdata.Fake{}
+			opts := []patch.Option{}
+
+			if tt.beforeFunc != nil {
+				tt.beforeFunc(obj)
+			}
+
+			opts = AddPatchOptions(obj, opts, tt.ownedConditions, tt.fieldOwner)
+
+			// Apply the options on a patch helper.
+			helperOpts := &patch.HelperOptions{}
+			for _, opt := range opts {
+				opt.ApplyToHelper(helperOpts)
+			}
+			g.Expect(helperOpts.FieldOwner).To(Equal(tt.wantFieldOwner))
+			g.Expect(helperOpts.OwnedConditions).To(Equal(tt.wantOwnedConditions))
+			g.Expect(helperOpts.IncludeStatusObservedGeneration).To(Equal(tt.wantIncludeStatusObservedGen))
+		})
+	}
+}


### PR DESCRIPTION
Add runtime packages `reconcile` and `object`. `reconcile` package provides helpers for finalizing the result of reconciliation and create patch helper options based on the finalized results. `object` package provides helpers for reading and writing attributes of GitOps Toolkit objects (runtime.Object) without converting them to their actual types. This is used by `reconcile` while analyzing the results of reconciliation.

### Background

In source-controller, `internal/reconcile` package provides helpers for summarizing the result of reconciliation and patching the mutated object at the end. It helps ensure that the status of the object is kstatus compliant and also takes into consideration other status attributes like `status.lastHandledReconcileAt`. It also handles logging and event recording the results after analyzing them.
All these did make the reconcilers to have consistent behavior and hide the complexity of result computation. But in order to use all these, the controllers need to adopt reconcile result abstraction, specific typed errors and custom status conditions such that the condition summary worked properly. These requirements may be too much to ask for simple controller with not too many sub-reconciliation steps.

HelmRepositoryOCI reconciler in source-controller is an example of a simple controller with simple status conditions (Ready, Reconciling and Stalled). In order to use the result summary and patching helpers described above, it'd have to add a lot of extra things which aren't necessary. In a way, it made the simple reconciler more complicated. To avoid using the existing helpers, HelmRepositoryOCI reconciler implemented all the final result computation and condition setting in-line, taking into consideration all the small details that the helpers handled. This showed an approach to make the tooling simpler such that a simple controller need not adopt all the complex requirements of the `internal/reconcile` package.

Package `runtime/reconcile` is a rewrite of the result computation and status condition setting based on the in-line result computation implementation in HelmRepositoryOCI reconciler with some more capabilities. It is also capable of working with complex conditions of different polarities and handle more different situations. Unlike the previous implementation, it does not handles patching of the object. The patching has to be done in the reconciler itself but it provides helpers to create patch helper options based on the computed results.
An example of the usage of this in HelmRepositoryOCI reconcile can be found in an [experimental implementation](https://github.com/fluxcd/source-controller/compare/main...darkowlzz:source-controller:reconcile-summary-v2?expand=1#diff-a082596eda38268c45eb4612b5a7b97e40b98dac5fb5d36773e80db2c24f6ac4) . The results of swapping the in-line code with these new helpers remain the same. The results of the initial tests done months ago for status conditions are still the same, refer https://gist.github.com/darkowlzz/c5c86afb148ad06dc7c4cc8c6afcdaef .

This new helper should be good to use in other simpler controllers.

`ResultFinalizer` computes the final result of reconciliation. It is configured with what a successful reconciliation means to a particular reconciler, a success message to be used for successful reconciliation in the case of missing Ready condition on the object, and an optional list of conditions, which are used when a reconciler has complex conditions with varying polarities. The `ResultFinalizer.Finalize()` method takes the result of reconciliation (ctrl.Result, reconciliation error and the object being reconciled) and analyzes the input to determine a runtime result of reconciliation that's compliant with kstatus. It tries to automatically correct the results based on some known rules, respecting any logically correct values already set in the conditions. An example of the correction is if the status condition contains Reconciling=True, but ctrl.Result and error indicate a successful reconciliation, it'll remove the Reconciling condition from the status. Similarly, it won't allow Reconciling and Stalled condition to be on the status at the same time. Based on the input parameters, it'll determine the result and correctly mutate the status and the reconciliation result.

Ref: https://github.com/fluxcd/flux2/issues/1601
This has been used in image-reflector-controller refactor, refer https://github.com/fluxcd/image-reflector-controller/pull/311.