### PR TITLE
Add `Repository()` method to `libgit2 Client

### DIFF
--- a/git/libgit2/repository_client.go
+++ b/git/libgit2/repository_client.go
@@ -508,6 +508,10 @@ func (l *Client) Head() (string, error) {
 	return head.Target().String(), nil
 }
 
+func (l *Client) Repository() *git2go.Repository {
+	return l.repository
+}
+
 func (l *Client) Path() string {
 	return l.path
 }


### PR DESCRIPTION
This pull request adds the `Repository` method to get the `git2go.Repository` underneath the Client.
This can be useful for doing other things not supported by the library,

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>