### PR TITLE
build: Fix gitkit and gitlab tests

### DIFF
--- a/git/internal/e2e/gitkit_test.go
+++ b/git/internal/e2e/gitkit_test.go
@@ -114,11 +114,11 @@ func TestGitKitE2E(t *testing.T) {
 
 			switch gitClient {
 			case gogit.ClientName:
-				client, err = gogit.NewClient(tmp, authOptions)
+				client, err = gogit.NewClient(tmp, authOptions, gogit.WithInsecureCredentialsOverHTTP, gogit.WithDiskStorage)
 				g.Expect(err).ToNot(HaveOccurred())
 				defer client.Close()
 			case libgit2.ClientName:
-				client, err = libgit2.NewClient(tmp, authOptions)
+				client, err = libgit2.NewClient(tmp, authOptions, libgit2.WithInsecureCredentialsOverHTTP, libgit2.WithDiskStorage)
 				g.Expect(err).ToNot(HaveOccurred())
 				defer client.Close()
 			default:

--- a/git/internal/e2e/gitlab_ce_test.go
+++ b/git/internal/e2e/gitlab_ce_test.go
@@ -178,11 +178,11 @@ func TestGitLabCEE2E(t *testing.T) {
 
 			switch gitClient {
 			case gogit.ClientName:
-				client, err = gogit.NewClient(tmp, authOptions)
+				client, err = gogit.NewClient(tmp, authOptions, gogit.WithInsecureCredentialsOverHTTP, gogit.WithDiskStorage)
 				g.Expect(err).ToNot(HaveOccurred())
 				defer client.Close()
 			case libgit2.ClientName:
-				client, err = libgit2.NewClient(tmp, authOptions)
+				client, err = libgit2.NewClient(tmp, authOptions, libgit2.WithInsecureCredentialsOverHTTP, libgit2.WithDiskStorage)
 				g.Expect(err).ToNot(HaveOccurred())
 				defer client.Close()
 			default:


### PR DESCRIPTION
The two sets of [tests affected](https://github.com/fluxcd/pkg/actions/runs/3438702214) are only executed at main branch and were sending credentials over HTTP, which has been blocked by #396. The changes use WithInsecureCredentialsOverHTTP to enable such behaviour.