### PR TITLE
git: Reimplement cloneRefName using cloneTag's implementation to support annotated tags

### DIFF
--- a/git/gogit/clone_test.go
+++ b/git/gogit/clone_test.go
@@ -225,7 +225,7 @@ func TestClone_cloneTag(t *testing.T) {
 			tagsInRepo:           []testTag{{"tag-1", false}},
 			checkoutTag:          "tag-1",
 			lastRevTag:           "tag-1",
-			expectConcreteCommit: false,
+			expectConcreteCommit: true,
 		},
 		{
 			name:                 "Last revision changed",
@@ -531,9 +531,12 @@ func TestClone_cloneRefName(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	_, err = tag(repo, hash, false, "v0.1.0", time.Now())
 	g.Expect(err).ToNot(HaveOccurred())
+	_, err = tag(repo, hash, true, "annotated", time.Now())
+	g.Expect(err).ToNot(HaveOccurred())
 	err = repo.Push(&extgogit.PushOptions{
 		RefSpecs: []config.RefSpec{
 			config.RefSpec("+refs/tags/v0.1.0" + ":refs/tags/v0.1.0"),
+			config.RefSpec("+refs/tags/annotated" + ":refs/tags/annotated"),
 		},
 	})
 	g.Expect(err).ToNot(HaveOccurred())
@@ -587,6 +590,14 @@ func TestClone_cloneRefName(t *testing.T) {
 			expectedConcreteCommit: true,
 		},
 		{
+			name:                   "ref name pointing to an annotated tag",
+			refName:                "refs/tags/annotated",
+			filesCreated:           map[string]string{"bar.txt": "this is the way"},
+			lastRevision:           "refs/heads/test" + "@" + git.HashTypeSHA1 + ":" + head.Hash().String(),
+			expectedCommit:         hash.String(),
+			expectedConcreteCommit: true,
+		},
+		{
 			name:                   "ref name pointing to a pull request",
 			refName:                "refs/pull/1/head",
 			filesCreated:           map[string]string{"bar.txt": "this is the way"},
@@ -596,7 +607,7 @@ func TestClone_cloneRefName(t *testing.T) {
 		{
 			name:        "non existing ref",
 			refName:     "refs/tags/v0.2.0",
-			expectedErr: "unable to resolve ref 'refs/tags/v0.2.0' to a specific commit",
+			expectedErr: "couldn't find remote ref \"refs/tags/v0.2.0\"",
 		},
 	}
 


### PR DESCRIPTION
`cloneRefName()` failed to support annotated tags and would attempt to clone the annotated tag object's id as if it were a commit object. This would cause the following error (with the tag's hash, not the commit):
```
unable to resolve commit object for 'da39a3ee5e6b4b0d3255bfef95601890afd80709': object not found
```

`cloneTag()` already had support for annotated tags, and could actually be modified to support cloning any ref with no modification. The implementation was moved to `cloneRefName()` and now `cloneTag()` is a wrapper for `cloneRefName()`.

Sharing an implementation between `cloneRefName()` and `cloneTag()` means error messages are slightly worse: they always say "ref" now instead of "tag" when appropriate.

Due to a bug(?) in go-git a ref like `refs/pull/1/head` can't be cloned used with SingleBranch == True. Go-git's `Repository.cloneRefSpec()` will try to build a refspec using `.Short()` on the ref, which doesn't behave the same for refs named like this (that don't [match any RefRevParseRules](https://github.com/src-d/go-git/blob/v4.13.1/plumbing/reference.go#L21)).
https://github.com/src-d/go-git/blob/v4.13.1/repository.go#L826-L829

A test for `cloneRefName()` using an annotated tag was added. Arguably the tests could be merged somewhat now that they share an implementation. There is one change in the cloneTag tests for expectConcreteCommit that I don't quite understand.

There is a TODO in this code about SingleBranch. Other that, I think this approach works. I've tested using the unit tests and they pass. If you have a different approach you'd like to use to fix this, please feel free to close this PR if you want an alternate solution.