### PR TITLE
runtime: Add `WithMaxConcurrentReconciles` to testenv

### DIFF
--- a/runtime/patch/suite_test.go
+++ b/runtime/patch/suite_test.go
@@ -49,6 +49,7 @@ func TestMain(m *testing.M) {
 	env = testenv.New(
 		testenv.WithScheme(scheme),
 		testenv.WithCRDPath("../conditions/testdata/crds"),
+		testenv.WithMaxConcurrentReconciles(4),
 	)
 
 	go func() {


### PR DESCRIPTION
Add `WithMaxConcurrentReconciles` to testenv and set `2` as the default value.