### PR TITLE
workflows: Update GCP & AZ secret names

### DIFF
--- a/.github/workflows/integration-azure.yaml
+++ b/.github/workflows/integration-azure.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Authenticate to Azure
         uses: Azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # v1.4.6
         with:
-          creds: '{"clientId":"${{ secrets.AZ_ARM_CLIENT_ID }}","clientSecret":"${{ secrets.AZ_ARM_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZ_ARM_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZ_ARM_TENANT_ID }}"}'
+          creds: '{"clientId":"${{ secrets.OCI_E2E_AZ_ARM_CLIENT_ID }}","clientSecret":"${{ secrets.OCI_E2E_AZ_ARM_CLIENT_SECRET }}","subscriptionId":"${{ secrets.OCI_E2E_AZ_ARM_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.OCI_E2E_AZ_ARM_TENANT_ID }}"}'
       - name: Setup QEMU
         uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
       - name: Setup Docker Buildx
@@ -34,7 +34,7 @@ jobs:
       - name: Set dynamic variables in .env
         run: |
           cat > .env <<EOF
-          export TF_VAR_tags='{"environment"="github", "ci"="true", "createdat"="$(date -u +x%Y-%m-%d_%Hh%Mm%Ss)"}'
+          export TF_VAR_tags='{"environment"="github", "ci"="true", "repo"="pkg", "createdat"="$(date -u +x%Y-%m-%d_%Hh%Mm%Ss)"}'
           EOF
       - name: Print .env for dynamic tag value reference
         run: cat .env
@@ -43,8 +43,8 @@ jobs:
       - name: Run tests
         run: . .env && make test-azure
         env:
-          ARM_CLIENT_ID: ${{ secrets.AZ_ARM_CLIENT_ID }}
-          ARM_CLIENT_SECRET: ${{ secrets.AZ_ARM_CLIENT_SECRET }}
-          ARM_SUBSCRIPTION_ID: ${{ secrets.AZ_ARM_SUBSCRIPTION_ID }}
-          ARM_TENANT_ID: ${{ secrets.AZ_ARM_TENANT_ID }}
+          ARM_CLIENT_ID: ${{ secrets.OCI_E2E_AZ_ARM_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.OCI_E2E_AZ_ARM_CLIENT_SECRET }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.OCI_E2E_AZ_ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.OCI_E2E_AZ_ARM_TENANT_ID }}
           TF_VAR_azure_location: ${{ vars.TF_VAR_azure_location }}

--- a/.github/workflows/integration-gcp.yaml
+++ b/.github/workflows/integration-gcp.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: google-github-actions/auth@e8df18b60c5dd38ba618c121b779307266153fbf # v1.1.0
         id: 'auth'
         with:
-          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
+          credentials_json: '${{ secrets.OCI_E2E_GOOGLE_CREDENTIALS }}'
           token_format: 'access_token'
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587 # v1.1.0
@@ -50,7 +50,7 @@ jobs:
       - name: Set dynamic variables in .env
         run: |
           cat > .env <<EOF
-          export TF_VAR_tags='{"environment"="github", "ci"="true", "createdat"="$(date -u +x%Y-%m-%d_%Hh%Mm%Ss)"}'
+          export TF_VAR_tags='{"environment"="github", "ci"="true", "repo"="pkg", "createdat"="$(date -u +x%Y-%m-%d_%Hh%Mm%Ss)"}'
           EOF
       - name: Print .env for dynamic tag value reference
         run: cat .env


### PR DESCRIPTION
Update the GCP and Azure secret names to be specific to the test they are for. This will help identify and manage the secrets and the permissions needed for particular tests separately.

Also, update the resource tags to have the name of the repository where they originate from. This will help identify which resources were created from which repository.

NOTE: Had a discussion with @hiddeco  before deciding on the naming format.