### PR TITLE
git/gogit: Add support for per client proxying

### DIFF
--- a/git/gogit/client.go
+++ b/git/gogit/client.go
@@ -32,6 +32,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/cache"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/storage"
 	"github.com/go-git/go-git/v5/storage/filesystem"
 	"github.com/go-git/go-git/v5/storage/memory"
@@ -55,6 +56,7 @@ type Client struct {
 	credentialsOverHTTP  bool
 	useDefaultKnownHosts bool
 	singleBranch         bool
+	proxy                transport.ProxyOptions
 }
 
 var _ repository.Client = &Client{}
@@ -95,6 +97,8 @@ func NewClient(path string, authOpts *git.AuthOptions, clientOpts ...ClientOptio
 	return g, nil
 }
 
+// WithStorer configures the client to use the provided Storer for
+// storing all Git related objects.
 func WithStorer(s storage.Storer) ClientOption {
 	return func(c *Client) error {
 		c.storer = s
@@ -102,6 +106,8 @@ func WithStorer(s storage.Storer) ClientOption {
 	}
 }
 
+// WithWorkTreeFS configures the client to use the provided filesystem
+// for storing the worktree.
 func WithWorkTreeFS(wt billy.Filesystem) ClientOption {
 	return func(c *Client) error {
 		c.worktreeFS = wt
@@ -128,6 +134,8 @@ func WithSingleBranch(singleBranch bool) ClientOption {
 	}
 }
 
+// WithDiskStorage configures the client to store the worktree and all
+// Git related objects on disk.
 func WithDiskStorage() ClientOption {
 	return func(c *Client) error {
 		wt := fs.New(c.path)
@@ -139,6 +147,8 @@ func WithDiskStorage() ClientOption {
 	}
 }
 
+// WithMemoryStorage configures the client to store the worktree and
+// all Git related objects in memory.
 func WithMemoryStorage() ClientOption {
 	return func(c *Client) error {
 		c.storer = memory.NewStorage()
@@ -161,6 +171,15 @@ func WithInsecureCredentialsOverHTTP() ClientOption {
 func WithFallbackToDefaultKnownHosts() ClientOption {
 	return func(c *Client) error {
 		c.useDefaultKnownHosts = true
+		return nil
+	}
+}
+
+// WithProxy configures the proxy settings to be used for all
+// remote operations.
+func WithProxy(opts transport.ProxyOptions) ClientOption {
+	return func(c *Client) error {
+		c.proxy = opts
 		return nil
 	}
 }

--- a/git/gogit/go.mod
+++ b/git/gogit/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/elazarl/goproxy v0.0.0-20221015165544-a0805db90819
 	github.com/fluxcd/gitkit v0.6.0
 	github.com/fluxcd/pkg/git v0.12.2
-	github.com/fluxcd/pkg/gittestserver v0.8.3
+	github.com/fluxcd/pkg/gittestserver v0.8.4
 	github.com/fluxcd/pkg/ssh v0.7.4
 	github.com/fluxcd/pkg/version v0.2.2
 	github.com/go-git/go-billy/v5 v5.4.1

--- a/git/internal/e2e/go.mod
+++ b/git/internal/e2e/go.mod
@@ -12,10 +12,10 @@ replace (
 )
 
 require (
-	github.com/fluxcd/go-git-providers v0.15.3
+	github.com/fluxcd/go-git-providers v0.16.0
 	github.com/fluxcd/pkg/git v0.12.2
-	github.com/fluxcd/pkg/git/gogit v0.9.0
-	github.com/fluxcd/pkg/gittestserver v0.8.3
+	github.com/fluxcd/pkg/git/gogit v0.11.1
+	github.com/fluxcd/pkg/gittestserver v0.8.4
 	github.com/fluxcd/pkg/ssh v0.7.4
 	github.com/go-git/go-git/v5 v5.7.0
 	github.com/go-logr/logr v1.2.4
@@ -40,7 +40,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
-	github.com/google/go-github/v49 v49.1.0 // indirect
+	github.com/google/go-github/v52 v52.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect

--- a/git/internal/e2e/go.sum
+++ b/git/internal/e2e/go.sum
@@ -25,8 +25,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fluxcd/gitkit v0.6.0 h1:iNg5LTx6ePo+Pl0ZwqHTAkhbUHxGVSY3YCxCdw7VIFg=
 github.com/fluxcd/gitkit v0.6.0/go.mod h1:svOHuKi0fO9HoawdK4HfHAJJseZDHHjk7I3ihnCIqNo=
-github.com/fluxcd/go-git-providers v0.15.3 h1:vJ1J+WxZYxrOrWp2ojpixjERxmN6XY9C/AxQbuVaIsQ=
-github.com/fluxcd/go-git-providers v0.15.3/go.mod h1:6fkRPzq0EQHQKO0/6CmfoEr6YHYwBKzDbxiEUjaxzl4=
+github.com/fluxcd/go-git-providers v0.16.0 h1:egDN1uv0jyHyvtFNHE1FQ1Slj5Xu7QEFxWj1shqYYGk=
+github.com/fluxcd/go-git-providers v0.16.0/go.mod h1:dIUEy97GuCKAYHkDQS39Jqb6Pfg1mnGnqA5y2mp3wR4=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
@@ -53,8 +53,8 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v49 v49.1.0 h1:LFkMgawGQ8dfzWLH/rNE0b3u1D3n6/dw7ZmrN3b+YFY=
-github.com/google/go-github/v49 v49.1.0/go.mod h1:MUUzHPrhGniB6vUKa27y37likpipzG+BXXJbG04J334=
+github.com/google/go-github/v52 v52.0.0 h1:uyGWOY+jMQ8GVGSX8dkSwCzlehU3WfdxQ7GweO/JP7M=
+github.com/google/go-github/v52 v52.0.0/go.mod h1:WJV6VEEUPuMo5pXqqa2ZCZEdbQqua4zAk2MZTIo+m+4=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=


### PR DESCRIPTION
Add `WithProxy()`, a `ClientOption` which configures the proxy settings for a `gogit.Client`. All remote operations performed by the client will then use the configured proxy.

Atm, the only way to use a proxy is to use the standard env vars, `HTTP_PROXY`, `HTTPS_PROXY`, etc. The problem with this is that its configuration at a global level, i.e. all clients will be forced to use these proxy settings. This PR allows for using different proxy settings for different clients, which is particularly helpful when working in multi tenant environments.