### PR TITLE
oci/tests/int: Set delete propagation policy

### DIFF
--- a/oci/tests/integration/repo_list_test.go
+++ b/oci/tests/integration/repo_list_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -96,7 +97,8 @@ func testImageRepositoryListTags(t *testing.T, args []string) {
 
 	g.Expect(testEnv.Client.Create(ctx, job)).To(Succeed())
 	defer func() {
-		g.Expect(testEnv.Client.Delete(ctx, job)).To(Succeed())
+		background := metav1.DeletePropagationBackground
+		g.Expect(testEnv.Client.Delete(ctx, job, &client.DeleteOptions{PropagationPolicy: &background})).To(Succeed())
 	}()
 	g.Eventually(func() bool {
 		if err := testEnv.Client.Get(ctx, key, job); err != nil {


### PR DESCRIPTION
The test `testImageRepositoryListTags` creates a Job that performs registry login and listing of tags. The Job is deleted at the end of the test. But the associated Pods are left behind in completed state. Pass a delete propagation policy to ensure the completed pods are cleaned up.

Before the fix, while testing #665 I noticed that the test run logs the following warning:
```console
=== RUN   TestImageRepositoryListTags
=== RUN   TestImageRepositoryListTags/gcr
I1030 16:55:38.383216 3142396 warning_handler.go:65] KubeAPIWarningLogger "msg"="child pods are preserved by default when jobs are deleted; set propagationPolicy=Background 
to remove them or set propagationPolicy=Orphan to suppress this warning"
=== RUN   TestImageRepositoryListTags/artifact_registry
```

And the pods after a test run:
```console
$ kubectl get pods
NAME                   READY   STATUS      RESTARTS   AGE
test-job-6c9kr-mdkk9   0/1     Completed   0          12m
test-job-ej648-mp2vt   0/1     Completed   0          12m
test-job-fnk4w-glxgg   0/1     Completed   0          12m
test-job-g6lxz-l68s9   0/1     Completed   0          12m
test-job-sgk4x-5tj26   0/1     Completed   0          12m
test-job-wetth-rktgp   0/1     Completed   0          12m
test-job-ys5ss-9v9rt   0/1     Completed   0          12m
```
With the delete policy, no pods remain after a test run:
```console
$ kubectl get pods
No resources found in default namespace.
```