### PR TITLE
Add integration tests for Workload Identity

### DIFF
--- a/oci/tests/integration/Makefile
+++ b/oci/tests/integration/Makefile
@@ -25,3 +25,12 @@ test-azure:
 
 test-gcp:
 	$(MAKE) test PROVIDER_ARG="-provider gcp"
+
+test-gcp-wi:
+	$(MAKE) test PROVIDER_ARG="-provider gcp -enable-wi" TF_VAR_enable_wi=true TF_VAR_k8s_serviceaccount_name=test-workload-id
+
+test-aws-wi:
+	$(MAKE) test PROVIDER_ARG="-provider aws -enable-wi" TF_VAR_enable_wi=true TF_VAR_k8s_serviceaccount_name=test-workload-id
+
+test-azure-wi:
+	$(MAKE) test PROVIDER_ARG="-provider azure -enable-wi" TF_VAR_enable_wi=true TF_VAR_k8s_serviceaccount_name=test-workload-id

--- a/oci/tests/integration/aws_test.go
+++ b/oci/tests/integration/aws_test.go
@@ -21,10 +21,15 @@ package integration
 
 import (
 	"context"
+	"fmt"
 
 	tfjson "github.com/hashicorp/terraform-json"
 
 	"github.com/fluxcd/test-infra/tftestenv"
+)
+
+const (
+	roleArnAnnotation = "eks.amazonaws.com/role-arn"
 )
 
 // createKubeconfigEKS constructs kubeconfig from the terraform state output at
@@ -79,4 +84,17 @@ func pushAppTestImagesECR(ctx context.Context, localImgs map[string]string, outp
 	repo := output["ecr_test_app_repo_url"].Value.(string)
 	remoteImage := repo + ":test"
 	return tftestenv.PushTestAppImagesECR(ctx, localImgs, remoteImage)
+}
+
+// getServiceAccountAnnotationAWS returns annotations for a kubernetes service account required to configure IRSA on AWS.
+// It gets the role ARN from the terraform output and returns the map[eks.amazonaws.com/role-arn=<arn>]
+func getServiceAccountAnnotationAWS(output map[string]*tfjson.StateOutput) (map[string]string, error) {
+	iamARN := output["aws_iam_arn"].Value.(string)
+	if iamARN == "" {
+		return nil, fmt.Errorf("no AWS iam role arn in terraform output")
+	}
+
+	return map[string]string{
+		roleArnAnnotation: iamARN,
+	}, nil
 }

--- a/oci/tests/integration/repo_list_test.go
+++ b/oci/tests/integration/repo_list_test.go
@@ -92,6 +92,17 @@ func testImageRepositoryListTags(t *testing.T, args []string) {
 	}
 	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
 
+	if *enableWI {
+		job.Spec.Template.Spec.ServiceAccountName = testSA
+
+		// azure requires this label on the pod for workload identity to work.
+		if *targetProvider == "azure" {
+			job.Spec.Template.Labels = map[string]string{
+				"azure.workload.identity/use": "true",
+			}
+		}
+	}
+
 	key := client.ObjectKeyFromObject(job)
 
 	g.Expect(testEnv.Client.Create(ctx, job)).To(Succeed())

--- a/oci/tests/integration/terraform/aws/main.tf
+++ b/oci/tests/integration/terraform/aws/main.tf
@@ -10,7 +10,7 @@ locals {
 }
 
 module "eks" {
-  source = "git::https://github.com/somtochiama/test-infra.git//tf-modules/aws/eks?ref=gcp-workload-id"
+  source = "git::https://github.com/fluxcd/test-infra.git//tf-modules/aws/eks"
 
   name = local.name
   tags = var.tags

--- a/oci/tests/integration/terraform/aws/oidc_assume_role_policy.json
+++ b/oci/tests/integration/terraform/aws/oidc_assume_role_policy.json
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "${OIDC_ARN}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "${OIDC_URL}:aud": "sts.amazonaws.com",
+          "${OIDC_URL}:sub": "system:serviceaccount:${NAMESPACE}:${SA_NAME}"
+        }
+      }
+    }
+  ]
+}

