### PR TITLE
bump deps in git sub packages

### DIFF
--- a/git/gogit/go.mod
+++ b/git/gogit/go.mod
@@ -13,8 +13,8 @@ replace (
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/fluxcd/gitkit v0.6.0
-	github.com/fluxcd/pkg/git v0.6.0
-	github.com/fluxcd/pkg/gittestserver v0.6.0
+	github.com/fluxcd/pkg/git v0.6.1
+	github.com/fluxcd/pkg/gittestserver v0.7.0
 	github.com/fluxcd/pkg/gitutil v0.2.0
 	github.com/fluxcd/pkg/ssh v0.6.0
 	github.com/fluxcd/pkg/version v0.2.0

--- a/git/internal/e2e/go.mod
+++ b/git/internal/e2e/go.mod
@@ -27,10 +27,10 @@ replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.16.0
 replace github.com/libgit2/git2go/v33 => github.com/pjbgf/git2go/v33 v33.0.9-nothread-check
 
 require (
-	github.com/fluxcd/pkg/git v0.6.0
+	github.com/fluxcd/pkg/git v0.6.1
 	github.com/fluxcd/pkg/git/gogit v0.0.0-00010101000000-000000000000
 	github.com/fluxcd/pkg/git/libgit2 v0.1.0
-	github.com/fluxcd/pkg/gittestserver v0.6.0
+	github.com/fluxcd/pkg/gittestserver v0.7.0
 	github.com/fluxcd/pkg/ssh v0.6.0
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/onsi/gomega v1.20.0

--- a/git/libgit2/go.mod
+++ b/git/libgit2/go.mod
@@ -33,8 +33,8 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/ProtonMail/go-crypto v0.0.0-20220824120805-4b6e5c587895
 	github.com/fluxcd/gitkit v0.6.0
-	github.com/fluxcd/pkg/git v0.6.0
-	github.com/fluxcd/pkg/gittestserver v0.6.0
+	github.com/fluxcd/pkg/git v0.6.1
+	github.com/fluxcd/pkg/gittestserver v0.7.0
 	github.com/fluxcd/pkg/gitutil v0.2.0
 	github.com/fluxcd/pkg/http/transport v0.0.1
 	github.com/fluxcd/pkg/ssh v0.6.0


### PR DESCRIPTION
1. Bump pkg/git to v0.6.1 in pkg/git/gogit, pkg/git/libgit2 &
pkg/git/internal/e2e
2. Bump pkg/gittestserver to v0.7.0 in pkg/git/gogit, pkg/git/libgit2
& pkg/git/internal/e2e

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>