### PR TITLE
ci: fix e2e conditonal logic

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -58,7 +58,7 @@ jobs:
 
           elif [[ ${{ matrix.provider }} = "github" ]]; then
             if [[ ${{ github.event_name }} != "pull_request" ]] || \
-              [[ ${{ github.event.pull_request.head.repo.full_name }} = ${{ github.repository }} ]]; then
+              [[ "${{ github.event.pull_request.head.repo.full_name }}" = ${{ github.repository }} ]]; then
               export GO_TESTS="-run TestGitHubE2E"
               export GITHUB_TOKEN="${{ secrets.GITPROVIDER_BOT_TOKEN }}"
             else


### PR DESCRIPTION
Fixes the conditional logic to run GitHub E2E tests in CI barring PRs from forks

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>