### PR TITLE
oci/test: update docker build command to buildx

### DIFF
--- a/oci/tests/integration/Makefile
+++ b/oci/tests/integration/Makefile
@@ -9,7 +9,7 @@ app:
 	CGO_ENABLED=0 go build -v -o app ./testapp
 
 docker-build: app
-	docker build -t $(TEST_IMG) --load .
+	docker buildx build -t $(TEST_IMG) --load .
 
 test:
 	docker image inspect $(TEST_IMG) >/dev/null


### PR DESCRIPTION
Update docker build command to use buildx. Build fails with unknown flag without it in the docker in CI.

The CI failed https://github.com/fluxcd/pkg/actions/runs/4951164544/jobs/8855770882#step:12:850 due to the docker build flag. I missed updating it in this repo. I fixed it and used it in my fork before https://github.com/darkowlzz/pkg/blob/cc06307b472367a49af9783dbf3ddc2be5e85549/oci/tests/integration/Makefile#L12 .