### PR TITLE
Remove special error handling for secrets

### DIFF
--- a/ssa/manager_apply_test.go
+++ b/ssa/manager_apply_test.go
@@ -175,7 +175,9 @@ func TestApply_Force(t *testing.T) {
 		}
 
 		// verify that the error message does not contain sensitive information
-		expectedErr := fmt.Sprintf("%s invalid, error: secret is immutable", FmtUnstructured(secret))
+		expectedErr := fmt.Sprintf(
+			"%s dry-run failed, reason: Invalid: Secret \"%s\" is invalid: data: Forbidden: field is immutable when `immutable` is set",
+			FmtUnstructured(secret), secret.GetName())
 		if diff := cmp.Diff(expectedErr, err.Error()); diff != "" {
 			t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
 		}

--- a/ssa/manager_diff.go
+++ b/ssa/manager_diff.go
@@ -20,7 +20,6 @@ package ssa
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -186,14 +185,6 @@ func (m *ResourceManager) validationError(object *unstructured.Unstructured, err
 	}
 
 	reason := fmt.Sprintf("%v", apierrors.ReasonForError(err))
-
-	if object.GetKind() == "Secret" {
-		msg := "data values must be of type string"
-		if strings.Contains(err.Error(), "immutable") {
-			msg = "secret is immutable"
-		}
-		return fmt.Errorf("%s %s, error: %s", FmtUnstructured(object), strings.ToLower(reason), msg)
-	}
 
 	// detect managed field conflict
 	if status, ok := apierrors.StatusCause(err, metav1.CauseTypeFieldManagerConflict); ok {


### PR DESCRIPTION
This pull request removes the special error handling for secrets that was used to prevent leaking secret data in the error message. With the move to server-side apply, the original patch (which contained the secret data) is no longer returned in the error.

Fix: https://github.com/fluxcd/kustomize-controller/issues/946
Fix: https://github.com/fluxcd/flux2/issues/4122