### PR TITLE
ssa: improve data masking

### DIFF
--- a/ssa/sanitize.go
+++ b/ssa/sanitize.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2023 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ssa
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	sanitizeMaskDefault = "***"
+	sanitizeMaskBefore  = "*** (before)"
+	sanitizeMaskAfter   = "*** (after)"
+)
+
+// SanitizeUnstructuredData masks the "data" values of an Unstructured object,
+// the objects are modified in place.
+// If the data value is the same in both objects, the mask is replaced with a
+// default mask. If the data value is different, the mask is replaced with a
+// before and after mask.
+func SanitizeUnstructuredData(old, new *unstructured.Unstructured) error {
+	oldData, err := getUnstructuredData(old)
+	if err != nil {
+		return fmt.Errorf("unable to get data from old object: %w", err)
+	}
+
+	newData, err := getUnstructuredData(new)
+	if err != nil {
+		return fmt.Errorf("unable to get data from new object: %w", err)
+	}
+
+	for k, _ := range oldData {
+		if _, ok := newData[k]; ok {
+			if oldData[k] != newData[k] {
+				oldData[k] = sanitizeMaskBefore
+				newData[k] = sanitizeMaskAfter
+				continue
+			}
+			newData[k] = sanitizeMaskDefault
+		}
+		oldData[k] = sanitizeMaskDefault
+	}
+	for k, _ := range newData {
+		if _, ok := oldData[k]; !ok {
+			newData[k] = sanitizeMaskDefault
+		}
+	}
+
+	if old != nil && oldData != nil {
+		if err = unstructured.SetNestedMap(old.Object, oldData, "data"); err != nil {
+			return fmt.Errorf("masking data in old object failed: %w", err)
+		}
+	}
+
+	if new != nil && newData != nil {
+		if err = unstructured.SetNestedMap(new.Object, newData, "data"); err != nil {
+			return fmt.Errorf("masking data in new object failed: %w", err)
+		}
+	}
+	return nil
+}
+
+// getUnstructuredData returns the data map from an Unstructured. If the given
+// object is nil or does not contain a data map, nil is returned.
+func getUnstructuredData(u *unstructured.Unstructured) (map[string]interface{}, error) {
+	if u == nil {
+		return nil, nil
+	}
+	data, found, err := unstructured.NestedMap(u.UnstructuredContent(), "data")
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+	return data, nil
+}

