### PR TITLE
Skip git e2e tests for dependabot PRs

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   git-test:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
The bot doesn't have access to the secrets needed to perform these tests.
