### PR TITLE
Enable daily cron for cloud integration test workflow

### DIFF
--- a/.github/workflows/integration-azure.yaml
+++ b/.github/workflows/integration-azure.yaml
@@ -2,6 +2,8 @@ name: integration-azure
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * *"
   # push:
   #   branches:
   #     - main

--- a/.github/workflows/integration-gcp.yaml
+++ b/.github/workflows/integration-gcp.yaml
@@ -2,6 +2,8 @@ name: integration-gcp
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * *"
   # push:
   #   branches:
   #     - main


### PR DESCRIPTION
Enable cron for the cloud integration tests for azure and gcp.

Runs 12 hours after the daily cleanup job.