### PR TITLE
Add integration test cleanup job for azure

### DIFF
--- a/.github/workflows/integration-cleanup.yaml
+++ b/.github/workflows/integration-cleanup.yaml
@@ -58,3 +58,27 @@ jobs:
         # NOTE: This is in dry-run mode by default. Pass `-delete` to allow it
         # to delete.
         run: go run ./ -provider gcp -gcpproject ${{ vars.TF_VAR_gcp_project_id }} -retention-period 1d -tags 'ci=true'
+
+  azure:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./tools/reaper
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        with:
+          repository: fluxcd/test-infra
+      - name: Setup Go
+        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        with:
+          go-version: 1.20.x
+          cache-dependency-path: ./tools/reaper/go.sum
+      - name: Authenticate to Azure
+        uses: Azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # v1.4.6
+        with:
+          creds: '{"clientId":"${{ secrets.CLEANUP_E2E_AZ_ARM_CLIENT_ID }}","clientSecret":"${{ secrets.CLEANUP_E2E_AZ_ARM_CLIENT_SECRET }}","subscriptionId":"${{ secrets.CLEANUP_E2E_AZ_ARM_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.CLEANUP_E2E_AZ_ARM_TENANT_ID }}"}'
+      - name: Run reaper
+        # NOTE: This is in dry-run mode by default. Pass `-delete` to allow it
+        # to delete.
+        run: go run ./ -provider azure -retention-period 1d -tags 'ci=true'


### PR DESCRIPTION
Appends the existing integration-cleanup workflow with a new job for azure.

Same as https://github.com/fluxcd/pkg/pull/553 but for azure.