### PR TITLE
build: Refactor e2e tests and update GitHub actions

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Restore Go cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
       - uses: ./actions/envtest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Go
       uses: actions/setup-go@v3
       with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,7 +23,7 @@ jobs:
           - github
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Since this is a monorepo, changes in other packages will also trigger these e2e tests
       # meant only for the git package. This detects us whether the changed files are part of the
@@ -40,7 +40,7 @@ jobs:
               - 'git/**'
       - name: Restore Go cache
         if: ${{ steps.filter.outputs.git == 'true' || steps.filter.outputs.e2e == 'true' || github.event_name == 'workflow_dispatch' }}
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: /home/runner/work/_temp/_github_home/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -48,7 +48,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Setup Go
         if: ${{ steps.filter.outputs.git == 'true' || steps.filter.outputs.e2e == 'true' || github.event_name == 'workflow_dispatch' }}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.19.x
       - name: Run tests

--- a/.github/workflows/ossf.yaml
+++ b/.github/workflows/ossf.yaml
@@ -25,9 +25,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v1.1.0
+        uses: ossf/scorecard-action@v2
         with:
           results_file: results.sarif
           results_format: sarif
@@ -42,7 +42,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v2.3.1
+        uses: actions/upload-artifact@v3
         with:
           name: SARIF file
           path: results.sarif
@@ -50,6 +50,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.19.x
       - name: Initialize CodeQL

--- a/git/internal/e2e/git_utils.go
+++ b/git/internal/e2e/git_utils.go
@@ -1,0 +1,44 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/fluxcd/pkg/git"
+	"github.com/fluxcd/pkg/git/gogit"
+	"github.com/fluxcd/pkg/git/libgit2"
+)
+
+func newClient(gitClient, tmp string, authOptions *git.AuthOptions, insecure bool) (git.RepositoryClient, error) {
+	switch gitClient {
+	case gogit.ClientName:
+		if insecure {
+			return gogit.NewClient(tmp, authOptions, gogit.WithInsecureCredentialsOverHTTP, gogit.WithDiskStorage)
+		}
+		return gogit.NewClient(tmp, authOptions)
+	case libgit2.ClientName:
+		if insecure {
+			return libgit2.NewClient(tmp, authOptions, libgit2.WithInsecureCredentialsOverHTTP, libgit2.WithDiskStorage)
+		}
+		return libgit2.NewClient(tmp, authOptions)
+	}
+	return nil, fmt.Errorf("invalid git client name: %s", gitClient)
+}

