### PR TITLE
ssa: remove `, error:` from wrapped error strings

### DIFF
--- a/ssa/manager_apply.go
+++ b/ssa/manager_apply.go
@@ -91,7 +91,7 @@ func (m *ResourceManager) Apply(ctx context.Context, object *unstructured.Unstru
 	if err := m.dryRunApply(ctx, dryRunObject); err != nil {
 		if !errors.IsNotFound(getError) && m.shouldForceApply(object, existingObject, opts, err) {
 			if err := m.client.Delete(ctx, existingObject); err != nil {
-				return nil, fmt.Errorf("%s immutable field detected, failed to delete object, error: %w",
+				return nil, fmt.Errorf("%s immutable field detected, failed to delete object: %w",
 					FmtUnstructured(dryRunObject), err)
 			}
 			return m.Apply(ctx, object, opts)
@@ -102,7 +102,7 @@ func (m *ResourceManager) Apply(ctx context.Context, object *unstructured.Unstru
 
 	patched, err := m.cleanupMetadata(ctx, object, existingObject, opts.Cleanup)
 	if err != nil {
-		return nil, fmt.Errorf("%s metadata.managedFields cleanup failed, error: %w",
+		return nil, fmt.Errorf("%s metadata.managedFields cleanup failed: %w",
 			FmtUnstructured(existingObject), err)
 	}
 
@@ -113,7 +113,7 @@ func (m *ResourceManager) Apply(ctx context.Context, object *unstructured.Unstru
 
 	appliedObject := object.DeepCopy()
 	if err := m.apply(ctx, appliedObject); err != nil {
-		return nil, fmt.Errorf("%s apply failed, error: %w", FmtUnstructured(appliedObject), err)
+		return nil, fmt.Errorf("%s apply failed: %w", FmtUnstructured(appliedObject), err)
 	}
 
 	if dryRunObject.GetResourceVersion() == "" {
@@ -145,7 +145,7 @@ func (m *ResourceManager) ApplyAll(ctx context.Context, objects []*unstructured.
 			// it when ApplyAll was called the last time (the check for ImmutableError returns false positives)
 			if !errors.IsNotFound(getError) && m.shouldForceApply(object, existingObject, opts, err) {
 				if err := m.client.Delete(ctx, existingObject); err != nil {
-					return nil, fmt.Errorf("%s immutable field detected, failed to delete object, error: %w",
+					return nil, fmt.Errorf("%s immutable field detected, failed to delete object: %w",
 						FmtUnstructured(dryRunObject), err)
 				}
 				return m.ApplyAll(ctx, objects, opts)
@@ -156,7 +156,7 @@ func (m *ResourceManager) ApplyAll(ctx context.Context, objects []*unstructured.
 
 		patched, err := m.cleanupMetadata(ctx, object, existingObject, opts.Cleanup)
 		if err != nil {
-			return nil, fmt.Errorf("%s metadata.managedFields cleanup failed, error: %w",
+			return nil, fmt.Errorf("%s metadata.managedFields cleanup failed: %w",
 				FmtUnstructured(existingObject), err)
 		}
 
@@ -175,7 +175,7 @@ func (m *ResourceManager) ApplyAll(ctx context.Context, objects []*unstructured.
 	for _, object := range toApply {
 		appliedObject := object.DeepCopy()
 		if err := m.apply(ctx, appliedObject); err != nil {
-			return nil, fmt.Errorf("%s apply failed, error: %w", FmtUnstructured(appliedObject), err)
+			return nil, fmt.Errorf("%s apply failed: %w", FmtUnstructured(appliedObject), err)
 		}
 	}
 

--- a/ssa/manager_delete.go
+++ b/ssa/manager_delete.go
@@ -66,7 +66,7 @@ func (m *ResourceManager) Delete(ctx context.Context, object *unstructured.Unstr
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return m.changeSetEntry(object, UnknownAction),
-				fmt.Errorf("%s query failed, error: %w", FmtUnstructured(object), err)
+				fmt.Errorf("%s query failed: %w", FmtUnstructured(object), err)
 		}
 		return m.changeSetEntry(object, DeletedAction), nil
 	}
@@ -74,7 +74,7 @@ func (m *ResourceManager) Delete(ctx context.Context, object *unstructured.Unstr
 	sel, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: opts.Inclusions})
 	if err != nil {
 		return m.changeSetEntry(object, UnknownAction),
-			fmt.Errorf("%s label selector failed, error: %w", FmtUnstructured(object), err)
+			fmt.Errorf("%s label selector failed: %w", FmtUnstructured(object), err)
 	}
 
 	if !sel.Matches(labels.Set(existingObject.GetLabels())) {
@@ -87,7 +87,7 @@ func (m *ResourceManager) Delete(ctx context.Context, object *unstructured.Unstr
 
 	if err := m.client.Delete(ctx, existingObject, client.PropagationPolicy(opts.PropagationPolicy)); err != nil {
 		return m.changeSetEntry(object, UnknownAction),
-			fmt.Errorf("%s delete failed, error: %w", FmtUnstructured(object), err)
+			fmt.Errorf("%s delete failed: %w", FmtUnstructured(object), err)
 	}
 
 	return m.changeSetEntry(object, DeletedAction), nil

--- a/ssa/manager_diff.go
+++ b/ssa/manager_diff.go
@@ -99,26 +99,26 @@ func (m *ResourceManager) Diff(ctx context.Context, object *unstructured.Unstruc
 func (m *ResourceManager) sanitizeDriftedSecrets(existingObject, dryRunObject *unstructured.Unstructured) (*unstructured.Unstructured, *unstructured.Unstructured, error) {
 	dryRunData, foundDryRun, err := getNestedMap(dryRunObject)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to get data from dry run object, error: %w", err)
+		return nil, nil, fmt.Errorf("unable to get data from dry run object: %w", err)
 	}
 
 	existingData, foundExisting, err := getNestedMap(existingObject)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to get data from existing object, error: %w", err)
+		return nil, nil, fmt.Errorf("unable to get data from existing object: %w", err)
 	}
 
 	if !foundDryRun || !foundExisting {
 		if foundDryRun {
 			d, err := maskSecret(dryRunData, dryRunObject, diffMask)
 			if err != nil {
-				return nil, nil, fmt.Errorf("masking secret data failed, error: %w", err)
+				return nil, nil, fmt.Errorf("masking secret data failed: %w", err)
 			}
 			return d, existingObject, nil
 		}
 
 		e, err := maskSecret(existingData, existingObject, diffMask)
 		if err != nil {
-			return nil, nil, fmt.Errorf("masking secret data failed, error: %w", err)
+			return nil, nil, fmt.Errorf("masking secret data failed: %w", err)
 		}
 		return dryRunObject, e, nil
 	}
@@ -128,12 +128,12 @@ func (m *ResourceManager) sanitizeDriftedSecrets(existingObject, dryRunObject *u
 
 		err := setNestedMap(dryRunObject, d)
 		if err != nil {
-			return nil, nil, fmt.Errorf("masking secret data failed, error: %w", err)
+			return nil, nil, fmt.Errorf("masking secret data failed: %w", err)
 		}
 
 		err = setNestedMap(existingObject, ex)
 		if err != nil {
-			return nil, nil, fmt.Errorf("masking secret data failed, error: %w", err)
+			return nil, nil, fmt.Errorf("masking secret data failed: %w", err)
 		}
 
 	}
@@ -182,7 +182,7 @@ func prepareObjectForDiff(object *unstructured.Unstructured) *unstructured.Unstr
 // if the error was caused by an invalid Kubernetes secrets.
 func (m *ResourceManager) validationError(object *unstructured.Unstructured, err error) error {
 	if apierrors.IsNotFound(err) {
-		return fmt.Errorf("%s namespace not specified, error: %w", FmtUnstructured(object), err)
+		return fmt.Errorf("%s namespace not specified: %w", FmtUnstructured(object), err)
 	}
 
 	reason := fmt.Sprintf("%v", apierrors.ReasonForError(err))
@@ -204,7 +204,7 @@ func (m *ResourceManager) validationError(object *unstructured.Unstructured, err
 		reason = fmt.Sprintf(", reason: %s", reason)
 	}
 
-	return fmt.Errorf("%s dry-run failed%s, error: %w",
+	return fmt.Errorf("%s dry-run failed%s: %w",
 		FmtUnstructured(object), reason, err)
 
 }

--- a/ssa/manager_wait.go
+++ b/ssa/manager_wait.go
@@ -142,7 +142,7 @@ func (m *ResourceManager) WaitForTermination(objects []*unstructured.Unstructure
 
 	for _, object := range objects {
 		if err := wait.PollImmediate(opts.Interval, opts.Timeout, m.isDeleted(ctx, object)); err != nil {
-			return fmt.Errorf("%s termination timeout, error: %w", FmtUnstructured(object), err)
+			return fmt.Errorf("%s termination timeout: %w", FmtUnstructured(object), err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Also infamously known as "un-stefan-fying".