### PR TITLE
git: add support for push options

### DIFF
--- a/git/gogit/client.go
+++ b/git/gogit/client.go
@@ -416,6 +416,7 @@ func (g *Client) Push(ctx context.Context, cfg repository.PushConfig) error {
 		Progress:     nil,
 		CABundle:     caBundle(g.authOpts),
 		ProxyOptions: g.proxy,
+		Options:      cfg.Options,
 	})
 	return goGitError(err)
 }

--- a/git/repository/options.go
+++ b/git/repository/options.go
@@ -62,6 +62,11 @@ type PushConfig struct {
 
 	// Force, if set to true, will result in a force push.
 	Force bool
+
+	// Options is a map specifying the push options that are sent
+	// to the Git server when performing a push option. For details, see:
+	// https://git-scm.com/docs/git-push#Documentation/git-push.txt---push-optionltoptiongt
+	Options map[string]string
 }
 
 // CheckoutStrategy provides options to checkout a repository to a target.


### PR DESCRIPTION
Add `PushConfig.Options` to allow specifying the push options to use when performing a push operation. For details about push options, please see: https://git-scm.com/docs/git-push#Documentation/git-push.txt---push-optionltoptiongt

This is useful for platforms like GitLab when used with image-automation-controller by enabling the creation of MRs automatically upon a push operation (ref: https://docs.gitlab.com/ee/user/project/push_options.html#push-options-for-merge-requests)

Update: Wrote a test case to test whether the push options are indeed send to the Git server.
```go
func TestPush_options(t *testing.T) {
	g := NewWithT(t)

	ggc, err := NewClient(t.TempDir(), &git.AuthOptions{
		Transport: git.HTTPS,
		Username:  "aryan9600",
		Password:  "***",
	})
	g.Expect(err).ToNot(HaveOccurred())

	_, err = ggc.Clone(context.TODO(), "https://gitlab.com/aryan9600/empty-test.git", repository.CloneConfig{
		CheckoutStrategy: repository.CheckoutStrategy{
			Branch: "main",
		},
	})
	g.Expect(err).ToNot(HaveOccurred())

	err = ggc.SwitchBranch(context.TODO(), "options")
	g.Expect(err).ToNot(HaveOccurred())

	_, err = ggc.Commit(
		git.Commit{
			Author: git.Signature{
				Name:  "Test User",
				Email: "test@example.com",
			},
			Message: "testing",
		},
		repository.WithFiles(map[string]io.Reader{
			"test": strings.NewReader("testing gogit commit"),
		}),
	)
	g.Expect(err).ToNot(HaveOccurred())

	err = ggc.Push(context.TODO(), repository.PushConfig{
		Options: map[string]string{
			"merge_request.create": "",
			"merge_request.target": "main",
		},
	})
	g.Expect(err).ToNot(HaveOccurred())
}
```

This successfully created a new MR from `options` to `main`.