### PR TITLE
ci: use inbuilt cache feature of setup-go

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,17 +18,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Restore Go cache
-        uses: actions/cache@v1
-        with:
-          path: /home/runner/work/_temp/_github_home/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
+          # https://github.com/actions/setup-go/blob/main/docs/adrs/0000-caching-dependencies.md#example-of-real-use-cases
+          cache: true
+          cache-dependency-path: |
+            **/go.sum
+            **/go.mod
       - name: Run tests
         run: make all
       - name: Check if working tree is dirty


### PR DESCRIPTION
Use the inbuilt cache feature in `actions/setup-go` which internally uses `actions/cache` itself.

This lets us cache module dependencies and previous builds as well which speeds up the entire workflow considerably from [~24 mins](https://github.com/fluxcd/pkg/runs/8111769892?check_suite_focus=true) to [~8mins](https://github.com/fluxcd/pkg/runs/8114612137?check_suite_focus=true) on Ubuntu.
It also fixes an issue where the cache was not being used on macOS runners: https://github.com/fluxcd/pkg/runs/8111770057?check_suite_focus=true#step:3:8

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>