### PR TITLE
git/libgit2: use uuid for transport options usage 

### DIFF
--- a/git/libgit2/go.mod
+++ b/git/libgit2/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/onsi/gomega v1.20.0
 	golang.org/x/crypto v0.0.0-20220824171710-5757bc0c5503
 	golang.org/x/net v0.0.0-20220822230855-b0a4917ee28c
+	k8s.io/apimachinery v0.25.0
 	sigs.k8s.io/controller-runtime v0.12.3
 )
 
@@ -110,7 +111,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.25.0 // indirect
 	k8s.io/apiextensions-apiserver v0.24.2 // indirect
-	k8s.io/apimachinery v0.25.0 // indirect
 	k8s.io/client-go v0.25.0 // indirect
 	k8s.io/component-base v0.25.0 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect

--- a/git/libgit2/utils.go
+++ b/git/libgit2/utils.go
@@ -18,10 +18,10 @@ package libgit2
 
 import (
 	"fmt"
-	"math/rand"
 	"strings"
 
 	git2go "github.com/libgit2/git2go/v33"
+	"k8s.io/apimachinery/pkg/util/uuid"
 
 	"github.com/fluxcd/pkg/git"
 )
@@ -31,12 +31,7 @@ const (
 )
 
 func getTransportOptsURL(transport git.TransportType) string {
-	letterRunes := []rune("abcdefghijklmnopqrstuvwxyz1234567890")
-	b := make([]rune, 12)
-	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
-	}
-	return string(transport) + "://" + string(b)
+	return string(transport) + "://" + string(uuid.NewUUID())
 }
 
 func pushError(err error, url string) error {


### PR DESCRIPTION
Use UUID for transport options URL, decreasing the chance of a clash and
hence use of the wrong transport options for a Git operation.


Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>