### PR TITLE
git/gogit: set `HostKeyCallback` for parent `PublicKeys` object

### DIFF
--- a/git/gogit/transport.go
+++ b/git/gogit/transport.go
@@ -114,14 +114,15 @@ func (a *CustomPublicKeys) String() string {
 }
 
 func (a *CustomPublicKeys) ClientConfig() (*gossh.ClientConfig, error) {
+	if a.callback != nil {
+		a.pk.HostKeyCallback = a.callback
+	}
+
 	config, err := a.pk.ClientConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	if a.callback != nil {
-		config.HostKeyCallback = a.callback
-	}
 	if len(git.KexAlgos) > 0 {
 		config.Config.KeyExchanges = git.KexAlgos
 	}
@@ -149,7 +150,6 @@ func (a *DefaultAuth) ClientConfig() (*gossh.ClientConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	config.HostKeyCallback, err = ssh.NewKnownHostsCallback()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Set `HostKeyCallback` for the parent `PublicKeys` object to avoid setting the callback to one that uses the system's known_hosts.

Fixes errors seen in: https://github.com/fluxcd/source-controller/actions/runs/5072863613/jobs/9111130473#step:4:164