### PR TITLE
oci: Use upstream layer digest for artifact diff

### DIFF
--- a/oci/client/diff_test.go
+++ b/oci/client/diff_test.go
@@ -51,7 +51,7 @@ func TestClient_Diff(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	defer os.RemoveAll(tmpBuildDir)
 
-	g.Expect(os.WriteFile(filepath.Join(tmpBuildDir, "test.txt"), []byte("test"), 0600)).ToNot(HaveOccurred())
+	g.Expect(os.WriteFile(filepath.Join(tmpBuildDir, "test.txt"), []byte("test"), 0o600)).ToNot(HaveOccurred())
 
 	newTag := "v0.0.2"
 	url = fmt.Sprintf("%s/%s:%s", dockerReg, repo, newTag)
@@ -61,4 +61,5 @@ func TestClient_Diff(t *testing.T) {
 
 	err = c.Diff(ctx, url, testDir, nil)
 	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError("the remote artifact contents differs from the local one"))
 }


### PR DESCRIPTION
**_Contributor details_**:
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>
Co-authored-by: Furkan Türkal <furkan.turkal@trendyol.com>

**_Features that are included in the PR_**:
- [x] use digest extracted directly from an OCI artifact instead of recalculating it through its contents
- [x] add size control to check whether the size between the OCI artifact layer and the local file or directory is equal
- [x] check whether the error message is the expected message.


/cc @stefanprodan