### PR TITLE
ssa: Add `skipped` action to report ignored resources

### DIFF
--- a/ssa/changeset.go
+++ b/ssa/changeset.go
@@ -41,6 +41,9 @@ const (
 	UnchangedAction Action = "unchanged"
 	// DeletedAction represents the deletion of an object.
 	DeletedAction Action = "deleted"
+	// SkippedAction represents the fact that no action was performed on an object
+	// due to the object being excluded from the reconciliation.
+	SkippedAction Action = "skipped"
 	// UnknownAction represents an unknown action.
 	UnknownAction Action = "unknown"
 )

--- a/ssa/manager_apply.go
+++ b/ssa/manager_apply.go
@@ -83,7 +83,7 @@ func (m *ResourceManager) Apply(ctx context.Context, object *unstructured.Unstru
 	_ = m.client.Get(ctx, client.ObjectKeyFromObject(object), existingObject)
 
 	if m.shouldSkipApply(object, existingObject, opts) {
-		return m.changeSetEntry(object, UnchangedAction), nil
+		return m.changeSetEntry(object, SkippedAction), nil
 	}
 
 	dryRunObject := object.DeepCopy()
@@ -133,7 +133,7 @@ func (m *ResourceManager) ApplyAll(ctx context.Context, objects []*unstructured.
 		_ = m.client.Get(ctx, client.ObjectKeyFromObject(object), existingObject)
 
 		if m.shouldSkipApply(object, existingObject, opts) {
-			changeSet.Add(*m.changeSetEntry(existingObject, UnchangedAction))
+			changeSet.Add(*m.changeSetEntry(existingObject, SkippedAction))
 			continue
 		}
 

--- a/ssa/manager_apply_test.go
+++ b/ssa/manager_apply_test.go
@@ -397,7 +397,7 @@ func TestApply_Exclusions(t *testing.T) {
 		}
 
 		for _, entry := range changeSet.Entries {
-			if entry.Action != UnchangedAction {
+			if entry.Action == ConfiguredAction {
 				t.Errorf("Diff found for %s", entry.String())
 			}
 		}

--- a/ssa/manager_delete.go
+++ b/ssa/manager_delete.go
@@ -78,11 +78,11 @@ func (m *ResourceManager) Delete(ctx context.Context, object *unstructured.Unstr
 	}
 
 	if !sel.Matches(labels.Set(existingObject.GetLabels())) {
-		return m.changeSetEntry(object, UnchangedAction), nil
+		return m.changeSetEntry(object, SkippedAction), nil
 	}
 
 	if AnyInMetadata(existingObject, opts.Exclusions) {
-		return m.changeSetEntry(object, UnchangedAction), nil
+		return m.changeSetEntry(object, SkippedAction), nil
 	}
 
 	if err := m.client.Delete(ctx, existingObject, client.PropagationPolicy(opts.PropagationPolicy)); err != nil {

--- a/ssa/manager_delete_test.go
+++ b/ssa/manager_delete_test.go
@@ -151,8 +151,8 @@ func TestDelete_Exclusions(t *testing.T) {
 		}
 
 		for _, entry := range changeSet.Entries {
-			if entry.Action != UnchangedAction && entry.Subject == FmtUnstructured(configMap) {
-				t.Errorf("Expected %s, got %s", UnchangedAction, entry.Action)
+			if entry.Action != SkippedAction && entry.Subject == FmtUnstructured(configMap) {
+				t.Errorf("Expected %s, got %s", SkippedAction, entry.Action)
 			}
 		}
 


### PR DESCRIPTION
Instead of reporting `unchanged` for objects which have the reconciliation disabled, we now mark these objects as `skipped`. 

Ref: https://github.com/fluxcd/kustomize-controller/issues/794