### PR TITLE
runtime/metrics: Delete metrics on object delete

### DIFF
--- a/runtime/controller/metrics_test.go
+++ b/runtime/controller/metrics_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2023 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fluxcd/pkg/runtime/conditions/testdata"
+)
+
+func TestMetrics_IsDelete(t *testing.T) {
+	testFinalizers := []string{"finalizers.fluxcd.io", "finalizers.foo.bar"}
+	timenow := metav1.NewTime(time.Now())
+
+	tests := []struct {
+		name            string
+		finalizers      []string
+		deleteTimestamp *metav1.Time
+		ownedFinalizers []string
+		want            bool
+	}{
+		{"equal finalizers, no delete timestamp", testFinalizers, nil, testFinalizers, false},
+		{"partial finalizers, no delete timestamp", []string{"finalizers.fluxcd.io"}, nil, testFinalizers, false},
+		{"unknown finalizers, no delete timestamp", []string{"foo"}, nil, testFinalizers, false},
+		{"unknown finalizers, delete timestamp", []string{"foo"}, &timenow, testFinalizers, true},
+		{"no finalizers, no delete timestamp", []string{}, nil, testFinalizers, false},
+		{"no owned finalizers, no delete timestamp", []string{"foo"}, nil, nil, false},
+		{"no finalizers, delete timestamp", []string{}, &timenow, testFinalizers, true},
+		{"no finalizers, no delete timestamp", nil, nil, nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			metrics := Metrics{ownedFinalizers: tt.ownedFinalizers}
+			obj := &testdata.Fake{}
+			obj.SetFinalizers(tt.finalizers)
+			obj.SetDeletionTimestamp(tt.deleteTimestamp)
+			g.Expect(metrics.IsDelete(obj)).To(Equal(tt.want))
+		})
+	}
+}


### PR DESCRIPTION
The current metrics `Record*()` methods continues to export the metrics
of deleted objects unless the program restarts.

This change deletes the object metrics when the object is deleted. This ensures
that stale metrics about a deleted object is no longer exported.

As a result, the `ConditionDelete` is no longer needed. Another reason
to not have `ConditionDelete` is that a condition can only be one of
True, False or Unknown.

This introduces new delete methods in the low level metrics `Recorder`. In
the high level controller metrics, a list of owned finalizers is
introduced which is used to determine if an object is being deleted.
The existing Record*() methods are updated to check if the given object
is deleted, and call record or delete based on that. The user of this
API has to pass in the finalizer they write on object they maintain to
the metrics helper and record the metrics at the very end of the
reconciliation so that the final object state can be used to determine
if the metrics can be deleted safely.
    
To allow creating multiple instances of metrics helper, the metrics
collector registration is now done using a new function
`MustMakeRecorder()` which returns a `metrics.Recorder`. `metrics.Recorder`
can be used to create multiple metrics helpers with different attributes
if required, sharing the same underlying metrics recorder.

Before this, for a helmrepo and helmchart, the following metrics will continue to be exported even after deleting the helmrepo and helmchart:

