### PR TITLE
[oci] Extend oci.Push to create layer with static uncompressed contents

### DIFF
--- a/oci/client/build.go
+++ b/oci/client/build.go
@@ -33,6 +33,10 @@ import (
 // Build archives the given directory as a tarball to the given local path.
 // While archiving, any environment specific data (for example, the user and group name) is stripped from file headers.
 func (c *Client) Build(artifactPath, sourceDir string, ignorePaths []string) (err error) {
+	return build(artifactPath, sourceDir, ignorePaths)
+}
+
+func build(artifactPath, sourceDir string, ignorePaths []string) (err error) {
 	absDir, err := filepath.Abs(sourceDir)
 	if err != nil {
 		return err

--- a/oci/client/build_test.go
+++ b/oci/client/build_test.go
@@ -31,7 +31,6 @@ import (
 
 func TestBuild(t *testing.T) {
 	g := NewWithT(t)
-	c := NewClient(DefaultOptions())
 
 	absPath := fmt.Sprintf("%s/deployment.yaml", t.TempDir())
 	err := copyFile(absPath, "testdata/artifact/deployment.yaml")
@@ -97,7 +96,7 @@ func TestBuild(t *testing.T) {
 			tmpDir := t.TempDir()
 			artifactPath := filepath.Join(tmpDir, "files.tar.gz")
 
-			err := c.Build(artifactPath, tt.path, tt.ignorePath)
+			err := build(artifactPath, tt.path, tt.ignorePath)
 			if tt.expectErr {
 				g.Expect(err).To(HaveOccurred())
 				return

--- a/oci/client/diff.go
+++ b/oci/client/diff.go
@@ -45,7 +45,7 @@ func (c *Client) Diff(ctx context.Context, url, dir string, ignorePaths []string
 
 	tmpFile := filepath.Join(tmpBuildDir, "artifact.tgz")
 
-	if err := c.Build(tmpFile, dir, ignorePaths); err != nil {
+	if err := build(tmpFile, dir, ignorePaths); err != nil {
 		return fmt.Errorf("building artifact failed: %w", err)
 	}
 

--- a/oci/client/diff_test.go
+++ b/oci/client/diff_test.go
@@ -41,7 +41,7 @@ func TestClient_Diff(t *testing.T) {
 	}
 
 	testDir := "testdata/artifact"
-	_, err := c.Push(ctx, url, testDir, metadata, nil)
+	_, err := c.Push(ctx, url, testDir, WithPushMetadata(metadata))
 	g.Expect(err).ToNot(HaveOccurred())
 
 	err = c.Diff(ctx, url, testDir, nil)
@@ -56,7 +56,7 @@ func TestClient_Diff(t *testing.T) {
 	newTag := "v0.0.2"
 	url = fmt.Sprintf("%s/%s:%s", dockerReg, repo, newTag)
 
-	_, err = c.Push(ctx, url, tmpBuildDir, metadata, nil)
+	_, err = c.Push(ctx, url, tmpBuildDir, WithPushMetadata(metadata))
 	g.Expect(err).ToNot(HaveOccurred())
 
 	err = c.Diff(ctx, url, testDir, nil)

--- a/oci/client/pull_test.go
+++ b/oci/client/pull_test.go
@@ -43,7 +43,7 @@ func Test_PullAnyTarball(t *testing.T) {
 	dst := fmt.Sprintf("%s/%s:%s", dockerReg, repo, tag)
 
 	artifact := filepath.Join(t.TempDir(), "artifact.tgz")
-	g.Expect(c.Build(artifact, testDir, nil)).To(Succeed())
+	g.Expect(build(artifact, testDir, nil)).To(Succeed())
 
 	img := mutate.MediaType(empty.Image, types.OCIManifestSchema1)
 	img = mutate.ConfigMediaType(img, oci.CanonicalConfigMediaType)

--- a/oci/client/push.go
+++ b/oci/client/push.go
@@ -28,45 +28,100 @@ import (
 	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/static"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 
 	"github.com/fluxcd/pkg/oci"
 )
 
-// Push creates an artifact from the given directory, uploads the artifact
+// LayerType is an enumeration of the supported layer types
+// when pushing an image.
+type LayerType string
+
+const (
+	// LayerTypeTarball produces a layer that contains a gzipped archive
+	LayerTypeTarball LayerType = "tarball"
+	// LayerTypeStatic produces a layer that contains the contents of a
+	// file without any compression.
+	LayerTypeStatic LayerType = "static"
+)
+
+// PushOptions are options for configuring the Push operation.
+type PushOptions struct {
+	layerType LayerType
+	layerOpts layerOptions
+	meta      Metadata
+}
+
+// layerOptions are options for configuring a layer.
+type layerOptions struct {
+	mediaTypeExt string
+	ignorePaths  []string
+}
+
+// PushOption is a function for configuring PushOptions.
+type PushOption func(o *PushOptions)
+
+// WithPushLayerType set the layer type that will be used when creating
+// the image layer.
+func WithPushLayerType(l LayerType) PushOption {
+	return func(o *PushOptions) {
+		o.layerType = l
+	}
+}
+
+// WithPushMediaTypeExt configures the media type extension for the image layer.
+// This is only used when the layer type is `LayerTypeStatic`.
+// The final media type will be prefixed with `application/vnd.cncf.flux.content.v1`
+func WithPushMediaTypeExt(extension string) PushOption {
+	return func(o *PushOptions) {
+		o.layerOpts.mediaTypeExt = extension
+	}
+}
+
+// WithPushIgnorePaths configures ignore paths for PushOptions
+func WithPushIgnorePaths(paths ...string) PushOption {
+	return func(o *PushOptions) {
+		o.layerOpts.ignorePaths = append(o.layerOpts.ignorePaths, paths...)
+	}
+}
+
+// WithPushMetadata configures Metadata that will be used for image annotations.
+func WithPushMetadata(meta Metadata) PushOption {
+	return func(o *PushOptions) {
+		o.meta = meta
+	}
+}
+
+// Push creates an artifact from the given path, uploads the artifact
 // to the given OCI repository and returns the digest.
-func (c *Client) Push(ctx context.Context, url, sourceDir string, meta Metadata, ignorePaths []string) (string, error) {
+func (c *Client) Push(ctx context.Context, url, sourcePath string, opts ...PushOption) (string, error) {
+	o := &PushOptions{
+		layerType: LayerTypeTarball,
+	}
+
+	for _, opt := range opts {
+		opt(o)
+	}
 	ref, err := name.ParseReference(url)
 	if err != nil {
 		return "", fmt.Errorf("invalid URL: %w", err)
 	}
 
-	tmpDir, err := os.MkdirTemp("", "oci")
+	layer, err := createLayer(sourcePath, o.layerType, o.layerOpts)
 	if err != nil {
-		return "", err
-	}
-	defer os.RemoveAll(tmpDir)
-
-	tmpFile := filepath.Join(tmpDir, "artifact.tgz")
-
-	if err := c.Build(tmpFile, sourceDir, ignorePaths); err != nil {
-		return "", err
+		return "", fmt.Errorf("error creating layer: %w", err)
 	}
 
-	if meta.Created == "" {
+	if o.meta.Created == "" {
 		ct := time.Now().UTC()
-		meta.Created = ct.Format(time.RFC3339)
+		o.meta.Created = ct.Format(time.RFC3339)
 	}
 
 	img := mutate.MediaType(empty.Image, types.OCIManifestSchema1)
 	img = mutate.ConfigMediaType(img, oci.CanonicalConfigMediaType)
-	img = mutate.Annotations(img, meta.ToAnnotations()).(gcrv1.Image)
-
-	layer, err := tarball.LayerFromFile(tmpFile, tarball.WithMediaType(oci.CanonicalContentMediaType))
-	if err != nil {
-		return "", fmt.Errorf("creating content layer failed: %w", err)
-	}
+	img = mutate.Annotations(img, o.meta.ToAnnotations()).(gcrv1.Image)
 
 	img, err = mutate.Append(img, mutate.Addendum{Layer: layer})
 	if err != nil {
@@ -83,4 +138,39 @@ func (c *Client) Push(ctx context.Context, url, sourceDir string, meta Metadata,
 	}
 
 	return ref.Context().Digest(digest.String()).String(), err
+}
+
+// createLayer creates a layer depending on the layerType.
+func createLayer(path string, layerType LayerType, opts layerOptions) (gcrv1.Layer, error) {
+	switch layerType {
+	case LayerTypeTarball:
+		var ociMediaType = oci.CanonicalContentMediaType
+		var tmpDir string
+		tmpDir, err := os.MkdirTemp("", "oci")
+		if err != nil {
+			return nil, err
+		}
+		defer os.RemoveAll(tmpDir)
+		tmpFile := filepath.Join(tmpDir, "artifact.tgz")
+		if err := build(tmpFile, path, opts.ignorePaths); err != nil {
+			return nil, err
+		}
+		return tarball.LayerFromFile(tmpFile, tarball.WithMediaType(ociMediaType), tarball.WithCompressedCaching)
+	case LayerTypeStatic:
+		var ociMediaType = getLayerMediaType(opts.mediaTypeExt)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("error reading file for static layer: %w", err)
+		}
+		return static.NewLayer(content, ociMediaType), nil
+	default:
+		return nil, fmt.Errorf("unsupported layer type: '%s'", layerType)
+	}
+}
+
+func getLayerMediaType(extension string) types.MediaType {
+	if extension == "" {
+		return oci.CanonicalMediaTypePrefix
+	}
+	return types.MediaType(fmt.Sprintf("%s.%s", oci.CanonicalMediaTypePrefix, extension))
 }

--- a/oci/client/push_pull_test.go
+++ b/oci/client/push_pull_test.go
@@ -19,6 +19,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -34,77 +35,190 @@ import (
 )
 
 func Test_Push_Pull(t *testing.T) {
-	g := NewWithT(t)
 	ctx := context.Background()
 	c := NewClient(DefaultOptions())
-	testDir := "testdata/artifact"
-	tag := "v0.0.1"
 	source := "github.com/fluxcd/flux2"
 	revision := "rev"
 	repo := "test-push" + randStringRunes(5)
 	ct := time.Now().UTC()
 	created := ct.Format(time.RFC3339)
 
-	url := fmt.Sprintf("%s/%s:%s", dockerReg, repo, tag)
-	metadata := Metadata{
-		Source:   source,
-		Revision: revision,
-		Created:  created,
-		Annotations: map[string]string{
-			"org.opencontainers.image.documentation": "https://my/readme.md",
-			"org.opencontainers.image.licenses":      "Apache-2.0",
+	tests := []struct {
+		name              string
+		sourcePath        string
+		tag               string
+		ignorePaths       []string
+		opts              []PushOption
+		expectErr         bool
+		expectedMediaType types.MediaType
+	}{
+		{
+			name:              "push directory (default layer type)",
+			tag:               "v0.0.1",
+			sourcePath:        "testdata/artifact",
+			expectedMediaType: oci.CanonicalContentMediaType,
+		},
+		{
+			name:              "push directory (specify layer type)",
+			tag:               "v0.0.1",
+			sourcePath:        "testdata/artifact",
+			expectedMediaType: oci.CanonicalContentMediaType,
+			opts: []PushOption{
+				WithPushLayerType(LayerTypeTarball),
+			},
+		},
+		{
+			name:       "push static file",
+			tag:        "v0.0.2",
+			sourcePath: "testdata/artifact/deployment.yaml",
+			opts: []PushOption{
+				WithPushLayerType(LayerTypeStatic),
+				WithPushMediaTypeExt("ml"),
+			},
+			expectedMediaType: getLayerMediaType("ml"),
+		},
+		{
+			name:       "push directory as static layer (should return error)",
+			sourcePath: "testdata/artifact",
+			opts: []PushOption{
+				WithPushLayerType(LayerTypeStatic),
+			},
+			expectErr: true,
+		},
+		{
+			name:       "push static file without media type extension",
+			tag:        "v0.0.2",
+			sourcePath: "testdata/artifact/deployment.yaml",
+			opts: []PushOption{
+				WithPushLayerType(LayerTypeStatic),
+			},
+			expectedMediaType: oci.CanonicalMediaTypePrefix,
 		},
 	}
 
-	// Build and push the artifact to registry
-	_, err := c.Push(ctx, url, testDir, metadata, nil)
-	g.Expect(err).ToNot(HaveOccurred())
-
-	// Verify that the artifact and its tag is present in the registry
-	tags, err := crane.ListTags(fmt.Sprintf("%s/%s", dockerReg, repo))
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(len(tags)).To(BeEquivalentTo(1))
-	g.Expect(tags[0]).To(BeEquivalentTo(tag))
-
-	// Pull the artifact from registry
-	image, err := crane.Pull(fmt.Sprintf("%s/%s:%s", dockerReg, repo, tag))
-	g.Expect(err).ToNot(HaveOccurred())
-
-	// Extract the manifest from the pulled artifact
-	manifest, err := image.Manifest()
-	g.Expect(err).ToNot(HaveOccurred())
-
-	// Verify that annotations exist in manifest
-	g.Expect(manifest.Annotations[oci.CreatedAnnotation]).To(BeEquivalentTo(created))
-	g.Expect(manifest.Annotations[oci.SourceAnnotation]).To(BeEquivalentTo(source))
-	g.Expect(manifest.Annotations[oci.RevisionAnnotation]).To(BeEquivalentTo(revision))
-
-	// Verify media types
-	g.Expect(manifest.MediaType).To(Equal(types.OCIManifestSchema1))
-	g.Expect(manifest.Config.MediaType).To(BeEquivalentTo(oci.CanonicalConfigMediaType))
-	g.Expect(len(manifest.Layers)).To(BeEquivalentTo(1))
-	g.Expect(manifest.Layers[0].MediaType).To(BeEquivalentTo(oci.CanonicalContentMediaType))
-
-	tmpDir := t.TempDir()
-
-	// Pull the artifact from registry and extract its contents to tmp
-	meta, err := c.Pull(ctx, url, tmpDir)
-	g.Expect(err).ToNot(HaveOccurred())
-
-	// Verify custom annotations
-	g.Expect(meta.Annotations["org.opencontainers.image.documentation"]).To(BeEquivalentTo("https://my/readme.md"))
-	g.Expect(meta.Annotations["org.opencontainers.image.licenses"]).To(BeEquivalentTo("Apache-2.0"))
-
-	// Walk the test directory and check that all files exist in the pulled artifact
-	fsErr := filepath.Walk(testDir, func(path string, info fs.FileInfo, err error) error {
-		if !info.IsDir() {
-			tmpPath := filepath.Join(tmpDir, strings.TrimPrefix(path, testDir))
-			if _, err := os.Stat(tmpPath); err != nil && os.IsNotExist(err) {
-				return fmt.Errorf("path '%s' doesn't exist in archive", path)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			url := fmt.Sprintf("%s/%s:%s", dockerReg, repo, tt.tag)
+			metadata := Metadata{
+				Source:   source,
+				Revision: revision,
+				Created:  created,
+				Annotations: map[string]string{
+					"org.opencontainers.image.documentation": "https://my/readme.md",
+					"org.opencontainers.image.licenses":      "Apache-2.0",
+				},
 			}
-		}
+			opts := append(tt.opts, WithPushMetadata(metadata))
 
-		return nil
-	})
-	g.Expect(fsErr).ToNot(HaveOccurred())
+			// Build and push the artifact to registry
+			_, err := c.Push(ctx, url, tt.sourcePath, opts...)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).To(Not(HaveOccurred()))
+			// Verify that the artifact and its tag is present in the registry
+			tags, err := crane.ListTags(fmt.Sprintf("%s/%s", dockerReg, repo))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(tags).To(ContainElement(tt.tag))
+
+			// Pull the artifact from registry
+			image, err := crane.Pull(fmt.Sprintf("%s/%s:%s", dockerReg, repo, tt.tag))
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Extract the manifest from the pulled artifact
+			manifest, err := image.Manifest()
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Verify that annotations exist in manifest
+			g.Expect(manifest.Annotations[oci.CreatedAnnotation]).To(BeEquivalentTo(created))
+			g.Expect(manifest.Annotations[oci.SourceAnnotation]).To(BeEquivalentTo(source))
+			g.Expect(manifest.Annotations[oci.RevisionAnnotation]).To(BeEquivalentTo(revision))
+
+			// Verify media types
+			g.Expect(manifest.MediaType).To(Equal(types.OCIManifestSchema1))
+			g.Expect(manifest.Config.MediaType).To(BeEquivalentTo(oci.CanonicalConfigMediaType))
+			g.Expect(len(manifest.Layers)).To(BeEquivalentTo(1))
+			g.Expect(manifest.Layers[0].MediaType).To(BeEquivalentTo(tt.expectedMediaType))
+
+			// Verify custom annotations
+			meta := MetadataFromAnnotations(manifest.Annotations)
+			g.Expect(meta.Annotations["org.opencontainers.image.documentation"]).To(BeEquivalentTo("https://my/readme.md"))
+			g.Expect(meta.Annotations["org.opencontainers.image.licenses"]).To(BeEquivalentTo("Apache-2.0"))
+
+			po := &PushOptions{}
+			for _, opt := range opts {
+				opt(po)
+			}
+			switch po.layerType {
+			case LayerTypeTarball:
+				// Pull the artifact from registry and extract its contents to tmp
+				tmpDir := t.TempDir()
+				_, err := c.Pull(ctx, url, tmpDir)
+				g.Expect(err).ToNot(HaveOccurred())
+				// Walk the test directory and check that all files exist in the pulled artifact
+				fsErr := filepath.Walk(tt.sourcePath, func(path string, info fs.FileInfo, err error) error {
+					if !info.IsDir() {
+						tmpPath := filepath.Join(tmpDir, strings.TrimPrefix(path, tt.sourcePath))
+						if _, err := os.Stat(tmpPath); err != nil && os.IsNotExist(err) {
+							return fmt.Errorf("path '%s' doesn't exist in archive", path)
+						}
+					}
+
+					return nil
+				})
+				g.Expect(fsErr).ToNot(HaveOccurred())
+			case LayerTypeStatic:
+				// contents of uncompressed and compressed layer should be the same as file
+				expectedBytes, err := os.ReadFile(tt.sourcePath)
+				g.Expect(err).To(Not(HaveOccurred()))
+				layers, err := image.Layers()
+				g.Expect(err).ToNot(HaveOccurred())
+
+				blob, err := layers[0].Uncompressed()
+				g.Expect(err).ToNot(HaveOccurred())
+
+				b, err := io.ReadAll(blob)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				g.Expect(b).To(BeEquivalentTo(expectedBytes))
+
+				blob, err = layers[0].Compressed()
+				g.Expect(err).ToNot(HaveOccurred())
+
+				b, err = io.ReadAll(blob)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				g.Expect(b).To(BeEquivalentTo(expectedBytes))
+			}
+		})
+	}
+}
+
+func Test_getLayerMediaType(t *testing.T) {
+	tests := []struct {
+		name              string
+		ext               string
+		expectedMediaType types.MediaType
+	}{
+		{
+			name:              "default oci media type",
+			expectedMediaType: oci.CanonicalMediaTypePrefix,
+		},
+		{
+			name:              "oci media type with extension",
+			ext:               "test",
+			expectedMediaType: types.MediaType(fmt.Sprintf("%s.test", oci.CanonicalMediaTypePrefix)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := getLayerMediaType(tt.ext)
+			g.Expect(got).To(BeEquivalentTo(tt.expectedMediaType))
+		})
+	}
 }

--- a/oci/globals.go
+++ b/oci/globals.go
@@ -16,14 +16,21 @@ limitations under the License.
 
 package oci
 
-import "github.com/google/go-containerregistry/pkg/v1/types"
+import (
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
 
 var (
 	// CanonicalConfigMediaType is the OCI media type for the config layer.
 	CanonicalConfigMediaType types.MediaType = "application/vnd.cncf.flux.config.v1+json"
 
+	// CanonicalMediaTypePrefix is the suffix for OCI media type for the content layer.
+	CanonicalMediaTypePrefix types.MediaType = "application/vnd.cncf.flux.content.v1"
+
 	// CanonicalContentMediaType is the OCI media type for the content layer.
-	CanonicalContentMediaType types.MediaType = "application/vnd.cncf.flux.content.v1.tar+gzip"
+	CanonicalContentMediaType = types.MediaType(fmt.Sprintf("%s.tar+gzip", CanonicalMediaTypePrefix))
 
 	// UserAgent string used for OCI calls.
 	UserAgent = "flux/v2"


### PR DESCRIPTION
This pull request adds different layer types when pushing an OCI image. The default is the `tarball` where the layer contains a tarball created from the sourcePath. The `static` type creates a layer containing the uncompressed contents of the file.

It also adds an option for configuring the media type extension of the layer and reactors the Push methods with functional options.