### PR TITLE
git/gogit: modify chroot to return a new os filesystem

### DIFF
--- a/git/gogit/fs/osfs_os.go
+++ b/git/gogit/fs/osfs_os.go
@@ -38,7 +38,7 @@ const (
 // OS is a fs implementation based on the OS filesystem which has some
 // changes in behaviour when compared to the upstream go-git/go-billy/v5/osfs:
 //
-// - Chroot is not supported and paths are not changed from the underlying OS fs.
+// - Chroot doesn't return a chrooted filesystem but returns a new OS filesystem.
 // - Relative paths are forced to descend from the working dir.
 // - Symlinks don't have its targets modified, and therefore can point to locations
 // outside the working dir or to non-existent paths.
@@ -213,8 +213,9 @@ func (fs *OS) Readlink(link string) (string, error) {
 	return os.Readlink(link)
 }
 
+// Chroot returns a new OS filesystem, with working directory set to path.
 func (fs *OS) Chroot(path string) (billy.Filesystem, error) {
-	return nil, billy.ErrNotSupported
+	return New(path), nil
 }
 
 // Root returns the current working dir of the billy.Filesystem.

--- a/git/gogit/fs/osfs_test.go
+++ b/git/gogit/fs/osfs_test.go
@@ -253,14 +253,13 @@ func TestTempFile(t *testing.T) {
 	g.Expect(f).To(BeNil())
 }
 
-func TestUnsupportedChroot(t *testing.T) {
+func TestChroot(t *testing.T) {
 	g := NewWithT(t)
 	fs := New(t.TempDir())
 
-	f, err := fs.Chroot("")
-	g.Expect(err).To(HaveOccurred())
-	g.Expect(err).To(Equal(billy.ErrNotSupported))
-	g.Expect(f).To(BeNil())
+	f, err := fs.Chroot("test")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(f).ToNot(BeNil())
 }
 
 func TestRoot(t *testing.T) {


### PR DESCRIPTION
Modify `Chroot()` into returning a new OS filesystem. The filesystem returned is not actually chrooted, but only enforces all files to be under the root working directory. This is required to avoid breaking cloning repos with submodules. Ref: https://github.com/fluxcd/go-git/blob/d979ddd67ae30aebcdd285c0b0133594e7194980/storage/filesystem/dotgit/dotgit.go#L1100-L1103

Related to: https://github.com/fluxcd/source-controller/issues/970

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>