### PR TITLE
oci/auth: Remove log message about autologin flag

### DIFF
--- a/oci/auth/aws/auth.go
+++ b/oci/auth/aws/auth.go
@@ -125,6 +125,5 @@ func (c *Client) Login(ctx context.Context, autoLogin bool, image string) (authn
 		auth := authn.FromConfig(authConfig)
 		return auth, nil
 	}
-	ctrl.LoggerFrom(ctx).Info("ECR authentication is not enabled. To enable, set the controller flag --aws-autologin-for-ecr")
 	return nil, fmt.Errorf("ECR authentication failed: %w", oci.ErrUnconfiguredProvider)
 }

--- a/oci/auth/azure/auth.go
+++ b/oci/auth/azure/auth.go
@@ -123,6 +123,5 @@ func (c *Client) Login(ctx context.Context, autoLogin bool, image string, ref na
 		auth := authn.FromConfig(authConfig)
 		return auth, nil
 	}
-	ctrl.LoggerFrom(ctx).Info("ACR authentication is not enabled. To enable, set the controller flag --azure-autologin-for-acr")
 	return nil, fmt.Errorf("ACR authentication failed: %w", oci.ErrUnconfiguredProvider)
 }

--- a/oci/auth/gcp/auth.go
+++ b/oci/auth/gcp/auth.go
@@ -115,6 +115,5 @@ func (c *Client) Login(ctx context.Context, autoLogin bool, image string, ref na
 		auth := authn.FromConfig(authConfig)
 		return auth, nil
 	}
-	ctrl.LoggerFrom(ctx).Info("GCR authentication is not enabled. To enable, set the controller flag --gcp-autologin-for-gcr")
 	return nil, fmt.Errorf("GCR authentication failed: %w", oci.ErrUnconfiguredProvider)
 }


### PR DESCRIPTION
OCI autologin/contextual login in source-controller has per object cloud provider option in the spec. Image-reflector-controller v1beta2 API ([upcoming](https://github.com/fluxcd/image-reflector-controller/pull/311)) also configures it per object in the spec. The autologin flag log can be removed now.