### PR TITLE
[oci] Test login for aws repository in a different region

### DIFF
--- a/oci/tests/integration/.env.sample
+++ b/oci/tests/integration/.env.sample
@@ -2,6 +2,9 @@
 # export AWS_ACCESS_KEY_ID=
 # export AWS_SECRET_ACCESS_KEY=
 # export AWS_REGION=us-east-2
+## This terraform variable should be different from
+## the region set above.
+# export TF_VAR_cross_region=us-east-1
 ## This random value is needed for AWS only to prevent
 ## https://github.com/hashicorp/terraform-provider-aws/issues/19583 which
 ## happens when using dynamic "name" value in presence of more than one tag.

--- a/oci/tests/integration/aws_test.go
+++ b/oci/tests/integration/aws_test.go
@@ -52,6 +52,14 @@ func registryLoginECR(ctx context.Context, output map[string]*tfjson.StateOutput
 	}
 	testRepos["ecr"] = testRepoURL
 
+	// test the cross-region repository
+	cross_region := output["cross_region"].Value.(string)
+	testCrossRepo := output["ecr_cross_region_repository_url"].Value.(string)
+	if err := tftestenv.RegistryLoginECR(ctx, cross_region, testCrossRepo); err != nil {
+		return nil, err
+	}
+	testRepos["ecr_cross_region"] = testCrossRepo
+
 	// Log into the test app repository to be able to push to it.
 	// This image is not used in testing and need not be included in
 	// testRepos.

--- a/oci/tests/integration/terraform/aws/main.tf
+++ b/oci/tests/integration/terraform/aws/main.tf
@@ -1,5 +1,10 @@
 provider "aws" {}
 
+provider "aws" {
+  alias  = "cross_region"
+  region = var.cross_region
+}
+
 locals {
   name = "flux-test-${var.rand}"
 }
@@ -16,6 +21,16 @@ module "test_ecr" {
 
   name = "test-repo-${local.name}"
   tags = var.tags
+}
+
+module "test_ecr_cross_reg" {
+  source = "git::https://github.com/fluxcd/test-infra.git//tf-modules/aws/ecr"
+
+  name = "test-repo-${local.name}-cross-reg"
+  tags = var.tags
+  providers = {
+    aws = aws.cross_region
+  }
 }
 
 module "test_app_ecr" {

--- a/oci/tests/integration/terraform/aws/outputs.tf
+++ b/oci/tests/integration/terraform/aws/outputs.tf
@@ -19,8 +19,17 @@ output "region" {
   value = module.eks.region
 }
 
+output "cross_region" {
+  value = var.cross_region
+}
+
+
 output "ecr_repository_url" {
   value = module.test_ecr.repository_url
+}
+
+output "ecr_cross_region_repository_url" {
+  value = module.test_ecr_cross_reg.repository_url
 }
 
 output "ecr_registry_id" {

--- a/oci/tests/integration/terraform/aws/variables.tf
+++ b/oci/tests/integration/terraform/aws/variables.tf
@@ -6,3 +6,8 @@ variable "tags" {
   type    = map(string)
   default = {}
 }
+
+variable "cross_region" {
+  type        = string
+  description = "different region for testing cross region resources"
+}


### PR DESCRIPTION
This pull request creates an ecr repository in a different region from that of the eks cluster in the integration tests