### PR TITLE
git: add support for showing full references

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -90,12 +90,23 @@ type Commit struct {
 }
 
 // String returns a string representation of the Commit, composed
-// out the last part of the Reference element, and/or Hash.
-// For example: 'tag-1/a0c14dc8580a23f79bc654faa79c4f62b46c2c22',
-// for a "tag-1" tag.
+// out of the last part of the Reference element (if not empty) and Hash.
+// For example: 'tag-1@sha1:a0c14dc8580a23f79bc654faa79c4f62b46c2c22',
+// for a "refs/tags/tag-1" Reference.
 func (c *Commit) String() string {
 	if short := strings.SplitAfterN(c.Reference, "/", 3); len(short) == 3 {
 		return fmt.Sprintf("%s@%s", short[2], c.Hash.Digest())
+	}
+	return c.Hash.Digest()
+}
+
+// AbsoluteReference returns a string representation of the Commit, composed
+// out of the Reference element (if not empty) and Hash.
+// For example: 'refs/tags/tag-1@sha1:a0c14dc8580a23f79bc654faa79c4f62b46c2c22'
+// for a "refs/tags/tag-1" Reference.
+func (c *Commit) AbsoluteReference() string {
+	if c.Reference != "" {
+		return fmt.Sprintf("%s@%s", c.Reference, c.Hash.Digest())
 	}
 	return c.Hash.Digest()
 }

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -235,6 +235,37 @@ func TestCommit_String(t *testing.T) {
 	}
 }
 
