### PR TITLE
build: disable cosign verification for CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,6 +29,8 @@ jobs:
             **/go.mod
       - name: Run tests
         run: make all
+        env:
+          SKIP_COSIGN_VERIFICATION: true
       - name: Check if working tree is dirty
         run: |
           if [[ $(git diff --stat) != '' ]]; then

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# Defines whether cosign verification should be skipped.
+SKIP_COSIGN_VERIFICATION ?= false
+
 PKG?=$*
 GO_TEST_ARGS ?= -race
 

--- a/git/libgit2/Makefile
+++ b/git/libgit2/Makefile
@@ -1,5 +1,8 @@
 PROJECT_DIR = $(shell git rev-parse --show-toplevel)
 
+# Defines whether cosign verification should be skipped.
+SKIP_COSIGN_VERIFICATION ?= false
+
 LIBGIT2_BUILD_DIR := $(shell pwd)/build
 # Include and export all libgit2 related setup variables before proceeding.
 include ./libgit2-vars.env

--- a/git/libgit2/hack/install-libraries.sh
+++ b/git/libgit2/hack/install-libraries.sh
@@ -6,6 +6,7 @@ IMG="${IMG:-}"
 TAG="${TAG:-}"
 IMG_TAG="${IMG}:${TAG}"
 DOWNLOAD_URL="https://github.com/fluxcd/golang-with-libgit2/releases/download/${TAG}"
+SKIP_COSIGN_VERIFICATION="${SKIP_COSIGN_VERIFICATION:-false}"
 
 TMP_DIR=$(mktemp -d)
 
@@ -48,9 +49,13 @@ cosign_verify(){
 assure_provenance() {
     [[ $# -eq 1 ]] || fatal 'assure_provenance needs exactly 1 arguments'
 
-    cosign_verify "${TMP_DIR}/checksums.txt.pem" \
-                  "${TMP_DIR}/checksums.txt.sig" \
-                  "${TMP_DIR}/checksums.txt"
+    if "${SKIP_COSIGN_VERIFICATION}"; then
+        echo 'Skipping cosign verification...'
+    else
+        cosign_verify "${TMP_DIR}/checksums.txt.pem" \
+                    "${TMP_DIR}/checksums.txt.sig" \
+                    "${TMP_DIR}/checksums.txt"
+    fi
 
     pushd "${TMP_DIR}" || exit
     if command -v sha256sum; then


### PR DESCRIPTION
The libgit2 libraries are downloaded and verified before some of the make targets are executed. This assures the provenance of such files before using them and is very important specially for end users running such tests on their machines.
