### PR TITLE
build: Bump golang-with-libgit2 to v0.4.0

### DIFF
--- a/git/internal/e2e/go.mod
+++ b/git/internal/e2e/go.mod
@@ -22,7 +22,7 @@ replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.16.0
 // For more information refer to:
 // - fluxcd/image-automation-controller/#339.
 // - libgit2/git2go#918.
-replace github.com/libgit2/git2go/v33 => github.com/fluxcd/git2go/v33 v33.0.9-flux
+replace github.com/libgit2/git2go/v34 => github.com/fluxcd/git2go/v34 v34.0.0
 
 replace github.com/go-git/go-git/v5 => github.com/fluxcd/go-git/v5 v5.0.0-20221019082644-b33dae782906
 
@@ -81,7 +81,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
-	github.com/libgit2/git2go/v33 v33.0.9 // indirect
+	github.com/libgit2/git2go/v34 v34.0.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/git/internal/e2e/go.sum
+++ b/git/internal/e2e/go.sum
@@ -149,8 +149,8 @@ github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/fluxcd/git2go/v33 v33.0.9-flux h1:H6SCbrVx4a4KMewMSHW7lFqr5+Mm8HDhV1RD6n7J5tg=
-github.com/fluxcd/git2go/v33 v33.0.9-flux/go.mod h1:KdpqkU+6+++4oHna/MIOgx4GCQ92IPCdpVRMRI80J+4=
+github.com/fluxcd/git2go/v34 v34.0.0 h1:08PEpdbsLO4sUTvFKuxmt6xBowaqObro9veChBWFwa8=
+github.com/fluxcd/git2go/v34 v34.0.0/go.mod h1:blVco2jDAw6YTXkErMMqzHLcAjKkwF0aWIRHBqiJkZ0=
 github.com/fluxcd/gitkit v0.6.0 h1:iNg5LTx6ePo+Pl0ZwqHTAkhbUHxGVSY3YCxCdw7VIFg=
 github.com/fluxcd/gitkit v0.6.0/go.mod h1:svOHuKi0fO9HoawdK4HfHAJJseZDHHjk7I3ihnCIqNo=
 github.com/fluxcd/go-git-providers v0.9.0 h1:iiiKe3dzRCgVkjEi8rfpvaWTZwuGRfb3RJFhjSNz+Uc=

--- a/git/libgit2/clone.go
+++ b/git/libgit2/clone.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	git2go "github.com/libgit2/git2go/v33"
+	git2go "github.com/libgit2/git2go/v34"
 
 	"github.com/fluxcd/pkg/git"
 	"github.com/fluxcd/pkg/gitutil"

--- a/git/libgit2/clone_test.go
+++ b/git/libgit2/clone_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	git2go "github.com/libgit2/git2go/v33"
+	git2go "github.com/libgit2/git2go/v34"
 	. "github.com/onsi/gomega"
 
 	"github.com/fluxcd/pkg/git"

--- a/git/libgit2/go.mod
+++ b/git/libgit2/go.mod
@@ -20,7 +20,7 @@ replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.16.0
 // For more information refer to:
 // - fluxcd/image-automation-controller/#339.
 // - libgit2/git2go#918.
-replace github.com/libgit2/git2go/v33 => github.com/fluxcd/git2go/v33 v33.0.9-flux
+replace github.com/libgit2/git2go/v34 => github.com/fluxcd/git2go/v34 v34.0.0
 
 // This lets us use `go-billy/util.Walk()`, as this function hasn't been released
 // in a tagged version yet:
