### PR TITLE
add support for checking out git repo to a ref

### DIFF
--- a/git/gogit/client.go
+++ b/git/gogit/client.go
@@ -226,6 +226,8 @@ func (g *Client) Clone(ctx context.Context, url string, cloneOpts repository.Clo
 	switch {
 	case checkoutStrat.Commit != "":
 		return g.cloneCommit(ctx, url, checkoutStrat.Commit, cloneOpts)
+	case checkoutStrat.RefName != "":
+		return g.cloneRefName(ctx, url, checkoutStrat.RefName, cloneOpts)
 	case checkoutStrat.Tag != "":
 		return g.cloneTag(ctx, url, checkoutStrat.Tag, cloneOpts)
 	case checkoutStrat.SemVer != "":

--- a/git/libgit2/client.go
+++ b/git/libgit2/client.go
@@ -193,6 +193,8 @@ func (l *Client) Clone(ctx context.Context, url string, cloneOpts repository.Clo
 	switch {
 	case checkoutStrat.Commit != "":
 		return l.cloneCommit(ctx, url, checkoutStrat.Commit, cloneOpts)
+	case checkoutStrat.RefName != "":
+		return nil, errors.New("unable to use RefName: client does not support this strategy")
 	case checkoutStrat.Tag != "":
 		return l.cloneTag(ctx, url, checkoutStrat.Tag, cloneOpts)
 	case checkoutStrat.SemVer != "":

--- a/git/repository/options.go
+++ b/git/repository/options.go
@@ -62,10 +62,16 @@ type CheckoutStrategy struct {
 	// Tag to checkout, takes precedence over Branch.
 	Tag string
 
-	// SemVer tag expression to checkout, takes precedence over Tag.
+	// SemVer tag expression to checkout, takes precedence over Branch and Tag.
 	SemVer string `json:"semver,omitempty"`
 
-	// Commit SHA1 to checkout, takes precedence over Tag and SemVer.
+	// RefName is the reference to checkout to. It must conform to the
+	// Git reference format: https://git-scm.com/book/en/v2/Git-Internals-Git-References
+	// Examples: "refs/heads/main", "refs/pull/420/head", "refs/tags/v0.1.0"
+	// It takes precedence over Branch, Tag and SemVer.
+	RefName string
+
+	// Commit SHA1 to checkout, takes precedence over all the other options.
 	// If supported by the client, it can be combined with Branch.
 	Commit string
 }


### PR DESCRIPTION
Add a new checkout strategy that enables checking out to a Git reference: https://git-scm.com/book/en/v2/Git-Internals-Git-References. This enables users to check out to a raw reference (that doesn't necessarily point to a branch/tag).

Related to: https://github.com/fluxcd/source-controller/issues/1017
Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>