### PR TITLE
git/gogit: fallback to machine known_hosts

### DIFF
--- a/git/gogit/client_test.go
+++ b/git/gogit/client_test.go
@@ -194,7 +194,7 @@ func TestPush(t *testing.T) {
 		Transport: git.HTTP,
 		Username:  "test-user",
 		Password:  "test-pass",
-	})
+	}, false)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	repo, err := extgogit.PlainClone(tmp, false, &extgogit.CloneOptions{
@@ -245,7 +245,7 @@ func TestForcePush(t *testing.T) {
 		Transport: git.HTTP,
 		Username:  "test-user",
 		Password:  "test-pass",
-	})
+	}, false)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	tmp1 := t.TempDir()

--- a/git/gogit/clone.go
+++ b/git/gogit/clone.go
@@ -42,7 +42,7 @@ func (g *Client) cloneBranch(ctx context.Context, url, branch string, opts repos
 	if g.authOpts == nil {
 		return nil, fmt.Errorf("unable to checkout repo with an empty set of auth options")
 	}
-	authMethod, err := transportAuth(g.authOpts)
+	authMethod, err := transportAuth(g.authOpts, g.useDefaultKnownHosts)
 	if err != nil {
 		return nil, fmt.Errorf("unable to construct auth method with options: %w", err)
 	}
@@ -132,7 +132,7 @@ func (g *Client) cloneTag(ctx context.Context, url, tag string, opts repository.
 		return nil, fmt.Errorf("unable to checkout repo with an empty set of auth options")
 	}
 
-	authMethod, err := transportAuth(g.authOpts)
+	authMethod, err := transportAuth(g.authOpts, g.useDefaultKnownHosts)
 	if err != nil {
 		return nil, fmt.Errorf("unable to construct auth method with options: %w", err)
 	}
@@ -206,7 +206,7 @@ func (g *Client) cloneTag(ctx context.Context, url, tag string, opts repository.
 }
 
 func (g *Client) cloneCommit(ctx context.Context, url, commit string, opts repository.CloneOptions) (*git.Commit, error) {
-	authMethod, err := transportAuth(g.authOpts)
+	authMethod, err := transportAuth(g.authOpts, g.useDefaultKnownHosts)
 	if err != nil {
 		return nil, fmt.Errorf("unable to construct auth method with options: %w", err)
 	}
@@ -263,7 +263,7 @@ func (g *Client) cloneSemVer(ctx context.Context, url, semverTag string, opts re
 		return nil, fmt.Errorf("semver parse error: %w", err)
 	}
 
-	authMethod, err := transportAuth(g.authOpts)
+	authMethod, err := transportAuth(g.authOpts, g.useDefaultKnownHosts)
 	if err != nil {
 		return nil, fmt.Errorf("unable to construct auth method with options: %w", err)
 	}


### PR DESCRIPTION
Add a new `AuthMethod` which uses the default `known_hosts`. Fallback to this when the provided auth options has an empty private key and known hosts.

Related to: https://github.com/fluxcd/flux2/issues/3358