### PR TITLE
oci: Allow consumers to set the OCI artifact created date

### DIFF
--- a/oci/client/push.go
+++ b/oci/client/push.go
@@ -54,8 +54,10 @@ func (c *Client) Push(ctx context.Context, url, sourceDir string, meta Metadata,
 		return "", err
 	}
 
-	ct := time.Now().UTC()
-	meta.Created = ct.Format(time.RFC3339)
+	if meta.Created == "" {
+		ct := time.Now().UTC()
+		meta.Created = ct.Format(time.RFC3339)
+	}
 
 	img := mutate.MediaType(empty.Image, types.OCIManifestSchema1)
 	img = mutate.ConfigMediaType(img, oci.CanonicalConfigMediaType)

--- a/oci/client/push_pull_test.go
+++ b/oci/client/push_pull_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/v1/types"
@@ -41,11 +42,14 @@ func Test_Push_Pull(t *testing.T) {
 	source := "github.com/fluxcd/flux2"
 	revision := "rev"
 	repo := "test-push" + randStringRunes(5)
+	ct := time.Now().UTC()
+	created := ct.Format(time.RFC3339)
 
 	url := fmt.Sprintf("%s/%s:%s", dockerReg, repo, tag)
 	metadata := Metadata{
 		Source:   source,
 		Revision: revision,
+		Created:  created,
 		Annotations: map[string]string{
 			"org.opencontainers.image.documentation": "https://my/readme.md",
 			"org.opencontainers.image.licenses":      "Apache-2.0",
@@ -71,7 +75,7 @@ func Test_Push_Pull(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Verify that annotations exist in manifest
-	g.Expect(manifest.Annotations[oci.CreatedAnnotation]).ToNot(BeEmpty())
+	g.Expect(manifest.Annotations[oci.CreatedAnnotation]).To(BeEquivalentTo(created))
 	g.Expect(manifest.Annotations[oci.SourceAnnotation]).To(BeEquivalentTo(source))
 	g.Expect(manifest.Annotations[oci.RevisionAnnotation]).To(BeEquivalentTo(revision))
 


### PR DESCRIPTION
For reproducible builds we need to allow consumers to set their own created date instead of enforcing time.now.