### PR TITLE
oci/client: Configureable retry backoff

### DIFF
--- a/oci/client/build_test.go
+++ b/oci/client/build_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestBuild(t *testing.T) {
 	g := NewWithT(t)
-	c := NewLocalClient()
+	c := NewClient(DefaultOptions())
 
 	absPath := fmt.Sprintf("%s/deployment.yaml", t.TempDir())
 	err := copyFile(absPath, "testdata/artifact/deployment.yaml")

--- a/oci/client/client.go
+++ b/oci/client/client.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	"github.com/fluxcd/pkg/oci"
 )
@@ -40,17 +41,16 @@ func NewClient(opts []crane.Option) *Client {
 	return &Client{options: options}
 }
 
-// NewLocalClient returns an OCI client configured with the Docker keychain helpers.
-func NewLocalClient() *Client {
-	options := []crane.Option{
-		crane.WithUserAgent(oci.UserAgent),
+// DefaultOptions returns an array containing crane.WithPlatform
+// to set the platform to flux.
+func DefaultOptions() []crane.Option {
+	return []crane.Option{
 		crane.WithPlatform(&gcrv1.Platform{
 			Architecture: "flux",
 			OS:           "flux",
 			OSVersion:    "v2",
 		}),
 	}
-	return &Client{options: options}
 }
 
 // GetOptions returns the list of crane.Option used by this Client.
@@ -64,4 +64,11 @@ func (c *Client) optionsWithContext(ctx context.Context) []crane.Option {
 		crane.WithContext(ctx),
 	}
 	return append(options, c.options...)
+}
+
+// WithRetryBackOff returns a function for setting the given backoff on crane.Option.
+func WithRetryBackOff(backoff remote.Backoff) crane.Option {
+	return func(options *crane.Options) {
+		options.Remote = append(options.Remote, remote.WithRetryBackoff(backoff))
+	}
 }

--- a/oci/client/delete_test.go
+++ b/oci/client/delete_test.go
@@ -31,7 +31,7 @@ import (
 func TestDelete(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
-	c := NewLocalClient()
+	c := NewClient(DefaultOptions())
 	repo := "test-delete" + randStringRunes(5)
 	tags := []string{"v0.0.1", "v0.0.2", "v0.0.3", "latest"}
 	source := "github.com/fluxcd/fluxv2"

--- a/oci/client/diff_test.go
+++ b/oci/client/diff_test.go
@@ -30,7 +30,7 @@ import (
 func TestClient_Diff(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
-	c := NewLocalClient()
+	c := NewClient(DefaultOptions())
 	tag := "v0.0.1"
 	repo := "test-push" + randStringRunes(5)
 

--- a/oci/client/list_test.go
+++ b/oci/client/list_test.go
@@ -33,7 +33,7 @@ import (
 func Test_List(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
-	c := NewLocalClient()
+	c := NewClient(DefaultOptions())
 	repo := "test-list" + randStringRunes(5)
 	tags := []string{"v0.0.1", "v0.0.2", "v0.0.3", "v6.0.0", "v6.0.1", "v6.0.2", "v6.0.2-rc.1", "v6.0.2-alpha", "staging-fb3355b"}
 	source := "github.com/fluxcd/fluxv2"

--- a/oci/client/login_test.go
+++ b/oci/client/login_test.go
@@ -60,7 +60,7 @@ func Test_Login(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			c := NewLocalClient()
+			c := NewClient(DefaultOptions())
 			ctx := context.Background()
 			err := c.LoginWithCredentials(tt.creds)
 			g.Expect(err).ToNot(HaveOccurred())

--- a/oci/client/push_pull_test.go
+++ b/oci/client/push_pull_test.go
@@ -35,7 +35,7 @@ import (
 func Test_Push_Pull(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
-	c := NewLocalClient()
+	c := NewClient(DefaultOptions())
 	testDir := "testdata/artifact"
 	tag := "v0.0.1"
 	source := "github.com/fluxcd/flux2"

--- a/oci/client/tag_test.go
+++ b/oci/client/tag_test.go
@@ -29,7 +29,7 @@ import (
 func Test_Tag(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
-	c := NewLocalClient()
+	c := NewClient(DefaultOptions())
 	testRepo := "test-tag"
 	url := fmt.Sprintf("%s/%s:v0.0.1", dockerReg, testRepo)
 	img, err := random.Image(1024, 1)


### PR DESCRIPTION
Part of: https://github.com/fluxcd/flux2/issues/3714

This pull request adds a function to configure the retry backoff on [crane](https://github.com/google/go-containerregistry/tree/main/pkg/crane) option for different OCI operations.

It also removes the `NewLocalClient` function, adding a function `DefaultOptions` that returns an array of crane.Options that can be passed into `NewClient` to get the same result.