### PR TITLE
sourceignore: make a copy of domain for pattern

### DIFF
--- a/sourceignore/sourceignore.go
+++ b/sourceignore/sourceignore.go
@@ -103,7 +103,12 @@ func ReadIgnoreFile(path string, domain []string) ([]gitignore.Pattern, error) {
 // LoadIgnorePatterns recursively loads the IgnoreFile patterns found
 // in the directory.
 func LoadIgnorePatterns(dir string, domain []string) ([]gitignore.Pattern, error) {
-	ps, err := ReadIgnoreFile(filepath.Join(dir, IgnoreFile), domain)
+	// Make a copy of the domain so that the underlying string array of domain
+	// in the gitignore patterns are unique without any side effects.
+	dom := make([]string, len(domain))
+	copy(dom, domain)
+
+	ps, err := ReadIgnoreFile(filepath.Join(dir, IgnoreFile), dom)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +119,7 @@ func LoadIgnorePatterns(dir string, domain []string) ([]gitignore.Pattern, error
 	for _, fi := range fis {
 		if fi.IsDir() && fi.Name() != ".git" {
 			var subps []gitignore.Pattern
-			if subps, err = LoadIgnorePatterns(filepath.Join(dir, fi.Name()), append(domain, fi.Name())); err != nil {
+			if subps, err = LoadIgnorePatterns(filepath.Join(dir, fi.Name()), append(dom, fi.Name())); err != nil {
 				return nil, err
 			}
 			if len(subps) > 0 {

--- a/sourceignore/sourceignore_test.go
+++ b/sourceignore/sourceignore_test.go
@@ -203,6 +203,8 @@ func TestLoadExcludePatterns(t *testing.T) {
 		"d/.gitignore":      "ignored",
 		"z/.sourceignore":   "last.txt",
 		"a/b/.sourceignore": "subdir.txt",
+		"e/last.txt":        "foo",
+		"a/c/subdir.txt":    "bar",
 	}
 	for n, c := range files {
 		if err := os.MkdirAll(filepath.Join(tmpDir, filepath.Dir(n)), 0o750); err != nil {
@@ -222,7 +224,7 @@ func TestLoadExcludePatterns(t *testing.T) {
 			name: "traverse loads",
 			dir:  tmpDir,
 			want: []gitignore.Pattern{
-				gitignore.ParsePattern("root.txt", nil),
+				gitignore.ParsePattern("root.txt", []string{}),
 				gitignore.ParsePattern("subdir.txt", []string{"a", "b"}),
 				gitignore.ParsePattern("last.txt", []string{"z"}),
 			},


### PR DESCRIPTION
`LoadIgnorePatterns()` modified the domain string slice after creating ignore pattern, due to which the domain of certain patterns created below the first directory level with multiple directories at the same level resulted in the patterns to have the domain of the last directory in the same directory level.

This is fixed by making a copy of the domain before creating a pattern.

Refer https://yourbasic.org/golang/gotcha-append/ for details about this side effect of appending slices.

Refer https://github.com/hiddeco/proof/tree/different-tree for an example repository to reproduce this issue.
`podinfo2/.sourceignore` contains `*`.

Without the fix, the artifact contains
```
flux
flux/apps
flux/apps/staging
flux/apps/staging/tests
flux/apps/staging/tests/podinfo1
flux/apps/staging/tests/podinfo1/podinfo-deploy.yaml
flux/apps/staging/tests/podinfo2
flux/apps/staging/tests/podinfo2/.sourceignore
flux/apps/staging/tests/podinfo2/podinfo-deploy.yaml
flux/apps/staging/tests/podinfo3
```
With the fix, the artifact contains
```
flux
flux/apps
flux/apps/staging
flux/apps/staging/tests
flux/apps/staging/tests/podinfo1
flux/apps/staging/tests/podinfo1/podinfo-deploy.yaml
flux/apps/staging/tests/podinfo2
flux/apps/staging/tests/podinfo3
flux/apps/staging/tests/podinfo3/podinfo-deploy.yaml

```