### PR TITLE
git/gogit: Use shallowclone in cloneRefName tests

### DIFF
--- a/git/gogit/clone_test.go
+++ b/git/gogit/clone_test.go
@@ -643,6 +643,7 @@ func TestClone_cloneRefName(t *testing.T) {
 				CheckoutStrategy: repository.CheckoutStrategy{
 					RefName: tt.refName,
 				},
+				ShallowClone:       true,
 				LastObservedCommit: tt.lastRevision,
 			})
 


### PR DESCRIPTION
For consistency across the various clone test, add shallow clone option in cloneRefName test.

Follow-up of https://github.com/fluxcd/pkg/pull/666.