### PR TITLE
git/gogit: bump to gittestserver v0.8.0

### DIFF
--- a/git/gogit/go.mod
+++ b/git/gogit/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/fluxcd/gitkit v0.6.0
 	github.com/fluxcd/go-git/v5 v5.0.0-20221206140629-ec778c2c37df
 	github.com/fluxcd/pkg/git v0.7.0
-	github.com/fluxcd/pkg/gittestserver v0.0.0-00010101000000-000000000000
+	github.com/fluxcd/pkg/gittestserver v0.8.0
 	github.com/fluxcd/pkg/ssh v0.7.0
 	github.com/fluxcd/pkg/version v0.2.0
 	github.com/go-git/go-billy/v5 v5.3.1


### PR DESCRIPTION
Fixes wrong version for gittestserver introduced by 49c90f601a5161a009735f72b006bbe8e1531d3d.
 
Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>