### PR TITLE
git: Add support for adding tag info to commit

### DIFF
--- a/git/gogit/clone.go
+++ b/git/gogit/clone.go
@@ -535,9 +535,11 @@ func buildSignature(s object.Signature) git.Signature {
 	}
 }
 
-func buildTag(t *object.Tag) (*git.AnnotatedTag, error) {
+func buildTag(t *object.Tag, ref plumbing.ReferenceName) (*git.Tag, error) {
 	if t == nil {
-		return nil, fmt.Errorf("unable to contruct tag: no object")
+		return &git.Tag{
+			Name: ref.Short(),
+		}, nil
 	}
 
 	encoded := &plumbing.MemoryObject{}
@@ -553,7 +555,7 @@ func buildTag(t *object.Tag) (*git.AnnotatedTag, error) {
 		return nil, fmt.Errorf("unable to read encoded tag '%s': %w", t.Name, err)
 	}
 
-	return &git.AnnotatedTag{
+	return &git.Tag{
 		Hash:      []byte(t.Hash.String()),
 		Name:      t.Name,
 		Author:    buildSignature(t.Tagger),
@@ -591,8 +593,8 @@ func buildCommitWithRef(c *object.Commit, t *object.Tag, ref plumbing.ReferenceN
 		Message:   c.Message,
 	}
 
-	if t != nil {
-		tt, err := buildTag(t)
+	if ref.IsTag() {
+		tt, err := buildTag(t, ref)
 		if err != nil {
 			return nil, err
 		}

--- a/git/gogit/clone_test.go
+++ b/git/gogit/clone_test.go
@@ -425,7 +425,7 @@ func TestClone_cloneSemVer(t *testing.T) {
 		},
 		{
 			tag:        "v0.1.0+build-3",
-			annotated:  true,
+			annotated:  false,
 			commitTime: now.Add(1 * time.Hour),
 			tagTime:    now.Add(1 * time.Hour), // This should be ignored during TS comparisons
 		},
@@ -439,6 +439,7 @@ func TestClone_cloneSemVer(t *testing.T) {
 	tests := []struct {
 		name       string
 		constraint string
+		annotated  bool
 		expectErr  error
 		expectTag  string
 	}{
@@ -446,6 +447,7 @@ func TestClone_cloneSemVer(t *testing.T) {
 			name:       "Orders by SemVer",
 			constraint: ">0.1.0",
 			expectTag:  "0.2.0",
+			annotated:  true,
 		},
 		{
 			name:       "Orders by SemVer and timestamp",
@@ -503,6 +505,12 @@ func TestClone_cloneSemVer(t *testing.T) {
 			g.Expect(cc.String()).To(Equal(tt.expectTag + "@" + git.HashTypeSHA1 + ":" + refs[tt.expectTag]))
 			g.Expect(filepath.Join(tmpDir, "tag")).To(BeARegularFile())
 			g.Expect(os.ReadFile(filepath.Join(tmpDir, "tag"))).To(BeEquivalentTo(tt.expectTag))
+			if tt.annotated {
+				g.Expect(cc.ReferencingTag).ToNot(BeNil())
+				g.Expect(cc.ReferencingTag.Message).To(Equal(fmt.Sprintf("Annotated tag for: %s\n", tt.expectTag)))
+			} else {
+				g.Expect(cc.ReferencingTag).To(BeNil())
+			}
 		})
 	}
 }

--- a/git/gogit/clone_test.go
+++ b/git/gogit/clone_test.go
@@ -290,6 +290,16 @@ func TestClone_cloneTag(t *testing.T) {
 				return
 			}
 
+			// Check if commit has a parent if the tag was annotated.
+			for _, tagInRepo := range tt.tagsInRepo {
+				if tagInRepo.annotated {
+					g.Expect(cc.ReferencingTag).ToNot(BeNil())
+					g.Expect(cc.ReferencingTag.Message).To(Equal(fmt.Sprintf("Annotated tag for: %s\n", tagInRepo.name)))
+				} else {
+					g.Expect(cc.ReferencingTag).To(BeNil())
+				}
+			}
+
 			// Check successful checkout results.
 			g.Expect(git.IsConcreteCommit(*cc)).To(Equal(tt.expectConcreteCommit))
 			targetTagHash := tagCommits[tt.checkoutTag]

--- a/git/gogit/clone_test.go
+++ b/git/gogit/clone_test.go
@@ -653,6 +653,10 @@ func TestClone_cloneRefName(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(cc.AbsoluteReference()).To(Equal(tt.refName + "@" + git.HashTypeSHA1 + ":" + tt.expectedCommit))
 			g.Expect(git.IsConcreteCommit(*cc)).To(Equal(tt.expectedConcreteCommit))
+			if strings.Contains(tt.refName, "tags") && !strings.HasSuffix(tt.refName, tagDereferenceSuffix) {
+				g.Expect(cc.ReferencingTag).ToNot(BeNil())
+				g.Expect(cc.ReferencingTag.Message).To(ContainSubstring("Annotated tag for"))
+			}
 
 			for k, v := range tt.filesCreated {
 				g.Expect(filepath.Join(tmpDir, k)).To(BeARegularFile())


### PR DESCRIPTION
Add a new struct `Tag` that represents a Git annotated tag and add it as a new field `Commit.ReferencingTag`, allowing for a commit to contain information about its referencing tag. Add support for verifying the referencing tag as well.
Update the cloning logic to include the tag object in the returned commit object when checking out via a specific tag, a semver range or if the provided refname points to a tag.

Related to: https://github.com/fluxcd/source-controller/issues/1133
Example usage: https://github.com/fluxcd/source-controller/pull/1187