+func TestCommit_AbsoluteReference(t *testing.T) {
+	tests := []struct {
+		name   string
+		commit *Commit
+		want   string
+	}{
+		{
+			name: "Reference and commit",
+			commit: &Commit{
+				Hash:      []byte("5394cb7f48332b2de7c17dd8b8384bbc84b7e738"),
+				Reference: "refs/heads/main",
+			},
+			want: "refs/heads/main@sha1:5394cb7f48332b2de7c17dd8b8384bbc84b7e738",
+		},
+		{
+			name: "No name reference",
+			commit: &Commit{
+				Hash: []byte("5394cb7f48332b2de7c17dd8b8384bbc84b7e738"),
+			},
+			want: "sha1:5394cb7f48332b2de7c17dd8b8384bbc84b7e738",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(tt.commit.AbsoluteReference()).To(Equal(tt.want))
+		})
+	}
+}
+
 func TestCommit_Verify(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/git/gogit/clone_test.go
+++ b/git/gogit/clone_test.go
@@ -561,36 +561,36 @@ func TestClone_cloneRefName(t *testing.T) {
 			name:                   "ref name pointing to a branch",
 			refName:                "refs/heads/master",
 			filesCreated:           map[string]string{"foo.txt": "test file\n"},
-			expectedCommit:         git.Hash(head.Hash().String()).Digest(),
+			expectedCommit:         head.Hash().String(),
 			expectedConcreteCommit: true,
 		},
 		{
 			name:                   "skip clone if LastRevision is unchanged",
 			refName:                "refs/heads/master",
-			lastRevision:           git.Hash(head.Hash().String()).Digest(),
-			expectedCommit:         git.Hash(head.Hash().String()).Digest(),
+			lastRevision:           "refs/heads/master" + "@" + git.HashTypeSHA1 + ":" + head.Hash().String(),
+			expectedCommit:         head.Hash().String(),
 			expectedConcreteCommit: false,
 		},
 		{
 			name:                   "skip clone if LastRevision is unchanged even if the reference changes",
 			refName:                "refs/heads/test",
-			lastRevision:           git.Hash(head.Hash().String()).Digest(),
-			expectedCommit:         git.Hash(head.Hash().String()).Digest(),
+			lastRevision:           "refs/heads/test" + "@" + git.HashTypeSHA1 + ":" + head.Hash().String(),
+			expectedCommit:         head.Hash().String(),
 			expectedConcreteCommit: false,
 		},
 		{
 			name:                   "ref name pointing to a tag",
 			refName:                "refs/tags/v0.1.0",
 			filesCreated:           map[string]string{"bar.txt": "this is the way"},
-			lastRevision:           git.Hash(head.Hash().String()).Digest(),
-			expectedCommit:         git.Hash(hash.String()).Digest(),
+			lastRevision:           "refs/heads/test" + "@" + git.HashTypeSHA1 + ":" + head.Hash().String(),
+			expectedCommit:         hash.String(),
 			expectedConcreteCommit: true,
 		},
 		{
 			name:                   "ref name pointing to a pull request",
 			refName:                "refs/pull/1/head",
 			filesCreated:           map[string]string{"bar.txt": "this is the way"},
-			expectedCommit:         git.Hash(hash.String()).Digest(),
+			expectedCommit:         hash.String(),
 			expectedConcreteCommit: true,
 		},
 		{
@@ -622,7 +622,7 @@ func TestClone_cloneRefName(t *testing.T) {
 			}
 
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(cc.String()).To(Equal(tt.expectedCommit))
+			g.Expect(cc.AbsoluteReference()).To(Equal(tt.refName + "@" + git.HashTypeSHA1 + ":" + tt.expectedCommit))
 			g.Expect(git.IsConcreteCommit(*cc)).To(Equal(tt.expectedConcreteCommit))
 
 			for k, v := range tt.filesCreated {
@@ -1128,7 +1128,7 @@ func Test_getRemoteHEAD(t *testing.T) {
 	ref := plumbing.NewBranchReferenceName(git.DefaultBranch)
 	head, err := getRemoteHEAD(context.TODO(), path, ref, &git.AuthOptions{}, nil)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(head).To(Equal(fmt.Sprintf("%s@%s", git.DefaultBranch, git.Hash(cc.String()).Digest())))
+	g.Expect(head).To(Equal(fmt.Sprintf("refs/heads/%s@%s", git.DefaultBranch, git.Hash(cc.String()).Digest())))
 
 	cc, err = commitFile(repo, "test", "testing current head tag", time.Now())
 	g.Expect(err).ToNot(HaveOccurred())
@@ -1138,7 +1138,7 @@ func Test_getRemoteHEAD(t *testing.T) {
 	ref = plumbing.NewTagReferenceName("v0.1.0")
 	head, err = getRemoteHEAD(context.TODO(), path, ref, &git.AuthOptions{}, nil)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(head).To(Equal(fmt.Sprintf("%s@%s", "v0.1.0", git.Hash(cc.String()).Digest())))
+	g.Expect(head).To(Equal(fmt.Sprintf("refs/tags/%s@%s", "v0.1.0", git.Hash(cc.String()).Digest())))
 
 	ref = plumbing.ReferenceName("/refs/heads/main")
 	head, err = getRemoteHEAD(context.TODO(), path, ref, &git.AuthOptions{}, nil)

--- a/git/utils_test.go
+++ b/git/utils_test.go
@@ -117,6 +117,12 @@ func TestSplitRevision(t *testing.T) {
 			wantHash:    Hash("5394cb7f48332b2de7c17dd8b8384bbc84b7e738"),
 		},
 		{
+			name:        "revision with reference name and digest",
+			rev:         "refs/pull/420/head@sha1:5394cb7f48332b2de7c17dd8b8384bbc84b7e738",
+			wantPointer: "refs/pull/420/head",
+			wantHash:    Hash("5394cb7f48332b2de7c17dd8b8384bbc84b7e738"),
+		},
+		{
 			name:     "revision with digest",
 			rev:      "sha1:5394cb7f48332b2de7c17dd8b8384bbc84b7e738",
 			wantHash: Hash("5394cb7f48332b2de7c17dd8b8384bbc84b7e738"),
@@ -168,6 +174,11 @@ func TestExtractNamedPointerFromRevision(t *testing.T) {
 			want: "main",
 		},
 		{
+			name: "revision with ref name and digest",
+			rev:  "refs/merge-request/1/head@sha1:5394cb7f48332b2de7c17dd8b8384bbc84b7e738",
+			want: "refs/merge-request/1/head",
+		},
+		{
 			name: "revision with digest",
 			rev:  "sha1:5394cb7f48332b2de7c17dd8b8384bbc84b7e738",
 			want: "",
@@ -216,6 +227,11 @@ func TestExtractHashFromRevision(t *testing.T) {
 		{
 			name: "revision with branch and digest",
 			rev:  "main@sha1:5394cb7f48332b2de7c17dd8b8384bbc84b7e738",
+			want: Hash("5394cb7f48332b2de7c17dd8b8384bbc84b7e738"),
+		},
+		{
+			name: "revision with ref name and digest",
+			rev:  "refs/pull/1/head@sha1:5394cb7f48332b2de7c17dd8b8384bbc84b7e738",
 			want: Hash("5394cb7f48332b2de7c17dd8b8384bbc84b7e738"),
 		},
 		{


### PR DESCRIPTION
Add a new method `AbsoluteReference()` to show the full reference along
with the hash of a commit object. Refactor logic related to
`LastObservedCommit` in order for it to work with full references when
required.

Fixes: #476 