### PR TITLE
runtime/client: add util func to check conn options compatibility with env

### DIFF
--- a/runtime/go.mod
+++ b/runtime/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.24.0
+	golang.org/x/net v0.10.0
 	k8s.io/api v0.27.3
 	k8s.io/apimachinery v0.27.3
 	k8s.io/client-go v0.27.3
@@ -89,7 +90,6 @@ require (
 	go.starlark.net v0.0.0-20221028183056-acb66ad56dd2 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
-	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/oauth2 v0.5.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/term v0.8.0 // indirect


### PR DESCRIPTION
Add `CheckEnvironmentCompatibility()` to check whether the configured connection options are compatible with the environment, by checking env vars like `HTTP_PROXY` and `HTTPS_PROXY`.