### PR TITLE
runtime/patch: increase (extended) timeout tests

### DIFF
--- a/runtime/patch/suite_test.go
+++ b/runtime/patch/suite_test.go
@@ -32,8 +32,8 @@ import (
 )
 
 const (
-	timeout         = time.Second * 10
-	extendedTimeout = time.Second * 15
+	timeout         = time.Second * 20
+	extendedTimeout = timeout * 2
 )
 
 var (


### PR DESCRIPTION
Once in awhile the tests appear to fail on this because it appears to take a little longer than the current configurations. Slightly increase both, to hopefully deal with it for good.

- https://github.com/fluxcd/pkg/actions/runs/4530985720/jobs/7980583099
- https://github.com/fluxcd/pkg/actions/runs/4500139007/jobs/7918873957
- https://github.com/fluxcd/pkg/actions/runs/4500711383/jobs/7920192543