### PR TITLE
Use registry region to get token for AWS

### DIFF
--- a/oci/auth/aws/auth_test.go
+++ b/oci/auth/aws/auth_test.go
@@ -157,11 +157,10 @@ func TestGetLoginAuth(t *testing.T) {
 			})
 			// set the region in the config since we are not using the `LoadDefaultConfig` function that sets the region
 			// by querying the instance metadata service(IMDS)
-			cfg.Region = "us-east-1"
 			cfg.Credentials = credentials.NewStaticCredentialsProvider("x", "y", "z")
 			ec.WithConfig(cfg)
 
-			a, err := ec.getLoginAuth(context.TODO())
+			a, err := ec.getLoginAuth(context.TODO(), "us-east-1")
 			g.Expect(err != nil).To(Equal(tt.wantErr))
 			if tt.statusCode == http.StatusOK {
 				g.Expect(a).To(Equal(tt.wantAuthConfig))
@@ -229,7 +228,7 @@ func TestLogin(t *testing.T) {
 			g.Expect(err != nil).To(Equal(tt.wantErr))
 
 			if tt.testOIDC {
-				_, err = ecrClient.OIDCLogin(context.TODO())
+				_, err = ecrClient.OIDCLogin(context.TODO(), tt.image)
 				g.Expect(err != nil).To(Equal(tt.wantErr))
 			}
 		})

--- a/oci/auth/login/login.go
+++ b/oci/auth/login/login.go
@@ -141,7 +141,7 @@ func (m *Manager) OIDCLogin(ctx context.Context, registryURL string, opts Provid
 			return nil, fmt.Errorf("ECR authentication failed: %w", oci.ErrUnconfiguredProvider)
 		}
 		ctrl.LoggerFrom(ctx).Info("logging in to AWS ECR for " + u.Host)
-		return m.ecr.OIDCLogin(ctx)
+		return m.ecr.OIDCLogin(ctx, u.Host)
 	case oci.ProviderGCP:
 		if !opts.GcpAutoLogin {
 			return nil, fmt.Errorf("GCR authentication failed: %w", oci.ErrUnconfiguredProvider)

--- a/oci/go.mod
+++ b/oci/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.18.1
 	github.com/aws/aws-sdk-go-v2/config v1.18.27
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.26
-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.4
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.18.13
 	github.com/distribution/distribution/v3 v3.0.0-20230621170613-87b280718d38
 	github.com/fluxcd/pkg/sourceignore v0.3.4
@@ -33,6 +32,7 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.0.0 // indirect
 	github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d // indirect
 	github.com/acomagu/bufpipe v1.0.4 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.28 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.35 // indirect


### PR DESCRIPTION
This pull request basically reverts a change introduced in #560  where the region of the instance was used instead of the region from the registry url

Ref: https://github.com/fluxcd/source-controller/issues/1155