### PR TITLE
git: add support for passphrases for commit gpg signing

### DIFF
--- a/git/gogit/client.go
+++ b/git/gogit/client.go
@@ -341,6 +341,12 @@ func (g *Client) Commit(info git.Commit, commitOpts ...repository.CommitOption) 
 	}
 
 	if options.Signer != nil {
+		if options.SignerPassphrase != "" {
+			err = options.Signer.PrivateKey.Decrypt([]byte(options.SignerPassphrase))
+			if err != nil {
+				return "", fmt.Errorf("failed to decrypt PGP private key: %w", err)
+			}
+		}
 		opts.SignKey = options.Signer
 	}
 

--- a/git/gogit/go.mod
+++ b/git/gogit/go.mod
@@ -11,6 +11,7 @@ replace (
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.0
+	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/cyphar/filepath-securejoin v0.2.3
 	github.com/elazarl/goproxy v0.0.0-20221015165544-a0805db90819
@@ -28,7 +29,6 @@ require (
 
 require (
 	github.com/Microsoft/go-winio v0.6.0 // indirect
-	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/cloudflare/circl v1.3.2 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect

--- a/git/repository/options.go
+++ b/git/repository/options.go
@@ -80,6 +80,10 @@ type CheckoutStrategy struct {
 type CommitOptions struct {
 	// Signer can be used to sign a commit using OpenPGP.
 	Signer *openpgp.Entity
+	// SignerPassphrase is the passphrase to be used for decrypting
+	// the private key of the Signer. It's required if the private key
+	// is encrypted.
+	SignerPassphrase string
 	// Files contains file names mapped to the file's content.
 	// Its used to write files which are then included in the commit.
 	Files map[string]io.Reader
@@ -89,10 +93,19 @@ type CommitOptions struct {
 type CommitOption func(*CommitOptions)
 
 // WithSigner allows for the commit to be signed using the provided
-// OpenPGP signer.
+// OpenPGP signer. To specify the passphrase for the private key, please
+// see WithSignerPassphrase.
 func WithSigner(signer *openpgp.Entity) CommitOption {
 	return func(co *CommitOptions) {
 		co.Signer = signer
+	}
+}
+
+// WithSignerPassphrase is used in conjunction with WithSigner in order
+// to be able to decrypt the private key that will be used for sigining commits.
+func WithSignerPassphrase(passphrase string) CommitOption {
+	return func(co *CommitOptions) {
+		co.SignerPassphrase = passphrase
 	}
 }
 


### PR DESCRIPTION
Add a new `CommitOption` for specifying the passphrase to use for decrypting the private key of the signer which will be used for signing the commit.