### PR TITLE
Change `all` target to run only `tidy|generate|fmt|vet`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Run tests
         env:
           SKIP_COSIGN_VERIFICATION: true
-        run: make all
+        run: make test
       - name: Check if working tree is dirty
         run: |
           if [[ $(git diff --stat) != '' ]]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ meeting](https://docs.google.com/document/d/1l_M0om0qUEN_NNiGgpqJ2tvsF2iioHkaARD
 You can run the unit tests by simply doing
 
 ```bash
-make all
+make test
 ```
 
 ## Acceptance policy

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,7 @@ ENVTEST_ARCH ?= amd64
 # Kubernetes versions to use envtest with
 ENVTEST_KUBERNETES_VERSION?=1.26
 
-all:
-	$(MAKE) $(addprefix test-, $(MODULES))
+all: tidy generate fmt vet
 
 tidy:
 	$(MAKE) $(addprefix tidy-, $(MODULES))
@@ -43,9 +42,18 @@ vet-%:
 	cd $(subst :,/,$*); go vet ./... ;\
 
 
+# Run generate for all modules
+generate:
+	$(MAKE) $(addprefix generate-, $(MODULES))
+
+# Generate manifests e.g. CRD, RBAC etc.
 generate-%: controller-gen
 	cd $(subst :,/,$*); CGO_ENABLED=0 $(CONTROLLER_GEN) schemapatch:manifests="./" paths="./..." ;\
 	CGO_ENABLED=0 $(CONTROLLER_GEN) object:headerFile="$(root_dir)/hack/boilerplate.go.txt" paths="./..." ;\
+
+# Run tests for all modules
+test:
+	$(MAKE) $(addprefix test-, $(MODULES))
 
 # Run tests
 KUBEBUILDER_ASSETS?="$(shell $(ENVTEST) --arch=$(ENVTEST_ARCH) use -i $(ENVTEST_KUBERNETES_VERSION) --bin-dir=$(ENVTEST_ASSETS_DIR) -p path)"


### PR DESCRIPTION
This is much cheaper than running all `test-%` variants, which can now be triggered using `make test`.

It wil also help speeding up the extremely slow CodeQL workflow, which at present runs the whole test suite without it being strictly required. Due to the behavior of the Autobuild step described in https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages#go