### PR TITLE
Add core api namespace sort priority to IsLessThan

### DIFF
--- a/ssa/sort.go
+++ b/ssa/sort.go
@@ -130,6 +130,9 @@ func IsLessThan(i, j schema.GroupKind) bool {
 	if indexI != indexJ {
 		return indexI < indexJ
 	}
+	if (i.Kind == types.NamespaceKind && j.Kind == types.NamespaceKind) && (i.Group == "" || j.Group == "") {
+		return i.Group > j.Group
+	}
 	if i.Group != j.Group {
 		return i.Group < j.Group
 	}


### PR DESCRIPTION
Adds differentiation and correct priority between ASO ServiceBus Namespace kind and core Kubernetes Namespace kind when sorting kustomize build output file. (core Kubernetes Namespace higher than ASO Namespace)