### PR TITLE
Add login capabilities to the OCI client

### DIFF
--- a/oci/client/login.go
+++ b/oci/client/login.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/fluxcd/pkg/oci/auth/login"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+// LoginWithCredentials configures the client with static credentials, accepts a single token
+// or a user:password format.
+func (c *Client) LoginWithCredentials(credentials string) error {
+	var authConfig authn.AuthConfig
+
+	if credentials == "" {
+		return errors.New("credentials cannot be empty")
+	}
+
+	parts := strings.SplitN(credentials, ":", 2)
+
+	if len(parts) == 1 {
+		authConfig = authn.AuthConfig{RegistryToken: parts[0]}
+	} else {
+		authConfig = authn.AuthConfig{Username: parts[0], Password: parts[1]}
+	}
+
+	c.options = append(c.options, crane.WithAuth(authn.FromConfig(authConfig)))
+	return nil
+}
+
+// AutoLogin configures the client to autologin with current supported providers based on the URL
+func (c *Client) AutoLogin(ctx context.Context, mgr *login.Manager, url string) error {
+	ref, err := name.ParseReference(url)
+	if err != nil {
+		return fmt.Errorf("could not create reference from url '%s': %w", url, err)
+	}
+
+	authenticator, err := mgr.Login(ctx, url, ref, login.ProviderOptions{
+		AwsAutoLogin:   true,
+		GcpAutoLogin:   true,
+		AzureAutoLogin: true,
+	})
+
+	if err != nil {
+		return fmt.Errorf("could not auto-login to registry with url %s: %w", url, err)
+	}
+
+	c.options = append(c.options, crane.WithAuth(authenticator))
+	return nil
+}

--- a/oci/client/login_test.go
+++ b/oci/client/login_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/fluxcd/pkg/oci/auth/aws"
+	"github.com/fluxcd/pkg/oci/auth/login"
+	"github.com/google/go-containerregistry/pkg/crane"
+	. "github.com/onsi/gomega"
+)
+
+type mockTransport struct {
+	request  *http.Request
+	response *http.Response
+	err      error
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.request = req.Clone(context.TODO())
+	return m.response, m.err
+}
+
+func Test_Login(t *testing.T) {
+	tests := []struct {
+		name         string
+		creds        string
+		expectedAuth string
+	}{
+		{
+			name:         "credentials with username and password",
+			creds:        "username:password",
+			expectedAuth: "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+		},
+		{
+			name:         "credentials like a pat-token",
+			creds:        "pat-token",
+			expectedAuth: "Bearer pat-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			c := NewLocalClient()
+			ctx := context.Background()
+			err := c.LoginWithCredentials(tt.creds)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			transportFunc := mockTransport{
+				response: &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(strings.NewReader(`{}`)),
+				},
+			}
+
+			c.options = append(c.options, crane.WithTransport(&transportFunc))
+
+			err = crane.Delete(fmt.Sprintf("%s/%s:%s", dockerReg, "test", "test"), c.optionsWithContext(ctx)...)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(transportFunc.request).ToNot(BeNil())
+			g.Expect(transportFunc.request.Header.Get("Authorization")).To(Equal(tt.expectedAuth))
+		})
+	}
+}
+
+func Test_AutoLogin(t *testing.T) {
+	g := NewWithT(t)
+	c := NewLocalClient()
+	ctx := context.Background()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"authorizationData": [{"authorizationToken": "c29tZS1rZXk6c29tZS1zZWNyZXQ="}]}`))
+	}))
+	t.Cleanup(func() {
+		srv.Close()
+	})
+
+	mgr := login.NewManager()
+	ecrClient := aws.NewClient()
+	ecrClient.Config = ecrClient.WithEndpoint(srv.URL).
+		WithCredentials(credentials.NewStaticCredentials("x", "y", "z"))
+	mgr.WithECRClient(ecrClient)
+
+	url := "012345678901.dkr.ecr.us-east-1.amazonaws.com/foo:v1"
+	err := c.AutoLogin(ctx, mgr, url)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	transportFunc := mockTransport{
+		response: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(strings.NewReader(`{}`)),
+		},
+	}
+
+	c.options = append(c.options, crane.WithTransport(&transportFunc))
+
+	err = crane.Delete(fmt.Sprintf("%s/%s:%s", dockerReg, "test", "test"), c.optionsWithContext(ctx)...)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(transportFunc.request).ToNot(BeNil())
+	g.Expect(transportFunc.request.Header.Get("Authorization")).To(Equal("Basic c29tZS1rZXk6c29tZS1zZWNyZXQ="))
+}

--- a/oci/client/login_test.go
+++ b/oci/client/login_test.go
@@ -21,13 +21,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/fluxcd/pkg/oci/auth/aws"
-	"github.com/fluxcd/pkg/oci/auth/login"
 	"github.com/google/go-containerregistry/pkg/crane"
 	. "github.com/onsi/gomega"
 )
@@ -84,42 +80,4 @@ func Test_Login(t *testing.T) {
 			g.Expect(transportFunc.request.Header.Get("Authorization")).To(Equal(tt.expectedAuth))
 		})
 	}
-}
-
-func Test_AutoLogin(t *testing.T) {
-	g := NewWithT(t)
-	c := NewLocalClient()
-	ctx := context.Background()
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"authorizationData": [{"authorizationToken": "c29tZS1rZXk6c29tZS1zZWNyZXQ="}]}`))
-	}))
-	t.Cleanup(func() {
-		srv.Close()
-	})
-
-	mgr := login.NewManager()
-	ecrClient := aws.NewClient()
-	ecrClient.Config = ecrClient.WithEndpoint(srv.URL).
-		WithCredentials(credentials.NewStaticCredentials("x", "y", "z"))
-	mgr.WithECRClient(ecrClient)
-
-	url := "012345678901.dkr.ecr.us-east-1.amazonaws.com/foo:v1"
-	err := c.AutoLogin(ctx, mgr, url)
-	g.Expect(err).ToNot(HaveOccurred())
-
-	transportFunc := mockTransport{
-		response: &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       ioutil.NopCloser(strings.NewReader(`{}`)),
-		},
-	}
-
-	c.options = append(c.options, crane.WithTransport(&transportFunc))
-
-	err = crane.Delete(fmt.Sprintf("%s/%s:%s", dockerReg, "test", "test"), c.optionsWithContext(ctx)...)
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(transportFunc.request).ToNot(BeNil())
-	g.Expect(transportFunc.request.Header.Get("Authorization")).To(Equal("Basic c29tZS1rZXk6c29tZS1zZWNyZXQ="))
 }


### PR DESCRIPTION
Hi 👋 

This can be re-used by flux to auto-login during artifacts operations as showcased in https://github.com/fluxcd/flux2/pull/3079

Let me know if you have any input!

Signed-off-by: Adrien Fillon <adrien.fillon@manomano.com>