### PR TITLE
runtime/reconcile: Fix Ready check in Finalizer

### DIFF
--- a/runtime/reconcile/result.go
+++ b/runtime/reconcile/result.go
@@ -134,7 +134,7 @@ func (rs ResultFinalizer) Finalize(obj conditions.Setter, res ctrl.Result, recEr
 	// Ready=False with the reconcile error. If Ready is already False with a
 	// reason, preserve the value.
 	if recErr != nil {
-		if conditions.IsUnknown(obj, meta.ReadyCondition) || conditions.IsReady(obj) {
+		if conditions.IsUnknown(obj, meta.ReadyCondition) || conditions.IsTrue(obj, meta.ReadyCondition) {
 			conditions.MarkFalse(obj, meta.ReadyCondition, meta.FailedReason, recErr.Error())
 		}
 	}

--- a/runtime/reconcile/result_test.go
+++ b/runtime/reconcile/result_test.go
@@ -171,6 +171,20 @@ func TestResultFinalizer(t *testing.T) {
 			},
 		},
 		{
+			name: "result with error, ready and reconciling, change to not ready",
+			beforeFunc: func(obj conditions.Setter) {
+				conditions.MarkReconciling(obj, "SomeReasonX", "some msg X")
+				conditions.MarkTrue(obj, meta.ReadyCondition, "SomeReasonY", "some msg Y")
+			},
+			result:  resultFailed,
+			recErr:  errors.New("foo failed"),
+			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.FalseCondition(meta.ReadyCondition, meta.FailedReason, "foo failed"),
+				*conditions.TrueCondition(meta.ReconcilingCondition, "SomeReasonX", "some msg X"),
+			},
+		},
+		{
 			name: "stalled and reconciling, Ready=False, remove reconciling, retain ready",
 			beforeFunc: func(obj conditions.Setter) {
 				conditions.MarkTrue(obj, meta.ReconcilingCondition, "SomeReasonX", "some msg X")


### PR DESCRIPTION
Fix the Ready condition check in the ResultFinalizer. `IsReady()` takes into account the Reconciling and Stalling conditons too. Use `IsTrue()` to precisely check if Ready=True.

This ensures that Ready=True is toggled when there's a reconciliation error in presence or other negative conditions.

This is needed to fix the issue in https://github.com/fluxcd/image-reflector-controller/issues/356.