### PR TITLE
gogit: create parent dirs for fs.Symlink()

### DIFF
--- a/git/gogit/fs/osfs_os.go
+++ b/git/gogit/fs/osfs_os.go
@@ -185,6 +185,10 @@ func (fs *OS) Symlink(target, link string) error {
 	if err != nil {
 		return err
 	}
+	// MkdirAll for containing dir.
+	if err := fs.createDir(ln); err != nil {
+		return err
+	}
 	return os.Symlink(target, ln)
 }
 


### PR DESCRIPTION
Go-git expects that the dir containing the target symlink exists, which is the same behaviour observed for regular files. Regular files and dir are managed by `fs.OpenFile()`, which is call by both `fs.Open()` and `fs.Create()`.

With the this change, `fs.Symlink()` aligns with the behaviour elsewhere within go-git.