### PR TITLE
*: remove deprecated `rand.Seed` calls

### DIFF
--- a/git/internal/e2e/utils.go
+++ b/git/internal/e2e/utils.go
@@ -237,7 +237,6 @@ func createSSHIdentitySecret(repoURL url.URL) (map[string][]byte, error) {
 }
 
 func randStringRunes(n int) string {
-	rand.Seed(time.Now().UnixNano())
 	b := make([]rune, n)
 	for i := range b {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]

--- a/oci/client/suite_test.go
+++ b/oci/client/suite_test.go
@@ -39,10 +39,6 @@ var (
 	dockerReg string
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 func setupRegistryServer(ctx context.Context) error {
 	// Registry config
 	config := &configuration.Configuration{}

--- a/oci/tests/integration/suite_test.go
+++ b/oci/tests/integration/suite_test.go
@@ -114,10 +114,6 @@ type ProviderConfig struct {
 	pushAppTestImages pushTestImages
 }
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz1234567890")
 
 func randStringRunes(n int) string {


### PR DESCRIPTION
Ref: https://go.dev/doc/go1.20#math/rand