### PR TITLE
Fix a silently dropping Kustomization remote resources

### DIFF
--- a/kustomize/testdata/remote/configmap.yaml
+++ b/kustomize/testdata/remote/configmap.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-vars
+  namespace: apps
+data:
+  config: key
+  

--- a/kustomize/testdata/remote/kustomization.yaml
+++ b/kustomize/testdata/remote/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: apps
+resources:
+- configmap.yaml
+# Arbitrary remote resource. The specific resource doesn't matter. We don't actually
+# build this in the test.
+- https://raw.githubusercontent.com/fluxcd/flux2/main/manifests/rbac/controller.yaml


### PR DESCRIPTION
Fix an issue where kustomizations with remote resources are silently dropped from `flux build ks`. The behavior change appears to have been introduced in https://github.com/fluxcd/flux2/pull/3763 and https://github.com/fluxcd/pkg/pull/528 when adding filters to ignore the source path. The behavior skips urls since they don't match file paths, but that had the side effect of not including them in the generated `Kustomization`. This PR reverts to the old behavor of ignoring remote urls and keeping them in the kustomization -- which is fine since source ignore paths are about paths in the source tree and not remote resources.

Fixes https://github.com/fluxcd/flux2/issues/4146 which describes how to reproduce the issue. An example test is included that exercises the issue ensuring the remote resource is included in the filtered kustomization, though does not actually try to build a remote resource.