### PR TITLE
runtime: update dependencies

### DIFF
--- a/runtime/go.mod
+++ b/runtime/go.mod
@@ -11,8 +11,8 @@ replace (
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1
 	github.com/fluxcd/pkg/apis/acl v0.1.0
-	github.com/fluxcd/pkg/apis/event v0.5.1
-	github.com/fluxcd/pkg/apis/meta v1.1.1
+	github.com/fluxcd/pkg/apis/event v0.5.2
+	github.com/fluxcd/pkg/apis/meta v1.1.2
 	github.com/go-logr/logr v1.2.4
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-retryablehttp v0.7.4


### PR DESCRIPTION
- github.com/fluxcd/pkg/apis/event to v0.5.2
- github.com/fluxcd/pkg/apis/meta to v1.1.2