### PR TITLE
oci/tests/int: Set exit code 1 on tf destroy fail

### DIFF
--- a/oci/tests/integration/suite_test.go
+++ b/oci/tests/integration/suite_test.go
@@ -184,6 +184,7 @@ func TestMain(m *testing.M) {
 	defer func() {
 		if err := testEnv.Stop(ctx); err != nil {
 			log.Printf("Failed to stop environment: %v", err)
+			exitCode = 1
 		}
 
 		// Log the panic error before exit to surface the cause of panic.


### PR DESCRIPTION
Explicitly set the test program exit code to 1 when terraform destroy fails to delete the infrastructure.

This was observed when GKE clusters failed to delete due to delete protection enabled by default in the latest version of terraform provider google.

Verified locally by reproducing the GKE delete failure:

```console
module.gcr.google_artifact_registry_repository.this: Destroying... [id=projects/test-project/locations/us-central1/repositories/flux-test-sharing-sawfly]
module.gke.google_container_cluster.primary: Destroying... [id=projects/test-project/locations/us-central1/clusters/flux-test-sharing-sawfly]
module.gcr.google_artifact_registry_repository.this: Destruction complete after 3s

Error: Cannot destroy cluster because deletion_protection is set to true. Set it to false to proceed with cluster deletion.

2023/11/04 00:33:13 Failed to stop environment: could not destroy infrastructure: exit status 1

Error: Cannot destroy cluster because deletion_protection is set to true. Set it to false to proceed with cluster deletion.

FAIL    github.com/fluxcd/pkg/oci/tests/integration     248.069s
FAIL
make[1]: *** [Makefile:18: test] Error 1
```

Refer to the original issue logs - https://github.com/fluxcd/flux2/actions/runs/6744039127/job/18333072766#step:13:137 .