### PR TITLE
integration-cleanup: Enable reaper delete

### DIFF
--- a/.github/workflows/integration-cleanup.yaml
+++ b/.github/workflows/integration-cleanup.yaml
@@ -3,7 +3,7 @@ name: integration-cleanup
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 * * * *"
 
 permissions: {}
 
@@ -53,11 +53,9 @@ jobs:
       - name: Run gcrgc
         # Cleanup all the GCR repositories in the project. They are not tracked
         # by terraform used to provision test infra and are left behind.
-        run: gcrgc gcr.io/${{ vars.TF_VAR_gcp_project_id }}
+        run: gcrgc gcr.io/${{ vars.TF_VAR_gcp_project_id }} --retention-period 1h
       - name: Run reaper
-        # NOTE: This is in dry-run mode by default. Pass `-delete` to allow it
-        # to delete.
-        run: go run ./ -provider gcp -gcpproject ${{ vars.TF_VAR_gcp_project_id }} -retention-period 1d -tags 'ci=true'
+        run: go run ./ -provider gcp -gcpproject ${{ vars.TF_VAR_gcp_project_id }} -retention-period 1h -tags 'ci=true' -delete
 
   azure:
     runs-on: ubuntu-latest
@@ -80,6 +78,4 @@ jobs:
         with:
           creds: '{"clientId":"${{ secrets.CLEANUP_E2E_AZ_ARM_CLIENT_ID }}","clientSecret":"${{ secrets.CLEANUP_E2E_AZ_ARM_CLIENT_SECRET }}","subscriptionId":"${{ secrets.CLEANUP_E2E_AZ_ARM_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.CLEANUP_E2E_AZ_ARM_TENANT_ID }}"}'
       - name: Run reaper
-        # NOTE: This is in dry-run mode by default. Pass `-delete` to allow it
-        # to delete.
-        run: go run ./ -provider azure -retention-period 1d -tags 'ci=true'
+        run: go run ./ -provider azure -retention-period 1h -tags 'ci=true' -delete


### PR DESCRIPTION
The integration test resources cleanup program, [reaper](https://github.com/fluxcd/test-infra/tree/main/tools/reaper), used to be run in dry-run mode before to only report on leftover resources that were more than a day old. Recently, once in a few days, some GKE clusters would provision in unusable state. In the GKE web console, the cluster shows the following error:

```
All cluster resources were brought up, but: only 2 nodes out of 3 have
registered; cluster may be unhealthy.
```

And trying to connect to the cluster using cloudshell results in connection errors and the following warning:

```
WARNING: cluster flux-test-casual-oryx is not RUNNING. The kubernetes
API may or may not be available. Check the cluster status for more
information.
```

The cluster is not usable.
When this happens, terraform waits for the cluster to be ready and timeout. Due to the timeout, the cluster is not written to the terraform state file and it can't be deleted by running terraform destroy.

The GKE and individual node logs and monitoring pages don't show any other details about the issue,

In the past, these resources were manually deleted from the web console. Since this failure can happen any time, enabling the reaper cleanup took with retention period 1 hour would be helpful to ensure such unusable cluster get deleted within an hour. Test clusters don't run for more than 20 minutes. Only the resources with the tag `ci=true` will get deleted. Also, update the cron time for cleanup to run every hour.

Failed test run with provision timeout https://github.com/fluxcd/image-reflector-controller/actions/runs/7470958065/job/20330456160 .
Example run to delete the recently leftover cluster from image-reflector-controller repository test cluster https://github.com/fluxcd/pkg/actions/runs/7475015909/job/20342320391#step:11:29 .

Previous attempt to solve this problem in https://github.com/fluxcd/pkg/pull/712 doesn't work because the cluster doesn't get registered in the state file. With this change, the cleanup should be more robust. Multiple pieces in place to perform cleanup automatically.