### PR TITLE
http/fetch: allow configuring a logger on client

### DIFF
--- a/http/fetch/go.mod
+++ b/http/fetch/go.mod
@@ -14,6 +14,7 @@ replace github.com/opencontainers/go-digest => github.com/opencontainers/go-dige
 require (
 	github.com/fluxcd/pkg/tar v0.4.0
 	github.com/fluxcd/pkg/testserver v0.5.0
+	github.com/go-logr/logr v1.3.0
 	github.com/hashicorp/go-retryablehttp v0.7.5
 	github.com/onsi/gomega v1.30.0
 	github.com/opencontainers/go-digest v1.0.0

--- a/http/fetch/go.sum
+++ b/http/fetch/go.sum
@@ -1,7 +1,8 @@
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
+github.com/go-logr/logr v1.3.0 h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=
+github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/http/fetch/logger.go
+++ b/http/fetch/logger.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2023 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fetch
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+// newErrorLogger returns a retryablehttp.LeveledLogger that only logs
+// errors to the given logr.Logger.
+func newErrorLogger(logr logr.Logger) retryablehttp.LeveledLogger {
+	return &errorLogger{log: logr}
+}
+
+// errorLogger is a wrapper around logr.Logger that implements the
+// retryablehttp.LeveledLogger interface while only logging errors.
+type errorLogger struct {
+	log logr.Logger
+}
+
+func (l *errorLogger) Error(msg string, keysAndValues ...interface{}) {
+	l.log.Info(msg, keysAndValues...)
+}
+
+func (l *errorLogger) Info(msg string, keysAndValues ...interface{}) {
+	// Do nothing.
+}
+
+func (l *errorLogger) Debug(msg string, keysAndValues ...interface{}) {
+	// Do nothing.
+}
+
+func (l *errorLogger) Warn(msg string, keysAndValues ...interface{}) {
+	// Do nothing.
+}


### PR DESCRIPTION
This allows for the configuration of a logger on the retryable HTTP client. While adding builtin support for providing a `logr.Logger` instance, which will be wrapped in  a `retryablehttp.LeveledLogger` to only log errors.

Part of: https://github.com/fluxcd/flux2/issues/4472