### PR TITLE
Remove `genclient:Namespaced` tag

### DIFF
--- a/runtime/conditions/testdata/fake.go
+++ b/runtime/conditions/testdata/fake.go
@@ -153,7 +153,6 @@ func (f *FakeStatus) DeepCopy() *FakeStatus {
 // Fake is a mock struct that adheres to the minimal requirements to
 // work with the condition helpers, by implementing client.Object.
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 type Fake struct {


### PR DESCRIPTION
This tag isn't used by controller-tools, only `nonNamespaced` is.

Context: https://cloud-native.slack.com/archives/CLAJ40HV3/p1708794732147909

Tested by running `make generate` and verifying that there is no diff.