### PR TITLE
gogit: Add WithSingleBranch

### DIFF
--- a/git/gogit/clone.go
+++ b/git/gogit/clone.go
@@ -83,7 +83,7 @@ func (g *Client) cloneBranch(ctx context.Context, url, branch string, opts repos
 		Auth:              authMethod,
 		RemoteName:        git.DefaultRemote,
 		ReferenceName:     plumbing.NewBranchReferenceName(branch),
-		SingleBranch:      true,
+		SingleBranch:      g.singleBranch,
 		NoCheckout:        false,
 		Depth:             depth,
 		RecurseSubmodules: recurseSubmodules(opts.RecurseSubmodules),
@@ -173,7 +173,7 @@ func (g *Client) cloneTag(ctx context.Context, url, tag string, opts repository.
 		Auth:              authMethod,
 		RemoteName:        git.DefaultRemote,
 		ReferenceName:     plumbing.NewTagReferenceName(tag),
-		SingleBranch:      true,
+		SingleBranch:      g.singleBranch,
 		NoCheckout:        false,
 		Depth:             depth,
 		RecurseSubmodules: recurseSubmodules(opts.RecurseSubmodules),
@@ -222,7 +222,7 @@ func (g *Client) cloneCommit(ctx context.Context, url, commit string, opts repos
 		CABundle:          caBundle(g.authOpts),
 	}
 	if opts.Branch != "" {
-		cloneOpts.SingleBranch = true
+		cloneOpts.SingleBranch = g.singleBranch
 		cloneOpts.ReferenceName = plumbing.NewBranchReferenceName(opts.Branch)
 	}
 


### PR DESCRIPTION
At present go-git does not support the `MULTI_ACK` capability, which means that follow-up fetches on a given remote will fail.

To support Image Automation Controller use cases, the SwitchBranch was initially short-circuited to avoid additional fetches. However, this has the side effect of the controller pushing the same change to the target repository multiple times. (fluxcd/flux2#3384)

In order to avoid this, a new `WithSingleBranch` option was created to enable the download of all references at the initial clone. From now on `SwitchBranch` has the single responsibility of switching branches, and no longer pulling references.

The package `git/gogit`'s primary goal is to support Flux use cases, currently there is no need to expand the current API to expose ways for users to refresh repository references outside the initial clone.