### PR TITLE
kustomize: Handle malformed YAML in manifest scan

### DIFF
--- a/kustomize/kustomize_generator_whitebox_test.go
+++ b/kustomize/kustomize_generator_whitebox_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2023 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kustomize
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+func TestScanManifests(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name      string
+		base      string
+		wantErr   bool
+		wantPaths []string
+	}{
+		{
+			name: "empty directory",
+			base: tmpDir,
+		},
+		{
+			name: "valid manifests",
+			base: "./testdata/nokustomization/resources",
+			wantPaths: []string{
+				"testdata/nokustomization/resources/configmap.yaml",
+				"testdata/nokustomization/resources/secret.yaml",
+			},
+		},
+		{
+			name:    "malformed YAML - panic recovery error",
+			base:    "./testdata/nokustomization/panic",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			fs := filesys.MakeFsOnDisk()
+
+			paths, err := scanManifests(fs, tt.base)
+			g.Expect(paths).To(Equal(tt.wantPaths))
+			g.Expect(err != nil).To(Equal(tt.wantErr))
+		})
+	}
+}

--- a/kustomize/testdata/nokustomization/panic/alert.yaml
+++ b/kustomize/testdata/nokustomization/panic/alert.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
+kind: Alert
+metadata:
+  name: on-call-webapp
+  namespace: default
+spec:
+  providerRef:
+    name: slack
+  eventSeverity: error
+  eventSources:
+    - kind: GitRepository
+      name: '*'
+    - kind: Kustomization
+      name: '*'
+  exclusionList:
+    # ignore messages when something first enters the system
+    - "version list argument cannot be empty"
+    - "ImageRepository\.image\.toolkit\.fluxcd\.io \".*\" not found"

--- a/kustomize/testdata/nokustomization/resources/configmap.yaml
+++ b/kustomize/testdata/nokustomization/resources/configmap.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+  namespace: foo
+data:
+  key: value

--- a/kustomize/testdata/nokustomization/resources/secret.yaml
+++ b/kustomize/testdata/nokustomization/resources/secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret
+  namespace: foo
+stringData:
+  foo: bar


### PR DESCRIPTION
While scanning YAML manifests for generating kustomization, certain invalid YAML files can cause panic. Add panic recovery while scanning manifests.

Extracts the manifest scan code into a separate function and adds white-box tests for it for different scenarios.

The recovery message tries to provide some helpful hint about the bad manifest to make it easier to find and fix the issue
```
recovered from panic while parsing YAML file alert.yaml: runtime error: invalid memory address or nil pointer dereference
```

Refer https://github.com/fluxcd/flux2/issues/3458