### PR TITLE
git/{libgit2,e2e}: bump git/gogit to v0.3.1

### DIFF
--- a/git/internal/e2e/go.mod
+++ b/git/internal/e2e/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/fluxcd/go-git-providers v0.10.0
 	github.com/fluxcd/go-git/v5 v5.0.0-20221206140629-ec778c2c37df
 	github.com/fluxcd/pkg/git v0.7.0
-	github.com/fluxcd/pkg/git/gogit v0.1.0
+	github.com/fluxcd/pkg/git/gogit v0.3.1
 	github.com/fluxcd/pkg/git/libgit2 v0.2.0
 	github.com/fluxcd/pkg/gittestserver v0.8.0
 	github.com/fluxcd/pkg/ssh v0.7.0

--- a/git/libgit2/go.mod
+++ b/git/libgit2/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/elazarl/goproxy v0.0.0-20221015165544-a0805db90819
 	github.com/fluxcd/gitkit v0.6.0
 	github.com/fluxcd/pkg/git v0.7.0
-	github.com/fluxcd/pkg/git/gogit v0.0.0-00010101000000-000000000000
+	github.com/fluxcd/pkg/git/gogit v0.3.1
 	github.com/fluxcd/pkg/gittestserver v0.8.0
 	github.com/fluxcd/pkg/http/transport v0.1.0
 	github.com/fluxcd/pkg/ssh v0.7.0


### PR DESCRIPTION
Fixes wrong version for git/gogit introduced by https://github.com/fluxcd/pkg/commit/51f482bd11c2327ea6dee81230ab21ecd46ec7b9

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>