```
# HELP gotk_reconcile_condition The current condition status of a GitOps Toolkit resource reconciliation.
# TYPE gotk_reconcile_condition gauge
gotk_reconcile_condition{kind="HelmChart",name="podinfo",namespace="default",status="False",type="Ready"} 0
gotk_reconcile_condition{kind="HelmChart",name="podinfo",namespace="default",status="True",type="Ready"} 1
gotk_reconcile_condition{kind="HelmChart",name="podinfo",namespace="default",status="Unknown",type="Ready"} 0
gotk_reconcile_condition{kind="HelmRepository",name="podinfo",namespace="default",status="False",type="Ready"} 0
gotk_reconcile_condition{kind="HelmRepository",name="podinfo",namespace="default",status="True",type="Ready"} 1
gotk_reconcile_condition{kind="HelmRepository",name="podinfo",namespace="default",status="Unknown",type="Ready"} 0
# HELP gotk_reconcile_duration_seconds The duration in seconds of a GitOps Toolkit resource reconciliation.
# TYPE gotk_reconcile_duration_seconds histogram
gotk_reconcile_duration_seconds_bucket{kind="HelmChart",name="podinfo",namespace="default",le="0.01"} 1
gotk_reconcile_duration_seconds_bucket{kind="HelmChart",name="podinfo",namespace="default",le="0.038363583488692544"} 1
gotk_reconcile_duration_seconds_bucket{kind="HelmChart",name="podinfo",namespace="default",le="0.1471764538093883"} 2
gotk_reconcile_duration_seconds_bucket{kind="HelmChart",name="podinfo",namespace="default",le="0.5646216173286169"} 2
gotk_reconcile_duration_seconds_bucket{kind="HelmChart",name="podinfo",namespace="default",le="2.166090855590701"} 2
gotk_reconcile_duration_seconds_bucket{kind="HelmChart",name="podinfo",namespace="default",le="8.309900738254731"} 2
gotk_reconcile_duration_seconds_bucket{kind="HelmChart",name="podinfo",namespace="default",le="31.879757075478317"} 2
gotk_reconcile_duration_seconds_bucket{kind="HelmChart",name="podinfo",namespace="default",le="122.30217221643493"} 2
gotk_reconcile_duration_seconds_bucket{kind="HelmChart",name="podinfo",namespace="default",le="469.19495946736544"} 2
gotk_reconcile_duration_seconds_bucket{kind="HelmChart",name="podinfo",namespace="default",le="1799.9999999999986"} 2
gotk_reconcile_duration_seconds_bucket{kind="HelmChart",name="podinfo",namespace="default",le="+Inf"} 2
gotk_reconcile_duration_seconds_sum{kind="HelmChart",name="podinfo",namespace="default"} 0.063555242
gotk_reconcile_duration_seconds_count{kind="HelmChart",name="podinfo",namespace="default"} 2
gotk_reconcile_duration_seconds_bucket{kind="HelmRepository",name="podinfo",namespace="default",le="0.01"} 1
gotk_reconcile_duration_seconds_bucket{kind="HelmRepository",name="podinfo",namespace="default",le="0.038363583488692544"} 1
gotk_reconcile_duration_seconds_bucket{kind="HelmRepository",name="podinfo",namespace="default",le="0.1471764538093883"} 2
gotk_reconcile_duration_seconds_bucket{kind="HelmRepository",name="podinfo",namespace="default",le="0.5646216173286169"} 2
gotk_reconcile_duration_seconds_bucket{kind="HelmRepository",name="podinfo",namespace="default",le="2.166090855590701"} 2
gotk_reconcile_duration_seconds_bucket{kind="HelmRepository",name="podinfo",namespace="default",le="8.309900738254731"} 2
gotk_reconcile_duration_seconds_bucket{kind="HelmRepository",name="podinfo",namespace="default",le="31.879757075478317"} 2
gotk_reconcile_duration_seconds_bucket{kind="HelmRepository",name="podinfo",namespace="default",le="122.30217221643493"} 2
gotk_reconcile_duration_seconds_bucket{kind="HelmRepository",name="podinfo",namespace="default",le="469.19495946736544"} 2
gotk_reconcile_duration_seconds_bucket{kind="HelmRepository",name="podinfo",namespace="default",le="1799.9999999999986"} 2
gotk_reconcile_duration_seconds_bucket{kind="HelmRepository",name="podinfo",namespace="default",le="+Inf"} 2
gotk_reconcile_duration_seconds_sum{kind="HelmRepository",name="podinfo",namespace="default"} 0.083907428
gotk_reconcile_duration_seconds_count{kind="HelmRepository",name="podinfo",namespace="default"} 2
# HELP gotk_suspend_status The current suspend status of a GitOps Toolkit resource.
# TYPE gotk_suspend_status gauge
gotk_suspend_status{kind="HelmChart",name="podinfo",namespace="default"} 0
gotk_suspend_status{kind="HelmRepository",name="podinfo",namespace="default"} 0
```

This persists for every object in the lifetime of the program.
With this change, all these metrics are deleted once the associated objects are deleted.
