### PR TITLE
git: fallback to 'git' for username only for ssh

### DIFF
--- a/git/options_test.go
+++ b/git/options_test.go
@@ -200,9 +200,12 @@ func TestAuthOptionsFromData(t *testing.T) {
 			},
 		},
 		{
-			name: "Sets default user",
-			URL:  "http://example.com",
-			data: nil,
+			name: "Sets default user for SSH",
+			URL:  "ssh://example.com",
+			data: map[string][]byte{
+				"identity":    []byte(privateKeyFixture),
+				"known_hosts": []byte(knownHostsFixture),
+			},
 			wantFunc: func(g *WithT, opts *AuthOptions) {
 				g.Expect(opts.Username).To(Equal(DefaultPublicKeyAuthUser))
 			},


### PR DESCRIPTION
Fallback to 'git' for username only when cloning Git repos through SSH,
since using 'git' as the username when cloning Git repos through HTTP(S)
might lead to 401s.

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>