### PR TITLE
ssa: Add test for CRD with regex validation

### DIFF
--- a/ssa/manager_wait_test.go
+++ b/ssa/manager_wait_test.go
@@ -48,6 +48,10 @@ func TestWaitForSet(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if err := SetNativeKindsDefaults(objects); err != nil {
+		t.Fatal(err)
+	}
+
 	manager.SetOwnerLabels(objects, "infra", "default")
 
 	_, crd := getFirstObject(objects, "CustomResourceDefinition", "clustertests.testing.fluxcd.io")

--- a/ssa/testdata/test5.yaml
+++ b/ssa/testdata/test5.yaml
@@ -31,6 +31,13 @@ spec:
             spec:
               description: TestSpec defines the desired state of a test run
               properties:
+                name:
+                  description: name specifies the subject name of schema. If not configured,
+                    the Schema CR name is used as the subject name.
+                  maxLength: 255
+                  minLength: 1
+                  pattern: ^[^\\]*$
+                  type: string
                 type:
                   description: Type of test
                   type: string


### PR DESCRIPTION
Add test to verify that the YAML parses does not remove escape characters from regexes.