### PR TITLE
tar: Optimise memory usage

### DIFF
--- a/oci/client/build_test.go
+++ b/oci/client/build_test.go
@@ -23,9 +23,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/fluxcd/pkg/tar"
 	. "github.com/onsi/gomega"
-
-	"github.com/fluxcd/pkg/untar"
 )
 
 func TestBuild(t *testing.T) {
@@ -84,7 +83,7 @@ func TestBuild(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			untarDir := t.TempDir()
-			_, err = untar.Untar(bytes.NewReader(b), untarDir)
+			err = tar.Untar(bytes.NewReader(b), untarDir, tar.WithMaxUntarSize(-1))
 			g.Expect(err).To(BeNil())
 
 			checkPathExists(t, untarDir, tt.path, tt.checkPaths)
@@ -115,7 +114,7 @@ func TestBuildOneFile(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	untarDir := t.TempDir()
-	_, err = untar.Untar(bytes.NewReader(b), untarDir)
+	err = tar.Untar(bytes.NewReader(b), untarDir, tar.WithMaxUntarSize(-1))
 	g.Expect(err).ToNot(HaveOccurred())
 
 	_, err = os.Stat(filepath.Join(untarDir, sourceFile))

--- a/oci/client/pull.go
+++ b/oci/client/pull.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/fluxcd/pkg/untar"
+	"github.com/fluxcd/pkg/tar"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 )
@@ -67,7 +67,7 @@ func (c *Client) Pull(ctx context.Context, url, outDir string) (*Metadata, error
 		return nil, fmt.Errorf("extracting first layer failed: %w", err)
 	}
 
-	if _, err = untar.Untar(blob, outDir); err != nil {
+	if err = tar.Untar(blob, outDir, tar.WithMaxUntarSize(-1)); err != nil {
 		return nil, fmt.Errorf("failed to untar first layer: %w", err)
 	}
 

--- a/oci/go.mod
+++ b/oci/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 replace (
 	github.com/fluxcd/pkg/sourceignore => ../sourceignore
-	github.com/fluxcd/pkg/untar => ../untar
+	github.com/fluxcd/pkg/tar => ../tar
 	github.com/fluxcd/pkg/version => ../version
 )
 
@@ -15,7 +15,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.105
 	github.com/distribution/distribution/v3 v3.0.0-20220907155224-78b9c98c5c31
 	github.com/fluxcd/pkg/sourceignore v0.2.0
-	github.com/fluxcd/pkg/untar v0.2.0
+	github.com/fluxcd/pkg/tar v0.1.0
 	github.com/fluxcd/pkg/version v0.2.0
 	github.com/google/go-containerregistry v0.11.0
 	github.com/onsi/gomega v1.20.2
@@ -35,6 +35,7 @@ require (
 	github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.12.0 // indirect
+	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/cli v20.10.17+incompatible // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect

--- a/oci/go.sum
+++ b/oci/go.sum
@@ -159,6 +159,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
+github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/daixiang0/gci v0.2.9/go.mod h1:+4dZ7TISfSmqfAGv59ePaHfNzgGtIkHAhhdKggP1JAc=
 github.com/danieljoos/wincred v1.1.0/go.mod h1:XYlo+eRTsVA9aHGp7NGjFkPla4m+DCL7hqDjlFjiygg=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/untar/go.mod
+++ b/untar/go.mod
@@ -1,3 +1,8 @@
+// Deprecated: use github.com/fluxcd/pkg/tar instead.
 module github.com/fluxcd/pkg/untar
 
 go 1.18
+
+require github.com/fluxcd/pkg/tar v0.1.0
+
+require github.com/cyphar/filepath-securejoin v0.2.3 // indirect

--- a/untar/go.sum
+++ b/untar/go.sum
@@ -1,0 +1,4 @@
+github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
+github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
+github.com/fluxcd/pkg/tar v0.1.0 h1:ObyUml8NJtGQtz/cRgexd7HU2mQsTmgjz2dtX4xdnng=
+github.com/fluxcd/pkg/tar v0.1.0/go.mod h1:w0/TOC7kwBJhnSJn7TCABkc/I7ib1f2Yz6vOsbLBnhw=

--- a/untar/untar.go
+++ b/untar/untar.go
@@ -9,115 +9,12 @@
 package untar
 
 import (
-	"archive/tar"
-	"compress/gzip"
-	"fmt"
 	"io"
-	"log"
-	"os"
-	"path/filepath"
-	"strings"
-	"time"
+
+	"github.com/fluxcd/pkg/tar"
 )
 
 // Untar reads the gzip-compressed tar file from r and writes it into dir.
 func Untar(r io.Reader, dir string) (summary string, err error) {
-	t0 := time.Now()
-	nFiles := 0
-	madeDir := map[string]bool{}
-	defer func() {
-		td := time.Since(t0)
-		if err == nil {
-			summary = fmt.Sprintf("Extracted tarball into %s: %d files, %d dirs (%v)", dir, nFiles, len(madeDir), td)
-		} else {
-			summary = fmt.Sprintf("Error extracting tarball into %s after %d files, %d dirs, %v: %v", dir, nFiles, len(madeDir), td, err)
-		}
-	}()
-	zr, err := gzip.NewReader(r)
-	if err != nil {
-		return summary, fmt.Errorf("requires gzip-compressed body: %v", err)
-	}
-	tr := tar.NewReader(zr)
-	loggedChtimesError := false
-	for {
-		f, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			log.Printf("tar reading error: %v", err)
-			return summary, fmt.Errorf("tar error: %v", err)
-		}
-		if !validRelPath(f.Name) {
-			return summary, fmt.Errorf("tar contained invalid name error %q", f.Name)
-		}
-		rel := filepath.FromSlash(f.Name)
-		abs := filepath.Join(dir, rel)
-
-		fi := f.FileInfo()
-		mode := fi.Mode()
-		switch {
-		case mode.IsRegular():
-			// Make the directory. This is redundant because it should
-			// already be made by a directory entry in the tar
-			// beforehand. Thus, don't check for errors; the next
-			// write will fail with the same error.
-			dir := filepath.Dir(abs)
-			if !madeDir[dir] {
-				if err := os.MkdirAll(filepath.Dir(abs), 0755); err != nil {
-					return summary, err
-				}
-				madeDir[dir] = true
-			}
-			wf, err := os.OpenFile(abs, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode.Perm())
-			if err != nil {
-				return summary, err
-			}
-			n, err := io.Copy(wf, tr)
-			if closeErr := wf.Close(); closeErr != nil && err == nil {
-				err = closeErr
-			}
-			if err != nil {
-				return summary, fmt.Errorf("error writing to %s: %v", abs, err)
-			}
-			if n != f.Size {
-				return summary, fmt.Errorf("only wrote %d bytes to %s; expected %d", n, abs, f.Size)
-			}
-			modTime := f.ModTime
-			if modTime.After(t0) {
-				// Clamp modtimes at system time. See
-				// golang.org/issue/19062 when clock on
-				// buildlet was behind the gitmirror server
-				// doing the git-archive.
-				modTime = t0
-			}
-			if !modTime.IsZero() {
-				if err := os.Chtimes(abs, modTime, modTime); err != nil && !loggedChtimesError {
-					// benign error. Gerrit doesn't even set the
-					// modtime in these, and we don't end up relying
-					// on it anywhere (the gomote push command relies
-					// on digests only), so this is a little pointless
-					// for now.
-					log.Printf("error changing modtime: %v (further Chtimes errors suppressed)", err)
-					loggedChtimesError = true // once is enough
-				}
-			}
-			nFiles++
-		case mode.IsDir():
-			if err := os.MkdirAll(abs, 0755); err != nil {
-				return summary, err
-			}
-			madeDir[abs] = true
-		default:
-			return summary, fmt.Errorf("tar file entry %s contained unsupported file type %v", f.Name, mode)
-		}
-	}
-	return summary, nil
-}
-
-func validRelPath(p string) bool {
-	if p == "" || strings.Contains(p, `\`) || strings.HasPrefix(p, "/") || strings.Contains(p, "../") {
-		return false
-	}
-	return true
+	return "", tar.Untar(r, dir, tar.WithMaxUntarSize(-1))
 }


### PR DESCRIPTION
The previous untar logic would take into memory each tar file entry,
causing large files to increase the likelihood of concurrent
reconciliations to cause OOM.

This change forces the untar process to use a buffer when processing
tar file entries, causing the memory profile per operation to be
reduced. On benchmarks below, the memory consumption per operation
was reduced from 10mb to 0.24mb:

```
Benchmark_Untar-16        6  188662186 ns/op  10962682 B/op  19836 allocs/op
Benchmark_Untar_Limit-16  8  131385484 ns/op   1964667 B/op  19274 allocs/op
```
The biggest file within the tar file was 95mb in size.

Testing the changes on `kustomize-controller` by tracking memory consumption, the instances with the new changes (blue and green) peak at 29mb whilst the existing code (yellow) peaks at 75mb:
![image](https://user-images.githubusercontent.com/5452977/195642286-c2ea3a6a-dde4-4f96-b333-30b86ba58524.png)


This PR also decommissions the `untar` package, so that the code does not need to be duplicated.

Should decrease the likelihood of: https://github.com/fluxcd/kustomize-controller/issues/725