### PR TITLE
build: Restore Go cache across actions

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -16,17 +16,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Restore Go cache
-        uses: actions/cache@v1
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
+      - id: go-env
+        run: |
+          echo "::set-output name=go-cache::$(go env GOCACHE)"
+          echo "::set-output name=go-mod-cache::$(go env GOMODCACHE)"
+      - name: Restore Go mod cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ steps.go-env.outputs.go-cache }}
+            ${{ steps.go-env.outputs.go-mod-cache }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go
       - uses: ./actions/envtest
       - uses: ./actions/kubectl
       - uses: ./actions/kustomize

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,11 +22,19 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
-          # https://github.com/actions/setup-go/blob/main/docs/adrs/0000-caching-dependencies.md#example-of-real-use-cases
-          cache: true
-          cache-dependency-path: |
-            **/go.sum
-            **/go.mod
+      - id: go-env
+        run: |
+          echo "::set-output name=go-cache::$(go env GOCACHE)"
+          echo "::set-output name=go-mod-cache::$(go env GOMODCACHE)"
+      - name: Restore Go mod cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ steps.go-env.outputs.go-cache }}
+            ${{ steps.go-env.outputs.go-mod-cache }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go
       - name: Run tests
         run: make all
       - name: Check if working tree is dirty

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,16 +15,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Restore Go cache
-        uses: actions/cache@v1
-        with:
-          path: /home/runner/work/_temp/_github_home/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
+      - id: go-env
+        run: |
+          echo "::set-output name=go-cache::$(go env GOCACHE)"
+          echo "::set-output name=go-mod-cache::$(go env GOMODCACHE)"
+      - name: Restore Go mod cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ steps.go-env.outputs.go-cache }}
+            ${{ steps.go-env.outputs.go-mod-cache }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go
       - name: Run tests
         run: cd git/internal/e2e && ./run.sh


### PR DESCRIPTION
Previous to this change the Go cache would only be restored to subsequent
executions of the same module with unchanged dependencies.

This fallbacks to a generic Go cache when dependencies change for example.
It should be a safe and faster alternative for builds that do not generate
binaries.