--- a/git/internal/e2e/github_test.go
+++ b/git/internal/e2e/github_test.go
@@ -124,21 +124,9 @@ func TestGitHubE2E(t *testing.T) {
 			repoURL, authOptions, err := repoInfo(proto, repo)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			var client git.RepositoryClient
-			tmp := t.TempDir()
-
-			switch gitClient {
-			case gogit.ClientName:
-				client, err = gogit.NewClient(tmp, authOptions)
-				g.Expect(err).ToNot(HaveOccurred())
-				defer client.Close()
-			case libgit2.ClientName:
-				client, err = libgit2.NewClient(tmp, authOptions)
-				g.Expect(err).ToNot(HaveOccurred())
-				defer client.Close()
-			default:
-				t.Fatalf("invalid git client name: %s", gitClient)
-			}
+			client, err := newClient(gitClient, t.TempDir(), authOptions, false)
+			g.Expect(err).ToNot(HaveOccurred())
+			defer client.Close()
 
 			testUsingClone(g, client, repoURL, upstreamRepoInfo{
 				url:      upstreamRepoURL,
@@ -163,21 +151,9 @@ func TestGitHubE2E(t *testing.T) {
 			repoURL, authOptions, err := repoInfo(proto, repo)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			var client git.RepositoryClient
-			tmp := t.TempDir()
-
-			switch gitClient {
-			case gogit.ClientName:
-				client, err = gogit.NewClient(tmp, authOptions)
-				g.Expect(err).ToNot(HaveOccurred())
-				defer client.Close()
-			case libgit2.ClientName:
-				client, err = libgit2.NewClient(tmp, authOptions)
-				g.Expect(err).ToNot(HaveOccurred())
-				defer client.Close()
-			default:
-				t.Fatalf("invalid git client name: %s", gitClient)
-			}
+			client, err := newClient(gitClient, t.TempDir(), authOptions, false)
+			g.Expect(err).ToNot(HaveOccurred())
+			defer client.Close()
 
 			testUsingInit(g, client, repoURL, upstreamRepoInfo{
 				url:      upstreamRepoURL,

--- a/git/internal/e2e/gitlab_ce_test.go
+++ b/git/internal/e2e/gitlab_ce_test.go
@@ -142,21 +142,9 @@ func TestGitLabCEE2E(t *testing.T) {
 			err = initRepo(upstreamRepoURL, "main", "../../testdata/git/repo", gitlabCEUsername, gitlabCEPassword)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			var client git.RepositoryClient
-			tmp := t.TempDir()
-
-			switch gitClient {
-			case gogit.ClientName:
-				client, err = gogit.NewClient(tmp, authOptions)
-				g.Expect(err).ToNot(HaveOccurred())
-				defer client.Close()
-			case libgit2.ClientName:
-				client, err = libgit2.NewClient(tmp, authOptions)
-				g.Expect(err).ToNot(HaveOccurred())
-				defer client.Close()
-			default:
-				t.Fatalf("invalid git client name: %s", gitClient)
-			}
+			client, err := newClient(gitClient, t.TempDir(), authOptions, true)
+			g.Expect(err).ToNot(HaveOccurred())
+			defer client.Close()
 
 			testUsingClone(g, client, repoURL, upstreamRepoInfo{
 				url:      upstreamRepoURL,
@@ -173,21 +161,9 @@ func TestGitLabCEE2E(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 			upstreamRepoURL := gitlabCEHTTPHost + "/" + gitlabCEUsername + "/" + repoName
 
-			var client git.RepositoryClient
-			tmp := t.TempDir()
-
-			switch gitClient {
-			case gogit.ClientName:
-				client, err = gogit.NewClient(tmp, authOptions, gogit.WithInsecureCredentialsOverHTTP, gogit.WithDiskStorage)
-				g.Expect(err).ToNot(HaveOccurred())
-				defer client.Close()
-			case libgit2.ClientName:
-				client, err = libgit2.NewClient(tmp, authOptions, libgit2.WithInsecureCredentialsOverHTTP, libgit2.WithDiskStorage)
-				g.Expect(err).ToNot(HaveOccurred())
-				defer client.Close()
-			default:
-				t.Fatalf("invalid git client name: %s", gitClient)
-			}
+			client, err := newClient(gitClient, t.TempDir(), authOptions, true)
+			g.Expect(err).ToNot(HaveOccurred())
+			defer client.Close()
 
 			testUsingInit(g, client, repoURL, upstreamRepoInfo{
 				url:      upstreamRepoURL,

--- a/git/internal/e2e/gitlab_test.go
+++ b/git/internal/e2e/gitlab_test.go
@@ -124,21 +124,9 @@ func TestGitLabE2E(t *testing.T) {
 			repoURL, authOptions, err := repoInfo(proto, repo)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			var client git.RepositoryClient
-			tmp := t.TempDir()
-
-			switch gitClient {
-			case gogit.ClientName:
-				client, err = gogit.NewClient(tmp, authOptions)
-				g.Expect(err).ToNot(HaveOccurred())
-				defer client.Close()
-			case libgit2.ClientName:
-				client, err = libgit2.NewClient(tmp, authOptions)
-				g.Expect(err).ToNot(HaveOccurred())
-				defer client.Close()
-			default:
-				t.Fatalf("invalid git client name: %s", gitClient)
-			}
+			client, err := newClient(gitClient, t.TempDir(), authOptions, false)
+			g.Expect(err).ToNot(HaveOccurred())
+			defer client.Close()
 
 			testUsingClone(g, client, repoURL, upstreamRepoInfo{
 				url:      upstreamRepoURL,
@@ -163,21 +151,9 @@ func TestGitLabE2E(t *testing.T) {
 			repoURL, authOptions, err := repoInfo(proto, repo)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			var client git.RepositoryClient
-			tmp := t.TempDir()
-
-			switch gitClient {
-			case gogit.ClientName:
-				client, err = gogit.NewClient(tmp, authOptions)
-				g.Expect(err).ToNot(HaveOccurred())
-				defer client.Close()
-			case libgit2.ClientName:
-				client, err = libgit2.NewClient(tmp, authOptions)
-				g.Expect(err).ToNot(HaveOccurred())
-				defer client.Close()
-			default:
-				t.Fatalf("invalid git client name: %s", gitClient)
-			}
+			client, err := newClient(gitClient, t.TempDir(), authOptions, false)
+			g.Expect(err).ToNot(HaveOccurred())
+			defer client.Close()
 
 			testUsingInit(g, client, repoURL, upstreamRepoInfo{
 				url:      upstreamRepoURL,


### PR DESCRIPTION
Refactored the e2e tests so Git client logic is shared across all tests.

Node.js 12 actions are deprecated so moving the actions to the latest version to remove warnings whilst running CI builds.