### PR TITLE
ssa: prevent unnecessary `DeepCopy`

### DIFF
--- a/ssa/manager_apply.go
+++ b/ssa/manager_apply.go
@@ -92,7 +92,8 @@ func DefaultApplyOptions() ApplyOptions {
 // Drift detection is performed by comparing the server-side dry-run result with the existing object.
 // When immutable field changes are detected, the object is recreated if 'force' is set to 'true'.
 func (m *ResourceManager) Apply(ctx context.Context, object *unstructured.Unstructured, opts ApplyOptions) (*ChangeSetEntry, error) {
-	existingObject := object.DeepCopy()
+	existingObject := &unstructured.Unstructured{}
+	existingObject.SetGroupVersionKind(object.GroupVersionKind())
 	getError := m.client.Get(ctx, client.ObjectKeyFromObject(object), existingObject)
 
 	if m.shouldSkipApply(object, existingObject, opts) {
@@ -153,7 +154,8 @@ func (m *ResourceManager) ApplyAll(ctx context.Context, objects []*unstructured.
 			i, object := i, object
 
 			g.Go(func() error {
-				existingObject := object.DeepCopy()
+				existingObject := &unstructured.Unstructured{}
+				existingObject.SetGroupVersionKind(object.GroupVersionKind())
 				getError := m.client.Get(ctx, client.ObjectKeyFromObject(object), existingObject)
 
 				if m.shouldSkipApply(object, existingObject, opts) {

--- a/ssa/manager_delete.go
+++ b/ssa/manager_delete.go
@@ -61,7 +61,8 @@ func DefaultDeleteOptions() DeleteOptions {
 // Delete deletes the given object (not found errors are ignored).
 func (m *ResourceManager) Delete(ctx context.Context, object *unstructured.Unstructured, opts DeleteOptions) (*ChangeSetEntry, error) {
 
-	existingObject := object.DeepCopy()
+	existingObject := &unstructured.Unstructured{}
+	existingObject.SetGroupVersionKind(object.GroupVersionKind())
 	err := m.client.Get(ctx, client.ObjectKeyFromObject(object), existingObject)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {

--- a/ssa/manager_diff.go
+++ b/ssa/manager_diff.go
@@ -19,6 +19,7 @@ package ssa
 
 import (
 	"context"
+
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,7 +49,8 @@ func (m *ResourceManager) Diff(ctx context.Context, object *unstructured.Unstruc
 	*unstructured.Unstructured,
 	error,
 ) {
-	existingObject := object.DeepCopy()
+	existingObject := &unstructured.Unstructured{}
+	existingObject.SetGroupVersionKind(object.GroupVersionKind())
 	_ = m.client.Get(ctx, client.ObjectKeyFromObject(object), existingObject)
 
 	if existingObject != nil && AnyInMetadata(existingObject, opts.Exclusions) {


### PR DESCRIPTION
When attempting to retrieve the object, setting the GVK on the Unstructured is sufficient to be able to retrieve it from the cluster.

This avoids deep-copying the object in full and then `nil` writing it again when it does not exist in the cluster. Which can potentially save quite some duplicate data when e.g. dealing with Custom Resource Definitions or other large object kinds.