### PR TITLE
runtime: Add `HasAnyReason` to conditions getter

### DIFF
--- a/runtime/conditions/getter.go
+++ b/runtime/conditions/getter.go
@@ -67,6 +67,17 @@ func HasAny(from Getter, t []string) bool {
 	return false
 }
 
+// HasAnyReason returns true if a condition with the given
+// type exists and any of the given reasons exist.
+func HasAnyReason(from Getter, t string, r ...string) bool {
+	for _, reason := range r {
+		if GetReason(from, t) == reason {
+			return true
+		}
+	}
+	return false
+}
+
 // IsTrue is true if the condition with the given type is True, otherwise it is false if the condition is not True or if
 // the condition does not exist (is nil).
 func IsTrue(from Getter, t string) bool {

--- a/runtime/conditions/getter_test.go
+++ b/runtime/conditions/getter_test.go
@@ -27,9 +27,10 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	"github.com/fluxcd/pkg/apis/meta"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fluxcd/pkg/apis/meta"
 
 	"github.com/fluxcd/pkg/runtime/conditions/testdata"
 )
@@ -64,6 +65,18 @@ func TestGetAndHas(t *testing.T) {
 	g.Expect(HasAny(obj, []string{"conditionFoo", "conditionX"})).To(BeTrue())
 	g.Expect(HasAny(obj, []string{"conditionY", "conditionBaz"})).To(BeTrue())
 	g.Expect(HasAny(obj, []string{"conditionX", "conditionY"})).To(BeFalse())
+}
+
+func TestHasAnyReason(t *testing.T) {
+	g := NewWithT(t)
+
+	obj := getterWithConditions(true1, false1, unknown1)
+
+	g.Expect(HasAnyReason(obj, "true1")).To(BeFalse())
+	g.Expect(HasAnyReason(obj, "true1", "reason true1")).To(BeTrue())
+	g.Expect(HasAnyReason(obj, "false1", "reason true1", "reason false1")).To(BeTrue())
+	g.Expect(HasAnyReason(obj, "unknown1", "reason unknown2", "reason unknown3")).To(BeFalse())
+	g.Expect(HasAnyReason(obj, "unknown2", "reason unknown1")).To(BeFalse())
 }
 
 func TestIsMethods(t *testing.T) {


### PR DESCRIPTION
Add `HasAnyReason` helper function that returns true if a condition with the given type exists and any of the given reasons exist.

To be used in: https://github.com/fluxcd/helm-controller/pull/884