### PR TITLE
git/gogit: Translate misleading go-git write access error of Gitlab

### DIFF
--- a/git/gogit/client.go
+++ b/git/gogit/client.go
@@ -408,7 +408,7 @@ func (g *Client) Push(ctx context.Context, cfg repository.PushConfig) error {
 		refspecs = append(refspecs, headRefspec)
 	}
 
-	return g.repository.PushContext(ctx, &extgogit.PushOptions{
+	err = g.repository.PushContext(ctx, &extgogit.PushOptions{
 		RefSpecs:   refspecs,
 		Force:      cfg.Force,
 		RemoteName: extgogit.DefaultRemoteName,
@@ -416,6 +416,7 @@ func (g *Client) Push(ctx context.Context, cfg repository.PushConfig) error {
 		Progress:   nil,
 		CABundle:   caBundle(g.authOpts),
 	})
+	return goGitError(err)
 }
 
 // SwitchBranch switches the current branch to the given branch name.


### PR DESCRIPTION
go-git returns an unhelpful error message `unknown error: remote:` when trying to push to a GitLab repository using a deploy key that does not have push access. Translate the error message to something more helpful and informative.

Related to: https://github.com/fluxcd/image-automation-controller/issues/491