@@ -39,7 +39,7 @@ require (
 	github.com/fluxcd/pkg/version v0.2.0
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-logr/logr v1.2.3
-	github.com/libgit2/git2go/v33 v33.0.9
+	github.com/libgit2/git2go/v34 v34.0.0
 	github.com/onsi/gomega v1.20.0
 	golang.org/x/crypto v0.0.0-20220824171710-5757bc0c5503
 	golang.org/x/net v0.0.0-20220822230855-b0a4917ee28c

--- a/git/libgit2/go.sum
+++ b/git/libgit2/go.sum
@@ -151,8 +151,8 @@ github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/fluxcd/git2go/v33 v33.0.9-flux h1:H6SCbrVx4a4KMewMSHW7lFqr5+Mm8HDhV1RD6n7J5tg=
-github.com/fluxcd/git2go/v33 v33.0.9-flux/go.mod h1:KdpqkU+6+++4oHna/MIOgx4GCQ92IPCdpVRMRI80J+4=
+github.com/fluxcd/git2go/v34 v34.0.0 h1:08PEpdbsLO4sUTvFKuxmt6xBowaqObro9veChBWFwa8=
+github.com/fluxcd/git2go/v34 v34.0.0/go.mod h1:blVco2jDAw6YTXkErMMqzHLcAjKkwF0aWIRHBqiJkZ0=
 github.com/fluxcd/gitkit v0.6.0 h1:iNg5LTx6ePo+Pl0ZwqHTAkhbUHxGVSY3YCxCdw7VIFg=
 github.com/fluxcd/gitkit v0.6.0/go.mod h1:svOHuKi0fO9HoawdK4HfHAJJseZDHHjk7I3ihnCIqNo=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=

--- a/git/libgit2/internal/test/utils.go
+++ b/git/libgit2/internal/test/utils.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	git2go "github.com/libgit2/git2go/v33"
+	git2go "github.com/libgit2/git2go/v34"
 )
 
 func CommitFile(repo *git2go.Repository, path, content string, time time.Time) (*git2go.Oid, error) {

--- a/git/libgit2/libgit2-vars.env
+++ b/git/libgit2/libgit2-vars.env
@@ -2,7 +2,7 @@
 # It's purpose is to reduce boilerplate, and provide a single source
 # of info for all other build scripts.
 LIBGIT2_IMG=ghcr.io/fluxcd/golang-with-libgit2
-LIBGIT2_TAG=v0.3.0
+LIBGIT2_TAG=v0.4.0
 LIBGIT2_PATH=${LIBGIT2_BUILD_DIR}/libgit2/${LIBGIT2_TAG}
 LIBGIT2_LIB_PATH=${LIBGIT2_PATH}/lib
 LIBGIT2=${LIBGIT2_LIB_PATH}/libgit2.a

--- a/git/libgit2/repository_client.go
+++ b/git/libgit2/repository_client.go
@@ -32,7 +32,7 @@ import (
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-billy/v5/util"
-	git2go "github.com/libgit2/git2go/v33"
+	git2go "github.com/libgit2/git2go/v34"
 
 	"github.com/fluxcd/pkg/git"
 	"github.com/fluxcd/pkg/git/libgit2/transport"

--- a/git/libgit2/repository_client_test.go
+++ b/git/libgit2/repository_client_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	git2go "github.com/libgit2/git2go/v33"
+	git2go "github.com/libgit2/git2go/v34"
 	. "github.com/onsi/gomega"
 
 	"github.com/fluxcd/pkg/git"

--- a/git/libgit2/transport/http.go
+++ b/git/libgit2/transport/http.go
@@ -56,7 +56,7 @@ import (
 	"github.com/fluxcd/pkg/git"
 	"github.com/fluxcd/pkg/http/transport"
 	"github.com/go-logr/logr"
-	git2go "github.com/libgit2/git2go/v33"
+	git2go "github.com/libgit2/git2go/v34"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 

--- a/git/libgit2/transport/http_test.go
+++ b/git/libgit2/transport/http_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	git2go "github.com/libgit2/git2go/v33"
+	git2go "github.com/libgit2/git2go/v34"
 	. "github.com/onsi/gomega"
 
 	"github.com/fluxcd/pkg/git"

--- a/git/libgit2/transport/options.go
+++ b/git/libgit2/transport/options.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 
 	"github.com/fluxcd/pkg/git"
-	git2go "github.com/libgit2/git2go/v33"
+	git2go "github.com/libgit2/git2go/v34"
 )
 
 // TransportOptions represents options to be applied at transport-level

--- a/git/libgit2/transport/ssh.go
+++ b/git/libgit2/transport/ssh.go
@@ -66,7 +66,7 @@ import (
 
 	"github.com/fluxcd/pkg/git"
 	"github.com/go-logr/logr"
-	git2go "github.com/libgit2/git2go/v33"
+	git2go "github.com/libgit2/git2go/v34"
 )
 
 const (

--- a/git/libgit2/transport/ssh_test.go
+++ b/git/libgit2/transport/ssh_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	git2go "github.com/libgit2/git2go/v33"
+	git2go "github.com/libgit2/git2go/v34"
 	. "github.com/onsi/gomega"
 
 	"github.com/fluxcd/pkg/git"

--- a/git/libgit2/utils.go
+++ b/git/libgit2/utils.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	git2go "github.com/libgit2/git2go/v33"
+	git2go "github.com/libgit2/git2go/v34"
 	"k8s.io/apimachinery/pkg/util/uuid"
 
 	"github.com/fluxcd/pkg/git"


### PR DESCRIPTION
The new version uses libgit2 1.5.0 and requires `git2go/v34`. This PR merges the changes into main.