### PR TITLE
git/gogit: fix chroot filesystem and add submodule test

### DIFF
--- a/git/gogit/fs/osfs_os.go
+++ b/git/gogit/fs/osfs_os.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"sync"
 
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/go-git/go-billy/v5"
 )
 
@@ -215,7 +216,11 @@ func (fs *OS) Readlink(link string) (string, error) {
 
 // Chroot returns a new OS filesystem, with working directory set to path.
 func (fs *OS) Chroot(path string) (billy.Filesystem, error) {
-	return New(path), nil
+	joined, err := securejoin.SecureJoin(fs.workingDir, path)
+	if err != nil {
+		return nil, err
+	}
+	return New(joined), nil
 }
 
 // Root returns the current working dir of the billy.Filesystem.

--- a/git/gogit/fs/osfs_test.go
+++ b/git/gogit/fs/osfs_test.go
@@ -255,11 +255,13 @@ func TestTempFile(t *testing.T) {
 
 func TestChroot(t *testing.T) {
 	g := NewWithT(t)
-	fs := New(t.TempDir())
+	tmp := t.TempDir()
+	fs := New(tmp)
 
 	f, err := fs.Chroot("test")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(f).ToNot(BeNil())
+	g.Expect(f.Root()).To(Equal(filepath.Join(tmp, "test")))
 }
 
 func TestRoot(t *testing.T) {

--- a/git/gogit/go.mod
+++ b/git/gogit/go.mod
@@ -12,6 +12,7 @@ replace (
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
+	github.com/cyphar/filepath-securejoin v0.2.3
 	github.com/elazarl/goproxy v0.0.0-20221015165544-a0805db90819
 	github.com/fluxcd/gitkit v0.6.0
 	github.com/fluxcd/go-git/v5 v5.0.0-20221206140629-ec778c2c37df
@@ -30,7 +31,6 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/cloudflare/circl v1.3.0 // indirect
-	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect

--- a/git/testdata/git/repo2/bar.txt
+++ b/git/testdata/git/repo2/bar.txt
@@ -1,0 +1,2 @@
+another test file
+another test file


### PR DESCRIPTION
Use `filepath-securejoin` to join root working dir of the base filesystem and the desired chroot root and return a filesystem using the resulting path as the root working dir. Add a test which clones a repo with a submodule to make sure this doesn't get broken again.

Related to: https://github.com/fluxcd/source-controller/issues/970