### PR TITLE
Disable azure CI jobs

### DIFF
--- a/.github/workflows/integration-azure.yaml
+++ b/.github/workflows/integration-azure.yaml
@@ -2,8 +2,8 @@ name: integration-azure
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 12 * * *"
+  # schedule:
+  #   - cron: "0 12 * * *"
   # push:
   #   branches:
   #     - main

--- a/.github/workflows/integration-cleanup.yaml
+++ b/.github/workflows/integration-cleanup.yaml
@@ -64,6 +64,7 @@ jobs:
     defaults:
       run:
         working-directory: ./tools/reaper
+    if: false
     steps:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3


### PR DESCRIPTION
No azure subscription to run the tests.

Refer:
- https://github.com/fluxcd/pkg/actions/workflows/integration-azure.yaml
- https://github.com/fluxcd/pkg/actions/workflows/integration-cleanup.yaml