--- a/oci/tests/integration/terraform/aws/outputs.tf
+++ b/oci/tests/integration/terraform/aws/outputs.tf
@@ -39,3 +39,7 @@ output "ecr_registry_id" {
 output "ecr_test_app_repo_url" {
   value = module.test_app_ecr.repository_url
 }
+
+output "aws_iam_arn" {
+  value = var.enable_wi ? aws_iam_role.assume_role[0].arn : ""
+}

--- a/oci/tests/integration/terraform/aws/variables.tf
+++ b/oci/tests/integration/terraform/aws/variables.tf
@@ -11,3 +11,21 @@ variable "cross_region" {
   type        = string
   description = "different region for testing cross region resources"
 }
+
+variable "k8s_serviceaccount_name" {
+  type        = string
+  default     = "test"
+  description = "Name of kubernetes service account that can assume the IAM role"
+}
+
+variable "k8s_serviceaccount_ns" {
+  type        = string
+  default     = "default"
+  description = "Namespace of kubernetes service account that can assume the IAM rolet"
+}
+
+variable "enable_wi" {
+  type        = bool
+  default     = false
+  description = "If set to true, will creat IAM role and policy for workload identity"
+}

--- a/oci/tests/integration/terraform/azure/outputs.tf
+++ b/oci/tests/integration/terraform/azure/outputs.tf
@@ -10,3 +10,7 @@ output "acr_registry_url" {
 output "acr_registry_id" {
   value = module.acr.registry_id
 }
+
+output "user_identity_client_id" {
+  value = var.enable_wi ? azurerm_user_assigned_identity.wi-id[0].client_id : ""
+}

--- a/oci/tests/integration/terraform/azure/variables.tf
+++ b/oci/tests/integration/terraform/azure/variables.tf
@@ -7,3 +7,21 @@ variable "tags" {
   type    = map(string)
   default = {}
 }
+
+variable "k8s_serviceaccount_name" {
+  type        = string
+  default     = "test"
+  description = "Name of kubernetes service account to establish federated identity with"
+}
+
+variable "k8s_serviceaccount_ns" {
+  type        = string
+  default     = "default"
+  description = "Namespace of kubernetes service account to establish federated identity with"
+}
+
+variable "enable_wi" {
+  type        = bool
+  default     = false
+  description = "Enable workload identity on cluster and create federated identity"
+}

--- a/oci/tests/integration/terraform/gcp/main.tf
+++ b/oci/tests/integration/terraform/gcp/main.tf
@@ -11,7 +11,7 @@ locals {
 }
 
 module "gke" {
-  source = "git::https://github.com/somtochiama/test-infra.git//tf-modules/gcp/gke?ref=gcp-workload-id"
+  source = "git::https://github.com/fluxcd/test-infra.git//tf-modules/gcp/gke"
 
   name      = local.name
   tags      = var.tags

--- a/oci/tests/integration/terraform/gcp/outputs.tf
+++ b/oci/tests/integration/terraform/gcp/outputs.tf
@@ -18,3 +18,11 @@ output "gcr_repository_url" {
 output "gcp_artifact_repository" {
   value = module.gcr.artifact_repository_id
 }
+
+output "iam_serviceaccount_email" {
+  value = var.enable_wi ? google_service_account.test[0].email : ""
+}
+
+output "input_sa" {
+  value = var.serviceaccount_name
+}

--- a/oci/tests/integration/terraform/gcp/outputs.tf
+++ b/oci/tests/integration/terraform/gcp/outputs.tf
@@ -22,7 +22,3 @@ output "gcp_artifact_repository" {
 output "iam_serviceaccount_email" {
   value = var.enable_wi ? google_service_account.test[0].email : ""
 }
-
-output "input_sa" {
-  value = var.serviceaccount_name
-}

--- a/oci/tests/integration/terraform/gcp/variables.tf
+++ b/oci/tests/integration/terraform/gcp/variables.tf
@@ -21,3 +21,21 @@ variable "tags" {
   type    = map(string)
   default = {}
 }
+
+variable "k8s_serviceaccount_name" {
+  type        = string
+  default     = "test"
+  description = "Name of kubernetes service account to be bound to GCP IAM serviceaccount"
+}
+
+variable "k8s_serviceaccount_ns" {
+  type        = string
+  default     = "default"
+  description = "Namespace of kubernetes service account to be bound to GCP IAM serviceaccount"
+}
+
+variable "enable_wi" {
+  type        = bool
+  default     = false
+  description = "Enable workload identity on cluster and create a federated identity with serviceaccount"
+}


### PR DESCRIPTION
This pull request extends the integration tests for the oci pkg to include workload identity.
