### PR TITLE
ssa: Detect immutable errors from CEL and custom webhooks

### DIFF
--- a/ssa/utils_test.go
+++ b/ssa/utils_test.go
@@ -239,3 +239,35 @@ stringData:
 		})
 	}
 }
+
+func TestIsImmutableError(t *testing.T) {
+	testCases := []struct {
+		name  string
+		err   error
+		match bool
+	}{
+		{
+			name:  "CEL immutable error",
+			err:   fmt.Errorf(`the ImmutableSinceFirstWrite "test1" is invalid: value: Invalid value: "string": Value is immutable`),
+			match: true,
+		},
+		{
+			name:  "Custom admission immutable error",
+			err:   fmt.Errorf(`the IAMPolicyMember's spec is immutable: admission webhook "deny-immutable-field-updates.cnrm.cloud.google.com" denied the request: the IAMPolicyMember's spec is immutable`),
+			match: true,
+		},
+		{
+			name:  "Not immutable error",
+			err:   fmt.Errorf(`is not immutable`),
+			match: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(IsImmutableError(tc.err)).To(BeIdenticalTo(tc.match))
+		})
+	}
+}


### PR DESCRIPTION
Custom admission webhooks such as those used by Google Cloud and Kubernetes CEL which reject requests due to immutable field changes do not comply with `errors.IsInvalid`. For Flux to be able to force apply resources rejected by these controllers, we have to do a match on the error string and look for `is immutable`.

Ref:
- https://github.com/fluxcd/kustomize-controller/issues/834
- https://github.com/stefanprodan/timoni/issues/153