### PR TITLE
git: add `PushConfig` to specify push config and add support for refspecs

### DIFF
--- a/git/gogit/client.go
+++ b/git/gogit/client.go
@@ -52,7 +52,6 @@ type Client struct {
 	authOpts             *git.AuthOptions
 	storer               storage.Storer
 	worktreeFS           billy.Filesystem
-	forcePush            bool
 	credentialsOverHTTP  bool
 	useDefaultKnownHosts bool
 	singleBranch         bool
@@ -144,16 +143,6 @@ func WithMemoryStorage() ClientOption {
 	return func(c *Client) error {
 		c.storer = memory.NewStorage()
 		c.worktreeFS = memfs.New()
-		return nil
-	}
-}
-
-// WithForcePush enables the use of force push for all push operations
-// back to the Git repository.
-// By default this is disabled.
-func WithForcePush() ClientOption {
-	return func(c *Client) error {
-		c.forcePush = true
 		return nil
 	}
 }
@@ -381,7 +370,7 @@ func (g *Client) Push(ctx context.Context, cfg repository.PushConfig) error {
 
 	return g.repository.PushContext(ctx, &extgogit.PushOptions{
 		RefSpecs:   refspecs,
-		Force:      g.forcePush,
+		Force:      cfg.Force,
 		RemoteName: extgogit.DefaultRemoteName,
 		Auth:       authMethod,
 		Progress:   nil,

--- a/git/gogit/client.go
+++ b/git/gogit/client.go
@@ -217,27 +217,27 @@ func (g *Client) Init(ctx context.Context, url, branch string) error {
 	return nil
 }
 
-func (g *Client) Clone(ctx context.Context, url string, cloneOpts repository.CloneOptions) (*git.Commit, error) {
+func (g *Client) Clone(ctx context.Context, url string, cfg repository.CloneConfig) (*git.Commit, error) {
 	if err := g.validateUrl(url); err != nil {
 		return nil, err
 	}
 
-	checkoutStrat := cloneOpts.CheckoutStrategy
+	checkoutStrat := cfg.CheckoutStrategy
 	switch {
 	case checkoutStrat.Commit != "":
-		return g.cloneCommit(ctx, url, checkoutStrat.Commit, cloneOpts)
+		return g.cloneCommit(ctx, url, checkoutStrat.Commit, cfg)
 	case checkoutStrat.RefName != "":
-		return g.cloneRefName(ctx, url, checkoutStrat.RefName, cloneOpts)
+		return g.cloneRefName(ctx, url, checkoutStrat.RefName, cfg)
 	case checkoutStrat.Tag != "":
-		return g.cloneTag(ctx, url, checkoutStrat.Tag, cloneOpts)
+		return g.cloneTag(ctx, url, checkoutStrat.Tag, cfg)
 	case checkoutStrat.SemVer != "":
-		return g.cloneSemVer(ctx, url, checkoutStrat.SemVer, cloneOpts)
+		return g.cloneSemVer(ctx, url, checkoutStrat.SemVer, cfg)
 	default:
 		branch := checkoutStrat.Branch
 		if branch == "" {
 			branch = git.DefaultBranch
 		}
-		return g.cloneBranch(ctx, url, branch, cloneOpts)
+		return g.cloneBranch(ctx, url, branch, cfg)
 	}
 }
 

--- a/git/gogit/clone.go
+++ b/git/gogit/clone.go
@@ -38,7 +38,7 @@ import (
 	"github.com/fluxcd/pkg/version"
 )
 
-func (g *Client) cloneBranch(ctx context.Context, url, branch string, opts repository.CloneOptions) (*git.Commit, error) {
+func (g *Client) cloneBranch(ctx context.Context, url, branch string, opts repository.CloneConfig) (*git.Commit, error) {
 	if g.authOpts == nil {
 		return nil, fmt.Errorf("unable to checkout repo with an empty set of auth options")
 	}
@@ -119,7 +119,7 @@ func (g *Client) cloneBranch(ctx context.Context, url, branch string, opts repos
 	return buildCommitWithRef(cc, ref)
 }
 
-func (g *Client) cloneTag(ctx context.Context, url, tag string, opts repository.CloneOptions) (*git.Commit, error) {
+func (g *Client) cloneTag(ctx context.Context, url, tag string, opts repository.CloneConfig) (*git.Commit, error) {
 	if g.authOpts == nil {
 		return nil, fmt.Errorf("unable to checkout repo with an empty set of auth options")
 	}
@@ -189,7 +189,7 @@ func (g *Client) cloneTag(ctx context.Context, url, tag string, opts repository.
 	return buildCommitWithRef(cc, ref)
 }
 
-func (g *Client) cloneCommit(ctx context.Context, url, commit string, opts repository.CloneOptions) (*git.Commit, error) {
+func (g *Client) cloneCommit(ctx context.Context, url, commit string, opts repository.CloneConfig) (*git.Commit, error) {
 	authMethod, err := transportAuth(g.authOpts, g.useDefaultKnownHosts)
 	if err != nil {
 		return nil, fmt.Errorf("unable to construct auth method with options: %w", err)
@@ -244,7 +244,7 @@ func (g *Client) cloneCommit(ctx context.Context, url, commit string, opts repos
 	return buildCommitWithRef(cc, cloneOpts.ReferenceName)
 }
 
-func (g *Client) cloneSemVer(ctx context.Context, url, semverTag string, opts repository.CloneOptions) (*git.Commit, error) {
+func (g *Client) cloneSemVer(ctx context.Context, url, semverTag string, opts repository.CloneConfig) (*git.Commit, error) {
 	verConstraint, err := semver.NewConstraint(semverTag)
 	if err != nil {
 		return nil, fmt.Errorf("semver parse error: %w", err)
@@ -363,7 +363,7 @@ func (g *Client) cloneSemVer(ctx context.Context, url, semverTag string, opts re
 	return buildCommitWithRef(cc, ref)
 }
 
-func (g *Client) cloneRefName(ctx context.Context, url string, refName string, cloneOpts repository.CloneOptions) (*git.Commit, error) {
+func (g *Client) cloneRefName(ctx context.Context, url string, refName string, cloneOpts repository.CloneConfig) (*git.Commit, error) {
 	if g.authOpts == nil {
 		return nil, fmt.Errorf("unable to checkout repo with an empty set of auth options")
 	}

--- a/git/gogit/clone_test.go
+++ b/git/gogit/clone_test.go
@@ -152,7 +152,7 @@ func TestClone_cloneBranch(t *testing.T) {
 				upstreamPath = repoPath
 			}
 
-			cc, err := ggc.Clone(context.TODO(), upstreamPath, repository.CloneOptions{
+			cc, err := ggc.Clone(context.TODO(), upstreamPath, repository.CloneConfig{
 				CheckoutStrategy: repository.CheckoutStrategy{
 					Branch: tt.branch,
 				},
@@ -265,7 +265,7 @@ func TestClone_cloneTag(t *testing.T) {
 			ggc, err := NewClient(tmpDir, &git.AuthOptions{Transport: git.HTTP})
 			g.Expect(err).ToNot(HaveOccurred())
 
-			opts := repository.CloneOptions{
+			opts := repository.CloneConfig{
 				CheckoutStrategy: repository.CheckoutStrategy{
 					Tag: tt.checkoutTag,
 				},
@@ -358,7 +358,7 @@ func TestClone_cloneCommit(t *testing.T) {
 			g := NewWithT(t)
 
 			tmpDir := t.TempDir()
-			opts := repository.CloneOptions{
+			opts := repository.CloneConfig{
 				CheckoutStrategy: repository.CheckoutStrategy{
 					Branch: tt.branch,
 					Commit: tt.commit,
@@ -472,7 +472,7 @@ func TestClone_cloneSemVer(t *testing.T) {
 			ggc, err := NewClient(tmpDir, nil)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			opts := repository.CloneOptions{
+			opts := repository.CloneConfig{
 				CheckoutStrategy: repository.CheckoutStrategy{
 					SemVer: tt.constraint,
 				},
@@ -607,7 +607,7 @@ func TestClone_cloneRefName(t *testing.T) {
 			ggc, err := NewClient(tmpDir, &git.AuthOptions{Transport: git.HTTP})
 			g.Expect(err).ToNot(HaveOccurred())
 
-			cc, err := ggc.Clone(context.TODO(), repoURL, repository.CloneOptions{
+			cc, err := ggc.Clone(context.TODO(), repoURL, repository.CloneConfig{
 				CheckoutStrategy: repository.CheckoutStrategy{
 					RefName: tt.refName,
 				},
@@ -686,7 +686,7 @@ func Test_cloneSubmodule(t *testing.T) {
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 
-	_, err = ggc.Clone(context.TODO(), server.HTTPAddress()+"/"+icingRepoPath, repository.CloneOptions{
+	_, err = ggc.Clone(context.TODO(), server.HTTPAddress()+"/"+icingRepoPath, repository.CloneConfig{
 		CheckoutStrategy: repository.CheckoutStrategy{
 			Branch: "master",
 		},
@@ -802,7 +802,7 @@ func Test_ssh_KeyTypes(t *testing.T) {
 			ggc, err := NewClient(tmpDir, &authOpts)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			cc, err := ggc.Clone(ctx, repoURL, repository.CloneOptions{
+			cc, err := ggc.Clone(ctx, repoURL, repository.CloneConfig{
 				CheckoutStrategy: repository.CheckoutStrategy{
 					Branch: git.DefaultBranch,
 				},
@@ -933,7 +933,7 @@ func Test_ssh_KeyExchangeAlgos(t *testing.T) {
 			ggc, err := NewClient(tmpDir, &authOpts)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			_, err = ggc.Clone(ctx, repoURL, repository.CloneOptions{
+			_, err = ggc.Clone(ctx, repoURL, repository.CloneConfig{
 				CheckoutStrategy: repository.CheckoutStrategy{
 					Branch: git.DefaultBranch,
 				},
@@ -1105,7 +1105,7 @@ func Test_ssh_HostKeyAlgos(t *testing.T) {
 			ggc, err := NewClient(tmpDir, &authOpts)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			_, err = ggc.Clone(ctx, repoURL, repository.CloneOptions{
+			_, err = ggc.Clone(ctx, repoURL, repository.CloneConfig{
 				CheckoutStrategy: repository.CheckoutStrategy{
 					Branch: git.DefaultBranch,
 				},
@@ -1323,7 +1323,7 @@ func TestClone_CredentialsOverHttp(t *testing.T) {
 				repoURL = tt.transformURL(ts.URL)
 			}
 
-			_, err = ggc.Clone(context.TODO(), repoURL, repository.CloneOptions{})
+			_, err = ggc.Clone(context.TODO(), repoURL, repository.CloneConfig{})
 
 			if tt.expectCloneErr != "" {
 				g.Expect(err).To(HaveOccurred())

--- a/git/gogit/internal/test/http_proxy_test.go
+++ b/git/gogit/internal/test/http_proxy_test.go
@@ -189,7 +189,7 @@ func Test_HTTP_proxy(t *testing.T) {
 			ggc, err := gogit.NewClient(tmpDir, authOpts)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			_, err = ggc.Clone(context.TODO(), tt.url, repository.CloneOptions{
+			_, err = ggc.Clone(context.TODO(), tt.url, repository.CloneConfig{
 				CheckoutStrategy: repository.CheckoutStrategy{
 					Branch: "main",
 				},

--- a/git/gogit/internal/test/socks_proxy_test.go
+++ b/git/gogit/internal/test/socks_proxy_test.go
@@ -96,7 +96,7 @@ func Test_SOCKS5_proxy(t *testing.T) {
 	ggc, err := gogit.NewClient(tmpDir, authOpts)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	_, err = ggc.Clone(context.TODO(), repoURL, repository.CloneOptions{
+	_, err = ggc.Clone(context.TODO(), repoURL, repository.CloneConfig{
 		CheckoutStrategy: repository.CheckoutStrategy{
 			Branch: "main",
 		},

--- a/git/internal/e2e/utils.go
+++ b/git/internal/e2e/utils.go
@@ -46,7 +46,7 @@ var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz1234567890")
 
 func testUsingClone(g *WithT, client repository.Client, repoURL *url.URL, upstreamRepo upstreamRepoInfo) {
 	// clone repo
-	_, err := client.Clone(context.TODO(), repoURL.String(), repository.CloneOptions{
+	_, err := client.Clone(context.TODO(), repoURL.String(), repository.CloneConfig{
 		CheckoutStrategy: repository.CheckoutStrategy{
 			Branch: "main",
 		},

--- a/git/internal/e2e/utils.go
+++ b/git/internal/e2e/utils.go
@@ -62,7 +62,7 @@ func testUsingClone(g *WithT, client repository.Client, repoURL *url.URL, upstre
 	)
 	g.Expect(err).ToNot(HaveOccurred(), "first commit")
 
-	err = client.Push(context.TODO())
+	err = client.Push(context.TODO(), repository.PushConfig{})
 	g.Expect(err).ToNot(HaveOccurred())
 
 	headCommit, _, err := headCommitWithBranch(upstreamRepo.url, "main", upstreamRepo.username, upstreamRepo.password)
@@ -82,7 +82,7 @@ func testUsingClone(g *WithT, client repository.Client, repoURL *url.URL, upstre
 	)
 	g.Expect(err).ToNot(HaveOccurred(), "second commit")
 
-	err = client.Push(context.TODO())
+	err = client.Push(context.TODO(), repository.PushConfig{})
 	g.Expect(err).ToNot(HaveOccurred())
 	headCommit, branch, err := headCommitWithBranch(upstreamRepo.url, "new", upstreamRepo.username, upstreamRepo.password)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -100,7 +100,7 @@ func testUsingClone(g *WithT, client repository.Client, repoURL *url.URL, upstre
 		}),
 	)
 	g.Expect(err).ToNot(HaveOccurred(), "third commit")
-	err = client.Push(context.TODO())
+	err = client.Push(context.TODO(), repository.PushConfig{})
 	g.Expect(err).ToNot(HaveOccurred())
 	headCommit, _, err = headCommitWithBranch(upstreamRepo.url, "new", upstreamRepo.username, upstreamRepo.password)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -120,7 +120,7 @@ func testUsingInit(g *WithT, client repository.Client, repoURL *url.URL, upstrea
 	)
 	g.Expect(err).ToNot(HaveOccurred(), "first commit")
 
-	err = client.Push(context.TODO())
+	err = client.Push(context.TODO(), repository.PushConfig{})
 	g.Expect(err).ToNot(HaveOccurred())
 
 	headCommit, _, err := headCommitWithBranch(upstreamRepo.url, "main", upstreamRepo.username, upstreamRepo.password)
@@ -138,7 +138,7 @@ func testUsingInit(g *WithT, client repository.Client, repoURL *url.URL, upstrea
 	)
 	g.Expect(err).ToNot(HaveOccurred(), "second commit")
 
-	err = client.Push(context.TODO())
+	err = client.Push(context.TODO(), repository.PushConfig{})
 	g.Expect(err).ToNot(HaveOccurred())
 	headCommit, branch, err := headCommitWithBranch(upstreamRepo.url, "new", upstreamRepo.username, upstreamRepo.password)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -155,7 +155,7 @@ func testUsingInit(g *WithT, client repository.Client, repoURL *url.URL, upstrea
 		}),
 	)
 	g.Expect(err).ToNot(HaveOccurred(), "third commit")
-	err = client.Push(context.TODO())
+	err = client.Push(context.TODO(), repository.PushConfig{})
 	g.Expect(err).ToNot(HaveOccurred())
 	headCommit, _, err = headCommitWithBranch(upstreamRepo.url, "new", upstreamRepo.username, upstreamRepo.password)
 	g.Expect(err).ToNot(HaveOccurred())

--- a/git/repository/client.go
+++ b/git/repository/client.go
@@ -44,8 +44,10 @@ type Writer interface {
 	// Init initializes a repository at the configured path with the remote
 	// origin set to url on the provided branch.
 	Init(ctx context.Context, url, branch string) error
-	// Push pushes the current branch of the repository to origin.
-	Push(ctx context.Context) error
+	// Push performs a Git push to origin. By default, it pushes the
+	// reference pointed to by the HEAD, to its equivalent destination at
+	// the origin, but this is configurable via PushConfig.
+	Push(ctx context.Context, cfg PushConfig) error
 	// SwitchBranch switches from the current branch of the repository to the
 	// provided branch. If the branch doesn't exist, it is created.
 	SwitchBranch(ctx context.Context, branch string) error

--- a/git/repository/client.go
+++ b/git/repository/client.go
@@ -25,10 +25,10 @@ import (
 // Reader knows how to perform local and remote read operations
 // on a Git repository.
 type Reader interface {
-	// Clone clones a repository from the provided url using the options provided.
+	// Clone clones a repository from the provided url using the config provided.
 	// It returns a Commit object describing the Git commit that the repository
 	// HEAD points to. If the repository is empty, it returns a nil Commit.
-	Clone(ctx context.Context, url string, cloneOpts CloneOptions) (*git.Commit, error)
+	Clone(ctx context.Context, url string, cfg CloneConfig) (*git.Commit, error)
 	// IsClean returns whether the working tree is clean.
 	IsClean() (bool, error)
 	// Head returns the hash of the current HEAD of the repo.

--- a/git/repository/options.go
+++ b/git/repository/options.go
@@ -28,8 +28,8 @@ const (
 	DefaultPublicKeyAuthUser = "git"
 )
 
-// CloneOptions are the options used for a Git clone.
-type CloneOptions struct {
+// CloneConfig provides configuration options for a Git clone.
+type CloneConfig struct {
 	// CheckoutStrategy defines a strategy to use while checking out
 	// the cloned repository to a specific target.
 	CheckoutStrategy

--- a/git/repository/options.go
+++ b/git/repository/options.go
@@ -53,6 +53,14 @@ type CloneOptions struct {
 	ShallowClone bool
 }
 
+// PushConfig provides configuration options for a Git push.
+type PushConfig struct {
+	// Refspecs is a list of refspecs to use for the push operation.
+	// For details about Git Refspecs, please see:
+	// https://git-scm.com/book/en/v2/Git-Internals-The-Refspec
+	Refspecs []string
+}
+
 // CheckoutStrategy provides options to checkout a repository to a target.
 type CheckoutStrategy struct {
 	// Branch to checkout. If supported by the client, it can be combined

--- a/git/repository/options.go
+++ b/git/repository/options.go
@@ -59,6 +59,9 @@ type PushConfig struct {
 	// For details about Git Refspecs, please see:
 	// https://git-scm.com/book/en/v2/Git-Internals-The-Refspec
 	Refspecs []string
+
+	// Force, if set to true, will result in a force push.
+	Force bool
 }
 
 // CheckoutStrategy provides options to checkout a repository to a target.


### PR DESCRIPTION
Add `PushConfig` for configuring a push operation. Users can use `PushConfig.Refspecs` to specify the refspecs when using `Push()`.

Furthermore, fix a bug related to `Push()` where all refs were pushed to origin, since we did not specify a refspec and the default refspec used by gogit is `refs/heads/*:/refs/heads/*`.

Add `PushConfig.Force` for force pushing and remove `gogit.Client.forcePush` in favor of the former.

Remove some stale test cases from `TestSwitchBranch` related to force push since we don't check if force pushing is enabled while switching branches anymore. Ref: https://github.com/fluxcd/pkg/pull/433

Part of: https://github.com/fluxcd/image-automation-controller/issues/509