### PR TITLE
git: add support for key `ca.crt` to specify CA data

### DIFF
--- a/git/options.go
+++ b/git/options.go
@@ -87,6 +87,11 @@ func (o AuthOptions) Validate() error {
 func NewAuthOptions(u url.URL, data map[string][]byte) (*AuthOptions, error) {
 	opts := newAuthOptions(u)
 	if len(data) > 0 {
+		var caBytes []byte
+		// ca.crt takes precedence over caFile.
+		if caBytes = data["ca.crt"]; len(caBytes) == 0 {
+			caBytes = data["caFile"]
+		}
 		if opts.Transport == SSH {
 			opts.Identity = data["identity"]
 			opts.KnownHosts = data["known_hosts"]
@@ -99,10 +104,10 @@ func NewAuthOptions(u url.URL, data map[string][]byte) (*AuthOptions, error) {
 				opts.Username = DefaultPublicKeyAuthUser
 			}
 		} else if token, found := data["bearerToken"]; found {
-			opts.CAFile = data["caFile"]
+			opts.CAFile = caBytes
 			opts.BearerToken = string(token)
 		} else {
-			opts.CAFile = data["caFile"]
+			opts.CAFile = caBytes
 			opts.Username = string(data["username"])
 			opts.Password = string(data["password"])
 		}

--- a/git/options_test.go
+++ b/git/options_test.go
@@ -188,7 +188,7 @@ func TestAuthOptionsFromData(t *testing.T) {
 				"password":    []byte("secret"),
 				"identity":    []byte(privateKeyFixture),
 				"known_hosts": []byte(knownHostsFixture),
-				"caFile":      []byte("mock"),
+				"ca.crt":      []byte("mock"),
 			},
 
 			wantFunc: func(g *WithT, opts *AuthOptions) {
@@ -209,7 +209,7 @@ func TestAuthOptionsFromData(t *testing.T) {
 				"bearerToken": []byte("token"),
 				"identity":    []byte(privateKeyFixture),
 				"known_hosts": []byte(knownHostsFixture),
-				"caFile":      []byte("mock"),
+				"ca.crt":      []byte("mock"),
 			},
 
 			wantFunc: func(g *WithT, opts *AuthOptions) {
@@ -230,7 +230,7 @@ func TestAuthOptionsFromData(t *testing.T) {
 				"bearerToken": []byte("token"),
 				"identity":    []byte(privateKeyFixture),
 				"known_hosts": []byte(knownHostsFixture),
-				"caFile":      []byte("mock"),
+				"ca.crt":      []byte("mock"),
 			},
 
 			wantFunc: func(g *WithT, opts *AuthOptions) {
@@ -265,10 +265,31 @@ func TestAuthOptionsFromData(t *testing.T) {
 			},
 		},
 		{
-			name: "Sets caFile for HTTPS",
+			name: "Sets CAFile for HTTPS using ca.crt",
+			URL:  "https://example.com",
+			data: map[string][]byte{
+				"ca.crt": []byte("mock"),
+			},
+			wantFunc: func(g *WithT, opts *AuthOptions) {
+				g.Expect(opts.CAFile).To(BeEquivalentTo("mock"))
+			},
+		},
+		{
+			name: "Sets CAFile for HTTPS using caFile",
 			URL:  "https://example.com",
 			data: map[string][]byte{
 				"caFile": []byte("mock"),
+			},
+			wantFunc: func(g *WithT, opts *AuthOptions) {
+				g.Expect(opts.CAFile).To(BeEquivalentTo("mock"))
+			},
+		},
+		{
+			name: "Sets CAFile for HTTPS using ca.crt and ignores caFile",
+			URL:  "https://example.com",
+			data: map[string][]byte{
+				"ca.crt": []byte("mock"),
+				"caFile": []byte("ignored"),
 			},
 			wantFunc: func(g *WithT, opts *AuthOptions) {
 				g.Expect(opts.CAFile).To(BeEquivalentTo("mock"))


### PR DESCRIPTION
Add support for key `ca.crt` in `NewAuthOptions()` to read CA certificate data. It takes precedence over `caFile`.