### PR TITLE
ssa: make `Action` true to type

### DIFF
--- a/sourceignore/go.mod
+++ b/sourceignore/go.mod
@@ -14,6 +14,6 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	golang.org/x/net v0.2.0 // indirect
+	golang.org/x/net v0.7.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/sourceignore/go.sum
+++ b/sourceignore/go.sum
@@ -61,8 +61,8 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
-golang.org/x/net v0.2.0 h1:sZfSu1wtKLGlWI4ZZayP0ck9Y73K1ynO6gqzTdBVdPU=
-golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
+golang.org/x/net v0.7.0 h1:rJrUqqhjsgNp7KqAIc25s9pZnjU7TUcSY7HcVZjdn1g=
+golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/ssa/changeset.go
+++ b/ssa/changeset.go
@@ -27,12 +27,22 @@ import (
 // Action represents the action type performed by the reconciliation process.
 type Action string
 
+// String returns the string representation of the action.
+func (a Action) String() string {
+	return string(a)
+}
+
 const (
-	CreatedAction    Action = "created"
+	// CreatedAction represents the creation of a new object.
+	CreatedAction Action = "created"
+	// ConfiguredAction represents the update of an existing object.
 	ConfiguredAction Action = "configured"
-	UnchangedAction  Action = "unchanged"
-	DeletedAction    Action = "deleted"
-	UnknownAction    Action = "unknown"
+	// UnchangedAction represents the absence of any action to an object.
+	UnchangedAction Action = "unchanged"
+	// DeletedAction represents the deletion of an object.
+	DeletedAction Action = "deleted"
+	// UnknownAction represents an unknown action.
+	UnknownAction Action = "unknown"
 )
 
 // ChangeSet holds the result of the reconciliation of an object collection.
@@ -63,8 +73,8 @@ func (c *ChangeSet) String() string {
 	return strings.TrimSuffix(b.String(), "\n")
 }
 
-func (c *ChangeSet) ToMap() map[string]string {
-	res := make(map[string]string, len(c.Entries))
+func (c *ChangeSet) ToMap() map[string]Action {
+	res := make(map[string]Action, len(c.Entries))
 	for _, entry := range c.Entries {
 		res[entry.Subject] = entry.Action
 	}
@@ -91,7 +101,7 @@ type ChangeSetEntry struct {
 	Subject string
 
 	// Action represents the action type taken by the reconciler for this object.
-	Action string
+	Action Action
 }
 
 func (e ChangeSetEntry) String() string {

--- a/ssa/manager.go
+++ b/ssa/manager.go
@@ -77,6 +77,6 @@ func (m *ResourceManager) changeSetEntry(o *unstructured.Unstructured, action Ac
 		ObjMetadata:  object.UnstructuredToObjMetadata(o),
 		GroupVersion: o.GroupVersionKind().Version,
 		Subject:      FmtUnstructured(o),
-		Action:       string(action),
+		Action:       action,
 	}
 }

--- a/ssa/manager_apply_test.go
+++ b/ssa/manager_apply_test.go
@@ -64,7 +64,7 @@ func TestApply(t *testing.T) {
 		// verify the change set contains only created actions
 		var output []string
 		for _, entry := range changeSet.Entries {
-			if diff := cmp.Diff(entry.Action, string(CreatedAction)); diff != "" {
+			if diff := cmp.Diff(entry.Action, CreatedAction); diff != "" {
 				t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 			}
 			output = append(output, entry.Subject)
@@ -85,7 +85,7 @@ func TestApply(t *testing.T) {
 
 		// verify the change set contains only unchanged actions
 		for _, entry := range changeSet.Entries {
-			if diff := cmp.Diff(string(UnchangedAction), entry.Action); diff != "" {
+			if diff := cmp.Diff(UnchangedAction, entry.Action); diff != "" {
 				t.Errorf("Mismatch from expected value (-want +got):\n%s\n%v", diff, changeSet)
 			}
 		}
@@ -107,11 +107,11 @@ func TestApply(t *testing.T) {
 		// verify the change set contains the configured action only for the configmap
 		for _, entry := range changeSet.Entries {
 			if entry.Subject == configMapName {
-				if diff := cmp.Diff(string(ConfiguredAction), entry.Action); diff != "" {
+				if diff := cmp.Diff(ConfiguredAction, entry.Action); diff != "" {
 					t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 				}
 			} else {
-				if diff := cmp.Diff(string(UnchangedAction), entry.Action); diff != "" {
+				if diff := cmp.Diff(UnchangedAction, entry.Action); diff != "" {
 					t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 				}
 			}
@@ -189,11 +189,11 @@ func TestApply_Force(t *testing.T) {
 		// verify the secret was recreated
 		for _, entry := range changeSet.Entries {
 			if entry.Subject == secretName {
-				if diff := cmp.Diff(string(CreatedAction), entry.Action); diff != "" {
+				if diff := cmp.Diff(CreatedAction, entry.Action); diff != "" {
 					t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 				}
 			} else {
-				if diff := cmp.Diff(string(UnchangedAction), entry.Action); diff != "" {
+				if diff := cmp.Diff(UnchangedAction, entry.Action); diff != "" {
 					t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 				}
 			}
@@ -234,7 +234,7 @@ func TestApply_Force(t *testing.T) {
 		// verify the binding was recreated
 		for _, entry := range changeSet.Entries {
 			if entry.Subject == crbName {
-				if diff := cmp.Diff(string(CreatedAction), entry.Action); diff != "" {
+				if diff := cmp.Diff(CreatedAction, entry.Action); diff != "" {
 					t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 				}
 				break
@@ -269,7 +269,7 @@ func TestApply_Force(t *testing.T) {
 		// verify the storage class was recreated
 		for _, entry := range changeSet.Entries {
 			if entry.Subject == stName {
-				if diff := cmp.Diff(string(CreatedAction), entry.Action); diff != "" {
+				if diff := cmp.Diff(CreatedAction, entry.Action); diff != "" {
 					t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 				}
 				break
@@ -337,7 +337,7 @@ func TestApply_NoOp(t *testing.T) {
 		}
 
 		for _, entry := range changeSet.Entries {
-			if entry.Action != string(UnchangedAction) {
+			if entry.Action != UnchangedAction {
 				t.Errorf("Diff found for %s", entry.String())
 			}
 		}
@@ -397,7 +397,7 @@ func TestApply_Exclusions(t *testing.T) {
 		}
 
 		for _, entry := range changeSet.Entries {
-			if entry.Action != string(UnchangedAction) {
+			if entry.Action != UnchangedAction {
 				t.Errorf("Diff found for %s", entry.String())
 			}
 		}
@@ -411,7 +411,7 @@ func TestApply_Exclusions(t *testing.T) {
 		}
 
 		for _, entry := range changeSet.Entries {
-			if entry.Action != string(ConfiguredAction) && entry.Subject == FmtUnstructured(configMap) {
+			if entry.Action != ConfiguredAction && entry.Subject == FmtUnstructured(configMap) {
 				t.Errorf("Expected %s, got %s", ConfiguredAction, entry.Action)
 			}
 		}
@@ -430,7 +430,7 @@ func TestApply_Exclusions(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if changeSet.Action != string(UnchangedAction) {
+		if changeSet.Action != UnchangedAction {
 			t.Errorf("Diff found for %s", changeSet.String())
 		}
 	})
@@ -494,7 +494,7 @@ func TestApply_Cleanup(t *testing.T) {
 		}
 
 		for _, entry := range changeSet.Entries {
-			if diff := cmp.Diff(string(ConfiguredAction), entry.Action); diff != "" {
+			if diff := cmp.Diff(ConfiguredAction, entry.Action); diff != "" {
 				t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 			}
 		}
@@ -542,7 +542,7 @@ func TestApply_Cleanup(t *testing.T) {
 		}
 
 		for _, entry := range changeSet.Entries {
-			if diff := cmp.Diff(string(ConfiguredAction), entry.Action); diff != "" {
+			if diff := cmp.Diff(ConfiguredAction, entry.Action); diff != "" {
 				t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 			}
 		}
@@ -751,7 +751,7 @@ func TestApply_Cleanup_Exclusions(t *testing.T) {
 		}
 
 		for _, entry := range changeSet.Entries {
-			if diff := cmp.Diff(string(ConfiguredAction), entry.Action); diff != "" {
+			if diff := cmp.Diff(ConfiguredAction, entry.Action); diff != "" {
 				t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 			}
 		}

--- a/ssa/manager_delete_test.go
+++ b/ssa/manager_delete_test.go
@@ -66,7 +66,7 @@ func TestDelete(t *testing.T) {
 		// verify the change set contains only created actions
 		var output []string
 		for _, entry := range changeSet.Entries {
-			if diff := cmp.Diff(entry.Action, string(DeletedAction)); diff != "" {
+			if diff := cmp.Diff(entry.Action, DeletedAction); diff != "" {
 				t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 			}
 			output = append(output, entry.Subject)
@@ -151,7 +151,7 @@ func TestDelete_Exclusions(t *testing.T) {
 		}
 
 		for _, entry := range changeSet.Entries {
-			if entry.Action != string(UnchangedAction) && entry.Subject == FmtUnstructured(configMap) {
+			if entry.Action != UnchangedAction && entry.Subject == FmtUnstructured(configMap) {
 				t.Errorf("Expected %s, got %s", UnchangedAction, entry.Action)
 			}
 		}

--- a/ssa/manager_diff_test.go
+++ b/ssa/manager_diff_test.go
@@ -59,7 +59,7 @@ func TestDiff(t *testing.T) {
 			t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(string(UnchangedAction), changeSetEntry.Action); diff != "" {
+		if diff := cmp.Diff(UnchangedAction, changeSetEntry.Action); diff != "" {
 			t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 		}
 	})
@@ -76,7 +76,7 @@ func TestDiff(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if diff := cmp.Diff(string(ConfiguredAction), changeSetEntry.Action); diff != "" {
+		if diff := cmp.Diff(ConfiguredAction, changeSetEntry.Action); diff != "" {
 			t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 		}
 
@@ -191,7 +191,7 @@ func TestDiff_Removals(t *testing.T) {
 			t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(string(UnchangedAction), changeSetEntry.Action); diff != "" {
+		if diff := cmp.Diff(UnchangedAction, changeSetEntry.Action); diff != "" {
 			t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 		}
 
@@ -214,7 +214,7 @@ func TestDiff_Removals(t *testing.T) {
 
 		mergedObjYaml, _ := yaml.Marshal(mergedObj)
 
-		if diff := cmp.Diff(string(ConfiguredAction), changeSetEntry.Action); diff != "" {
+		if diff := cmp.Diff(ConfiguredAction, changeSetEntry.Action); diff != "" {
 			t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 		}
 
@@ -235,7 +235,7 @@ func TestDiff_Removals(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if diff := cmp.Diff(string(ConfiguredAction), changeSetEntry.Action); diff != "" {
+		if diff := cmp.Diff(ConfiguredAction, changeSetEntry.Action); diff != "" {
 			t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 		}
 
@@ -274,7 +274,7 @@ func TestDiffHPA(t *testing.T) {
 			t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(string(UnchangedAction), changeSetEntry.Action); diff != "" {
+		if diff := cmp.Diff(UnchangedAction, changeSetEntry.Action); diff != "" {
 			t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 		}
 	})
@@ -295,7 +295,7 @@ func TestDiffHPA(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if diff := cmp.Diff(string(ConfiguredAction), changeSetEntry.Action); diff != "" {
+		if diff := cmp.Diff(ConfiguredAction, changeSetEntry.Action); diff != "" {
 			t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 		}
 
@@ -310,7 +310,7 @@ func TestDiffHPA(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if diff := cmp.Diff(string(UnchangedAction), changeSetEntry.Action); diff != "" {
+		if diff := cmp.Diff(UnchangedAction, changeSetEntry.Action); diff != "" {
 			t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 		}
 	})
@@ -326,7 +326,7 @@ func TestDiffHPA(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if diff := cmp.Diff(string(ConfiguredAction), changeSetEntry.Action); diff != "" {
+		if diff := cmp.Diff(ConfiguredAction, changeSetEntry.Action); diff != "" {
 			t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 		}
 


### PR DESCRIPTION
This makes the Action type a first-class citizen, over casting it to a string. Resolving a whole lot of annoyances while working with the change set when determining if something equals to (the string representation of).