### PR TITLE
git: add support for cloning empty repos

### DIFF
--- a/git/client.go
+++ b/git/client.go
@@ -24,6 +24,8 @@ import (
 // on a Git repository.
 type RepositoryReader interface {
 	// Clone clones a repository from the provided url using the options provided.
+	// It returns a Commit object describing the Git commit that the repository
+	// HEAD points to. If the repository is empty, it returns a nil Commit.
 	Clone(ctx context.Context, url string, cloneOpts CloneOptions) (*Commit, error)
 	// IsClean returns whether the working tree is clean.
 	IsClean() (bool, error)

--- a/git/libgit2/clone.go
+++ b/git/libgit2/clone.go
@@ -79,6 +79,14 @@ func (l *Client) cloneBranch(ctx context.Context, url, branch string, opts git.C
 		return nil, fmt.Errorf("unable to fetch remote '%s': %w", url, gitutil.LibGit2Error(err))
 	}
 
+	isEmpty, err := l.repository.IsEmpty()
+	if err != nil {
+		return nil, fmt.Errorf("unable to check if cloned repo '%s' is empty: %w", url, err)
+	}
+	if isEmpty {
+		return nil, nil
+	}
+
 	branchRef, err := l.repository.References.Lookup(fmt.Sprintf("refs/remotes/origin/%s", branch))
 	if err != nil {
 		return nil, fmt.Errorf("unable to lookup branch '%s' for '%s': %w", branch, url, gitutil.LibGit2Error(err))


### PR DESCRIPTION
Add support for cloning empty repos using `go-git` and `libgit2`.
`go-git` returns an error when cloning an empty repository directly, which is handled by using the advice provided here: https://github.com/go-git/go-git/issues/118#issuecomment-773488577. `libgit2` doesn't return an error and thus the change is much simpler.
The `go-git` package gets test coverage for this scenario but the `libgit2` package does not because of the following weird behavior:
```go
_, err := git2go.InitRepository(filepath.Join(server.Root(), emptyRepoPath), true)

err = l.remote.Fetch([]string{branch},
	&git2go.FetchOptions{
		DownloadTags:    git2go.DownloadTagsNone,
		RemoteCallbacks: remoteCallBacks,
	},
	"")
if err != nil {
	return nil, fmt.Errorf("unable to fetch remote '%s': %w", url, gitutil.LibGit2Error(err))
}

isEmpty, err := l.repository.IsEmpty()
fmt.Println(isEmpty) // prints false
```
To make sure the changes to the `libgit2` package have the intended effect, it was tested (and confirmed to have the correct behavior) using empty repos on GitHub and GitLab.(same goes for the `go-git` package as well).
Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>