### PR TITLE
git/gogit: add proxy support for pushing to remote

### DIFF
--- a/git/gogit/client.go
+++ b/git/gogit/client.go
@@ -409,12 +409,13 @@ func (g *Client) Push(ctx context.Context, cfg repository.PushConfig) error {
 	}
 
 	err = g.repository.PushContext(ctx, &extgogit.PushOptions{
-		RefSpecs:   refspecs,
-		Force:      cfg.Force,
-		RemoteName: extgogit.DefaultRemoteName,
-		Auth:       authMethod,
-		Progress:   nil,
-		CABundle:   caBundle(g.authOpts),
+		RefSpecs:     refspecs,
+		Force:        cfg.Force,
+		RemoteName:   extgogit.DefaultRemoteName,
+		Auth:         authMethod,
+		Progress:     nil,
+		CABundle:     caBundle(g.authOpts),
+		ProxyOptions: g.proxy,
 	})
 	return goGitError(err)
 }


### PR DESCRIPTION
Add proxy support to`gogit.Client.Push()`.