### PR TITLE
git/gogit: configure hostkey callback only when known_hosts is provided

### DIFF
--- a/git/gogit/transport.go
+++ b/git/gogit/transport.go
@@ -50,10 +50,15 @@ func transportAuth(opts *git.AuthOptions) (transport.AuthMethod, error) {
 		if err != nil {
 			return nil, err
 		}
-		callback, err := knownhosts.New(opts.KnownHosts)
-		if err != nil {
-			return nil, err
+
+		var callback gossh.HostKeyCallback
+		if len(opts.KnownHosts) > 0 {
+			callback, err = knownhosts.New(opts.KnownHosts)
+			if err != nil {
+				return nil, err
+			}
 		}
+
 		customPK := &CustomPublicKeys{
 			pk:       pk,
 			callback: callback,
@@ -95,7 +100,9 @@ func (a *CustomPublicKeys) ClientConfig() (*gossh.ClientConfig, error) {
 		return nil, err
 	}
 
-	config.HostKeyCallback = a.callback
+	if a.callback != nil {
+		config.HostKeyCallback = a.callback
+	}
 	if len(git.KexAlgos) > 0 {
 		config.Config.KeyExchanges = git.KexAlgos
 	}

--- a/git/gogit/transport_test.go
+++ b/git/gogit/transport_test.go
@@ -207,6 +207,20 @@ func Test_transportAuth(t *testing.T) {
 			wantErr: errors.New("knownhosts: knownhosts: missing host pattern"),
 		},
 		{
+			name: "SSH private key without known_hosts",
+			opts: &git.AuthOptions{
+				Transport: git.SSH,
+				Username:  "example",
+				Identity:  []byte(privateKeyFixture),
+			},
+			wantFunc: func(g *WithT, t transport.AuthMethod, opts *git.AuthOptions) {
+				tt, ok := t.(*CustomPublicKeys)
+				g.Expect(ok).To(BeTrue())
+				g.Expect(tt.pk.User).To(Equal(opts.Username))
+				g.Expect(tt.callback).To(BeNil())
+			},
+		},
+		{
 			name:    "Empty",
 			opts:    &git.AuthOptions{},
 			wantErr: errors.New("no transport type set"),


### PR DESCRIPTION
Some applications like CLIs might prefer to use the known_hosts of the machine which then leads to an empty known_hosts value being used in `git.AuthOptions` resulting in an invalid callback.

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>