### PR TITLE
oci: Allow setting custom annotations on artifacts

### DIFF
--- a/oci/client/meta.go
+++ b/oci/client/meta.go
@@ -25,11 +25,12 @@ import (
 // Metadata holds the upstream information about on artifact's source.
 // https://github.com/opencontainers/image-spec/blob/main/annotations.md
 type Metadata struct {
-	Created  string `json:"created"`
-	Source   string `json:"source_url"`
-	Revision string `json:"source_revision"`
-	Digest   string `json:"digest"`
-	URL      string `json:"url"`
+	Created     string            `json:"created"`
+	Source      string            `json:"source_url"`
+	Revision    string            `json:"source_revision"`
+	Digest      string            `json:"digest"`
+	URL         string            `json:"url"`
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // ToAnnotations returns the OpenContainers annotations map.
@@ -38,6 +39,10 @@ func (m *Metadata) ToAnnotations() map[string]string {
 		oci.CreatedAnnotation:  m.Created,
 		oci.SourceAnnotation:   m.Source,
 		oci.RevisionAnnotation: m.Revision,
+	}
+
+	for k, v := range m.Annotations {
+		annotations[k] = v
 	}
 
 	return annotations
@@ -61,9 +66,10 @@ func MetadataFromAnnotations(annotations map[string]string) (*Metadata, error) {
 	}
 
 	m := Metadata{
-		Created:  created,
-		Source:   source,
-		Revision: revision,
+		Created:     created,
+		Source:      source,
+		Revision:    revision,
+		Annotations: annotations,
 	}
 
 	return &m, nil

--- a/oci/client/push_pull_test.go
+++ b/oci/client/push_pull_test.go
@@ -46,6 +46,10 @@ func Test_Push_Pull(t *testing.T) {
 	metadata := Metadata{
 		Source:   source,
 		Revision: revision,
+		Annotations: map[string]string{
+			"org.opencontainers.image.documentation": "https://my/readme.md",
+			"org.opencontainers.image.licenses":      "Apache-2.0",
+		},
 	}
 
 	// Build and push the artifact to registry
@@ -80,8 +84,12 @@ func Test_Push_Pull(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Pull the artifact from registry and extract its contents to tmp
-	_, err = c.Pull(ctx, url, tmpDir)
+	meta, err := c.Pull(ctx, url, tmpDir)
 	g.Expect(err).ToNot(HaveOccurred())
+
+	// Verify custom annotations
+	g.Expect(meta.Annotations["org.opencontainers.image.documentation"]).To(BeEquivalentTo("https://my/readme.md"))
+	g.Expect(meta.Annotations["org.opencontainers.image.licenses"]).To(BeEquivalentTo("Apache-2.0"))
 
 	// Walk the test directory and check that all files exist in the pulled artifact
 	fsErr := filepath.Walk(testDir, func(path string, info fs.FileInfo, err error) error {


### PR DESCRIPTION
This feature will enable us to make the Flux artifacts conform to ArtifactHub which requires extra annotations for advertising the artifact license, documentation, etc.