### PR TITLE
oci/auth: Add support for Azure China and US Gov regions

### DIFF
--- a/oci/auth/azure/auth.go
+++ b/oci/auth/azure/auth.go
@@ -74,10 +74,10 @@ func (c *Client) getLoginAuth(ctx context.Context, registryURL string) (authn.Au
 		c.credential = cred
 	}
 
+	configurationEnvironment := getCloudConfiguration(registryURL)
 	// Obtain access token using the token credential.
-	// TODO: Add support for other azure endpoints as well.
 	armToken, err := c.credential.GetToken(ctx, policy.TokenRequestOptions{
-		Scopes: []string{cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint + "/" + ".default"},
+		Scopes: []string{configurationEnvironment.Services[cloud.ResourceManager].Endpoint + "/" + ".default"},
 	})
 	if err != nil {
 		return authConfig, err
@@ -96,6 +96,19 @@ func (c *Client) getLoginAuth(ctx context.Context, registryURL string) (authn.Au
 		Username: "00000000-0000-0000-0000-000000000000",
 		Password: accessToken,
 	}, nil
+}
+
+// getCloudConfiguration returns the cloud configuration based on the registry URL.
+// List from https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/containers/azcontainerregistry/cloud_config.go#L16
+func getCloudConfiguration(url string) cloud.Configuration {
+	switch {
+	case strings.HasSuffix(url, ".azurecr.cn"):
+		return cloud.AzureChina
+	case strings.HasSuffix(url, ".azurecr.us"):
+		return cloud.AzureGovernment
+	default:
+		return cloud.AzurePublic
+	}
 }
 
 // ValidHost returns if a given host is a Azure container registry.

--- a/oci/auth/azure/auth_test.go
+++ b/oci/auth/azure/auth_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	. "github.com/onsi/gomega"
@@ -109,6 +110,25 @@ func TestValidHost(t *testing.T) {
 		t.Run(tt.host, func(t *testing.T) {
 			g := NewWithT(t)
 			g.Expect(ValidHost(tt.host)).To(Equal(tt.result))
+		})
+	}
+}
+
+func TestGetCloudConfiguration(t *testing.T) {
+	tests := []struct {
+		host   string
+		result cloud.Configuration
+	}{
+		{"foo.azurecr.io", cloud.AzurePublic},
+		{"foo.azurecr.cn", cloud.AzureChina},
+		{"foo.azurecr.de", cloud.AzurePublic},
+		{"foo.azurecr.us", cloud.AzureGovernment},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(getCloudConfiguration(tt.host)).To(Equal(tt.result))
 		})
 	}
 }


### PR DESCRIPTION
### Description
When using the OCI authentication in azure with managed identity in usgovernment  environment, the source-controller  cannot get the permissions for the cloud because it defaults to the public azure cloud. 

### Error
```
error logging into ACR error exchanging token: unexpected status code 401 from exchange request,
 response body: {\"errors\":[{\"code\":\"UNAUTHORIZED\", \"message\":\"retrieving permissions failed: 
https://management.usgovcloudapi.net/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.ContainerRegistry/registries/xxx/providers/Microsoft.Authorization/permissions/?api-version=xxx\"}]}"
```
### Fix
The fix proposes a map for each azure cloud environment that is automatically detected by the suffix of the ACR.