--- a/ssa/sanitize_test.go
+++ b/ssa/sanitize_test.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2023 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ssa
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestSanitizeUnstructuredData(t *testing.T) {
+	type diff struct {
+		old *unstructured.Unstructured
+		new *unstructured.Unstructured
+	}
+
+	tests := []struct {
+		name    string
+		input   diff
+		want    diff
+		wantErr bool
+	}{
+		{
+			name: "sanitizes data",
+			input: diff{
+				old: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{
+							"token":    "abc",
+							"password": "123",
+						},
+					},
+				},
+				new: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{
+							"token":    "abc",
+							"password": "123",
+						},
+					},
+				},
+			},
+			want: diff{
+				old: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{
+							"token":    sanitizeMaskDefault,
+							"password": sanitizeMaskDefault,
+						},
+					},
+				},
+				new: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{
+							"token":    sanitizeMaskDefault,
+							"password": sanitizeMaskDefault,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "sanitizes data with different values",
+			input: diff{
+				old: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{
+							"token":    "abc",
+							"password": "123",
+						},
+					},
+				},
+				new: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{
+							"token":    "def",
+							"password": "456",
+						},
+					},
+				},
+			},
+			want: diff{
+				old: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{
+							"token":    sanitizeMaskBefore,
+							"password": sanitizeMaskBefore,
+						},
+					},
+				},
+				new: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{
+							"token":    sanitizeMaskAfter,
+							"password": sanitizeMaskAfter,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "sanitizes data with different keys",
+			input: diff{
+				old: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{
+							"token":    "abc",
+							"password": "123",
+						},
+					},
+				},
+				new: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{
+							"username": "hello",
+							"token":    "abc",
+						},
+					},
+				},
+			},
+			want: diff{
+				old: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{
+							"token":    sanitizeMaskDefault,
+							"password": sanitizeMaskDefault,
+						},
+					},
+				},
+				new: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{
+							"username": sanitizeMaskDefault,
+							"token":    sanitizeMaskDefault,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "sanitizes new object without old object",
+			input: diff{
+				old: nil,
+				new: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{
+							"token": "abc",
+						},
+					},
+				},
+			},
+			want: diff{
+				old: nil,
+				new: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{
+							"token": sanitizeMaskDefault,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "sanitizes old object without new object",
+			input: diff{
+				old: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{
+							"token": "abc",
+						},
+					},
+				},
+				new: nil,
+			},
+			want: diff{
+				old: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{
+							"token": sanitizeMaskDefault,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "sanitizes empty objecct",
+			input: diff{
+				old: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{},
+					},
+				},
+				new: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{},
+					},
+				},
+			},
+			want: diff{
+				old: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{},
+					},
+				},
+				new: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"data": map[string]interface{}{},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := SanitizeUnstructuredData(tt.input.old, tt.input.new); (err != nil) != tt.wantErr {
+				t.Errorf("SanitizeUnstructuredData() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.input.old != nil && tt.want.old != nil {
+				if diff := cmp.Diff(tt.input.old, tt.want.old); diff != "" {
+					t.Errorf("SanitizeUnstructuredData() old mismatch (-want +got):\n%s", diff)
+				}
+			}
+
+			if tt.input.new != nil && tt.want.new != nil {
+				if diff := cmp.Diff(tt.input.new, tt.want.new); diff != "" {
+					t.Errorf("SanitizeUnstructuredData() new mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/ssa/utils.go
+++ b/ssa/utils.go
@@ -24,7 +24,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	hpav2 "k8s.io/api/autoscaling/v2"
 	hpav2beta1 "k8s.io/api/autoscaling/v2beta1"
@@ -96,69 +95,6 @@ func FmtUnstructuredList(objects []*unstructured.Unstructured) string {
 		b.WriteString(FmtObjMetadata(object.UnstructuredToObjMetadata(obj)) + "\n")
 	}
 	return strings.TrimSuffix(b.String(), "\n")
-}
-
-func getNestedMap(object *unstructured.Unstructured) (map[string]interface{}, bool, error) {
-	dryRunData, foundDryRun, err := unstructured.NestedMap(object.Object, "data")
-	if err != nil {
-		return nil, foundDryRun, err
-	}
-
-	return dryRunData, foundDryRun, nil
-}
-
-func setNestedMap(object *unstructured.Unstructured, data map[string]interface{}) error {
-	err := unstructured.SetNestedMap(object.Object, data, "data")
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func cmpMaskData(currentData, futureData map[string]interface{}) (map[string]interface{}, map[string]interface{}) {
-	for k, currentVal := range currentData {
-		futureVal, ok := futureData[k]
-		if !ok {
-			// if the key is not in the existing object, we apply the default masking
-			currentData[k] = defaultMask
-			continue
-		}
-		// if the key is in the existing object, we need to check if the value is the same
-		if cmp.Diff(currentVal, futureVal) != "" {
-			// if the value is different, we need to apply different masking
-			currentData[k] = defaultMask
-			futureData[k] = diffMask
-			continue
-		}
-		// if the value is the same, we apply the same masking
-		currentData[k] = defaultMask
-		futureData[k] = defaultMask
-	}
-
-	for k := range futureData {
-		if _, ok := currentData[k]; !ok {
-			// if the key is not in the dry run object, we apply the default masking
-			futureData[k] = defaultMask
-		}
-	}
-
-	return currentData, futureData
-}
-
-// maskSecret replaces the data key values with the given mask.
-func maskSecret(data map[string]interface{}, object *unstructured.Unstructured, mask string) (*unstructured.Unstructured, error) {
-
-	for k := range data {
-		data[k] = mask
-	}
-
-	err := setNestedMap(object, data)
-	if err != nil {
-		return nil, err
-	}
-
-	return object, err
 }
 
 // ReadObject decodes a YAML or JSON document from the given reader into an unstructured Kubernetes API object.
@@ -283,6 +219,11 @@ func IsKustomization(object *unstructured.Unstructured) bool {
 		return true
 	}
 	return false
+}
+
+// IsSecret returns true if the given object is a Kubernetes Secret.
+func IsSecret(object *unstructured.Unstructured) bool {
+	return strings.ToLower(object.GetKind()) == "secret" && object.GetAPIVersion() == "v1"
 }
 
 // Match CEL immutable error variants.

--- a/ssa/utils_test.go
+++ b/ssa/utils_test.go
@@ -21,77 +21,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 )
-
-func TestCmpMaskData(t *testing.T) {
-	testCases := []struct {
-		name     string
-		current  map[string]interface{}
-		future   map[string]interface{}
-		expected string
-	}{
-		{
-			name:     "empty",
-			current:  map[string]interface{}{},
-			future:   map[string]interface{}{},
-			expected: "",
-		},
-		{
-			name: "no change",
-			current: map[string]interface{}{
-				"foo": "bar",
-			},
-			future: map[string]interface{}{
-				"foo": "bar",
-			},
-			expected: "",
-		},
-		{
-			name: "simple value changed",
-			current: map[string]interface{}{
-				"foo": "bar",
-			},
-			future: map[string]interface{}{
-				"foo": "baz",
-			},
-			expected: fmt.Sprintf("foo\": string(\"%s\")", defaultMask),
-		},
-		{
-			name: "simple value changed with different casing",
-			current: map[string]interface{}{
-				"foo": "bar",
-			},
-			future: map[string]interface{}{
-				"FOO": "baz",
-			},
-			expected: fmt.Sprintf("foo\": string(\"%s\")", defaultMask),
-		},
-		{
-			name: "value changed with different casing and different values",
-			current: map[string]interface{}{
-				"foo": "bar",
-				"baz": "qux",
-			},
-			future: map[string]interface{}{
-				"foo": "baz",
-				"baz": "qux",
-			},
-			expected: fmt.Sprintf("baz\": string(\"%s\")", defaultMask),
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			c, ft := cmpMaskData(tc.current, tc.future)
-			if diff := cmp.Diff(c, ft); !strings.Contains(diff, tc.expected) {
-				t.Errorf("expected %s in %s", tc.expected, diff)
-			}
-		})
-	}
-
-}
 
 func TestReadObjects_DropsInvalid(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
Instead of masking the data with `****` or `*****`, provide an easier to distinguish `*** (before)` and `*** (after)` for values which have changed. Matching the output of `kubectl diff`.

In addition, make the function public as it can be of use outside of the `Diff` of the resource manager, and allow passing only one instance of an object (for scenarios where a resource is either created or deleted).