### PR TITLE
runtime/events: change log level to trace

### DIFF
--- a/runtime/events/recorder.go
+++ b/runtime/events/recorder.go
@@ -130,8 +130,8 @@ func (r *Recorder) AnnotatedEventf(
 	// Add object info in the logger.
 	log := r.Log.WithValues("name", ref.Name, "namespace", ref.Namespace, "reconciler kind", ref.Kind)
 
-	// Log the event if in debug mode.
-	if log.GetSink().Enabled(logger.DebugLevel) {
+	// Log the event if in trace mode.
+	if log.GetSink().Enabled(logger.TraceLevel) {
 		msg := fmt.Sprintf(messageFmt, args...)
 		if eventtype == corev1.EventTypeWarning {
 			log.Error(errors.New(reason), msg, "annotations", annotations)


### PR DESCRIPTION
This commit changes the log level of the event recorder to `trace`, reduing the noise one may receive while running a controller with log level set to `debug` (to get a more extensive insight into what a controller reports, but not as in-depth as `trace`).

This seems a more appropriate level, given the controller often emits a variation of the information pushed in an event by itself on log level `info`, and the knowledge about emitted events likely only has value when deeply looking into the behavior of the application.