### PR TITLE
Add regex to support ECR as OCI Helm registry

### DIFF
--- a/oci/auth/aws/auth.go
+++ b/oci/auth/aws/auth.go
@@ -33,13 +33,13 @@ import (
 	"github.com/fluxcd/pkg/oci"
 )
 
-var registryPartRe = regexp.MustCompile(`([0-9+]*).dkr.ecr.([^/.]*)\.(amazonaws\.com[.cn]*)/([^:]+):?(.*)`)
+var registryPartRe = regexp.MustCompile(`([0-9+]*).dkr.ecr.([^/.]*)\.(amazonaws\.com[.cn]*)`)
 
-// ParseImage returns the AWS account ID and region and `true` if
-// the image repository is hosted in AWS's Elastic Container Registry,
+// ParseRegistry returns the AWS account ID and region and `true` if
+// the image registry/repository is hosted in AWS's Elastic Container Registry,
 // otherwise empty strings and `false`.
-func ParseImage(image string) (accountId, awsEcrRegion string, ok bool) {
-	registryParts := registryPartRe.FindAllStringSubmatch(image, -1)
+func ParseRegistry(registry string) (accountId, awsEcrRegion string, ok bool) {
+	registryParts := registryPartRe.FindAllStringSubmatch(registry, -1)
 	if len(registryParts) < 1 || len(registryParts[0]) < 3 {
 		return "", "", false
 	}
@@ -108,11 +108,11 @@ func (c *Client) getLoginAuth(accountId, awsEcrRegion string) (authn.AuthConfig,
 
 // Login attempts to get the authentication material for ECR. It extracts
 // the account and region information from the image URI. The caller can ensure
-// that the passed image is a valid ECR image using ParseImage().
+// that the passed image is a valid ECR image using ParseRegistry().
 func (c *Client) Login(ctx context.Context, autoLogin bool, image string) (authn.Authenticator, error) {
 	if autoLogin {
 		ctrl.LoggerFrom(ctx).Info("logging in to AWS ECR for " + image)
-		accountId, awsEcrRegion, ok := ParseImage(image)
+		accountId, awsEcrRegion, ok := ParseRegistry(image)
 		if !ok {
 			return nil, errors.New("failed to parse AWS ECR image, invalid ECR image")
 		}

--- a/oci/auth/aws/auth_test.go
+++ b/oci/auth/aws/auth_test.go
@@ -31,40 +31,42 @@ const (
 	testValidECRImage = "012345678901.dkr.ecr.us-east-1.amazonaws.com/foo:v1"
 )
 
-func TestParseImage(t *testing.T) {
+func TestParseRegistry(t *testing.T) {
 	tests := []struct {
-		image         string
+		registry      string
 		wantAccountID string
 		wantRegion    string
 		wantOK        bool
 	}{
 		{
-			image:         "012345678901.dkr.ecr.us-east-1.amazonaws.com/foo:v1",
+			registry:      "012345678901.dkr.ecr.us-east-1.amazonaws.com/foo:v1",
 			wantAccountID: "012345678901",
 			wantRegion:    "us-east-1",
 			wantOK:        true,
 		},
 		{
-			image:         "012345678901.dkr.ecr.us-east-1.amazonaws.com/foo",
+			registry:      "012345678901.dkr.ecr.us-east-1.amazonaws.com/foo",
 			wantAccountID: "012345678901",
 			wantRegion:    "us-east-1",
 			wantOK:        true,
 		},
 		{
-			image:  "012345678901.dkr.ecr.us-east-1.amazonaws.com",
-			wantOK: false,
+			registry:      "012345678901.dkr.ecr.us-east-1.amazonaws.com",
+			wantAccountID: "012345678901",
+			wantRegion:    "us-east-1",
+			wantOK:        true,
 		},
 		{
-			image:  "gcr.io/foo/bar:baz",
-			wantOK: false,
+			registry: "gcr.io/foo/bar:baz",
+			wantOK:   false,
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.image, func(t *testing.T) {
+		t.Run(tt.registry, func(t *testing.T) {
 			g := NewWithT(t)
 
-			accId, region, ok := ParseImage(tt.image)
+			accId, region, ok := ParseRegistry(tt.registry)
 			g.Expect(ok).To(Equal(tt.wantOK), "unexpected OK")
 			g.Expect(accId).To(Equal(tt.wantAccountID), "unexpected account IDs")
 			g.Expect(region).To(Equal(tt.wantRegion), "unexpected regions")

--- a/oci/auth/login/login.go
+++ b/oci/auth/login/login.go
@@ -28,10 +28,10 @@ import (
 	"github.com/fluxcd/pkg/oci/auth/gcp"
 )
 
-// ImageRegistryProvider analyzes the provided image and returns the identified
+// ImageRegistryProvider analyzes the provided registry and returns the identified
 // container image registry provider.
-func ImageRegistryProvider(image string, ref name.Reference) oci.Provider {
-	_, _, ok := aws.ParseImage(image)
+func ImageRegistryProvider(ref name.Reference) oci.Provider {
+	_, _, ok := aws.ParseRegistry(ref.Context().RegistryStr())
 	if ok {
 		return oci.ProviderAWS
 	}
@@ -95,7 +95,7 @@ func (m *Manager) WithACRClient(c *azure.Client) *Manager {
 // Login performs authentication against a registry and returns the
 // authentication material. For generic registry provider, it is no-op.
 func (m *Manager) Login(ctx context.Context, image string, ref name.Reference, opts ProviderOptions) (authn.Authenticator, error) {
-	switch ImageRegistryProvider(image, ref) {
+	switch ImageRegistryProvider(ref) {
 	case oci.ProviderAWS:
 		return m.ecr.Login(ctx, opts.AwsAutoLogin, image)
 	case oci.ProviderGCP:

--- a/oci/auth/login/login_test.go
+++ b/oci/auth/login/login_test.go
@@ -50,7 +50,7 @@ func TestImageRegistryProvider(t *testing.T) {
 
 			ref, err := name.ParseReference(tt.image)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(ImageRegistryProvider(tt.image, ref)).To(Equal(tt.want))
+			g.Expect(ImageRegistryProvider(ref)).To(Equal(tt.want))
 		})
 	}
 }


### PR DESCRIPTION
This change adds a new regex to parse AWS ECR OCI URLs when to allow URLs that point to the root of an AWS account's ECR registry, instead of forcing all repositories to contain a "/" character.

When accepted this will resolve https://github.com/fluxcd/source-controller/issues/905.

I've verified this change resolves the issue by rebuilding the source-controller image and deploying it to a Kubernetes cluster and verifying it can properly authenticate and pull from AWS ECR when given a URL like `oci://<account>.dkr.ecr.<region>.amazonaws.com` in a HelmRepository object.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203048932854531