### PR TITLE
Expose the default rate limiter

### DIFF
--- a/runtime/controller/rate_limiter.go
+++ b/runtime/controller/rate_limiter.go
@@ -59,3 +59,11 @@ func GetRateLimiter(opts RateLimiterOptions) ratelimiter.RateLimiter {
 		opts.MinRetryDelay,
 		opts.MaxRetryDelay)
 }
+
+// GetDefaultRateLimiter returns a new exponential failure
+// ratelimiter.RateLimiter with the default configuration.
+func GetDefaultRateLimiter() ratelimiter.RateLimiter {
+	return workqueue.NewItemExponentialFailureRateLimiter(
+		defaultMinRetryDelay,
+		defaultMaxRetryDelay)
+}


### PR DESCRIPTION
The default configurations for rate limiter is exposed only to flag set. This change adds a new function `GetDefaultRateLimiter()` to provide access to the same rate limiter configuration without flags. This is useful for setting the default rate limiter for reconcilers in test suites.
The default rate limiter configuration set in [upstream client-go](https://github.com/kubernetes/client-go/blob/v0.25.4/util/workqueue/default_rate_limiters.go#L41) code has a very short minimum delay, which results in a flood of error logs in the tests when it's an expected behavior. Because the reconcilers are configured differently in the [test suite](https://github.com/fluxcd/source-controller/blob/v0.33.0/controllers/suite_test.go#L244) and a [properly deployed controller](https://github.com/fluxcd/source-controller/blob/v0.33.0/main.go#L215), there is a difference in the observed results. This change allows for the test and deployment configuration of the reconcilers to be similarly configured with the same default rate limiter.