### PR TITLE
Increase default burst to 300 to conform `client-go`

### DIFF
--- a/runtime/client/client.go
+++ b/runtime/client/client.go
@@ -52,7 +52,7 @@ type Options struct {
 	// QPS indicates the maximum queries-per-second of requests sent to the Kubernetes API, defaults to 50.
 	QPS float32
 
-	// Burst indicates the maximum burst queries-per-second of requests sent to the Kubernetes API, defaults to 100.
+	// Burst indicates the maximum burst queries-per-second of requests sent to the Kubernetes API, defaults to 300.
 	Burst int
 }
 
@@ -60,7 +60,7 @@ type Options struct {
 func (o *Options) BindFlags(fs *pflag.FlagSet) {
 	fs.Float32Var(&o.QPS, flagQPS, 50.0,
 		"The maximum queries-per-second of requests sent to the Kubernetes API.")
-	fs.IntVar(&o.Burst, flagBurst, 100,
+	fs.IntVar(&o.Burst, flagBurst, 300,
 		"The maximum burst queries-per-second of requests sent to the Kubernetes API.")
 }
 


### PR DESCRIPTION
In `client-go` version `v0.25.0` the burst limit was increased to 300 for the discovery client: https://github.com/kubernetes/kubernetes/pull/109141

This is especially useful for clusters with `crossplane` ([see](https://github.com/crossplane/crossplane/issues/3272)), but since `client-go` itself got the change as well, I think it makes sense to increase the default for Flux controllers too, because - if I am not mistaken - this setting goes down into the discovery client, e.g. for `helm-controller`:

1. https://github.com/fluxcd/helm-controller/blob/v0.29.0/go.mod#L24
2. https://github.com/fluxcd/helm-controller/blob/v0.29.0/go.mod#L13
3. https://github.com/fluxcd/pkg/blob/runtime/v0.27.0/runtime/client/client.go#L59-L65
4. https://github.com/fluxcd/helm-controller/blob/v0.29.0/internal/kube/client.go#L121-L124

NOTE: If controllers get updated to this version, then https://github.com/fluxcd/website needs to updated in [various places](https://sourcegraph.com/search?q=context:global+repo:fluxcd+The+maximum+burst+queries-per-second+of+requests+sent+to+the+Kubernetes+API.+%28default+100%29&patternType=standard&sm=0&groupBy=repo) as well.