### PR TITLE
crdjsonschema action now creates a `all.json` schema to validate any Flux2 resource via a single schema

### DIFF
--- a/actions/crdjsonschema/entrypoint.sh
+++ b/actions/crdjsonschema/entrypoint.sh
@@ -23,10 +23,7 @@ mkdir -p "$SPLIT_DIR"
 kubernetes-split-yaml --outdir "$SPLIT_DIR" "$CRD_PATH"
 
 ( cd "$WORK_DIR"
-  for f in "$SPLIT_DIR"/*
-  do
-    openapi2jsonschema "$f"
-  done
+  openapi2jsonschema "$SPLIT_DIR"/*
 )
 
 mv "$WORK_DIR"/*.json "$OUTPUT_DIR"


### PR DESCRIPTION
This enables JSON schema extensions to validate Flux2 resources by pointing to the `all.json` file. Background: https://github.com/fluxcd-community/flux2-schemas/issues/23

I dropped some old Python2 compatibility code (`iteritems`) and I am using dataclasses (minimum Python version 3.7). I think this is not a problem because it is being run through the Dockerfile which is using `python:3-alpine` anyways.

# Example usage in VSCode
When using the [YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) extension you could use this new `all.json` schema like so (if this PR is merged and the flux2-schemas repo is updated):

**.vscode/settings.json**
```json
  "yaml.schemas": {
    "https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/all.json": "*.yaml"
  },
```
This would net you nice validation in (for example) VSCode for Flux2 resources:
![image](https://github.com/fluxcd/pkg/assets/3524694/6ac2c8c0-20e9-48a8-8afc-62ae4256b939)

Schema validations are based on glob patterns and in the case of YAML for VSCode will not fallback when providing multiple root schemas. This means that in a typical GitOps repository (in which you mix Flux and Kubernetes resources) you either validate Flux resources OR Kubernetes resources. This sucks, but it can be fixed by stitching together Kubernetes schemas and flux schemas like so.

**.vscode/kubernetes.json**
```json
{
  "oneOf": [
    { "$ref": "https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/all.json" },
    {
      "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/all.json"
    }
  ]
}
```
*I experimented with including this kubernetes.json schema file as well, but that does not feel right and it probably makes more sense to leave this configuration step up to an end user. Especially because different JSON schema validation plugins will handle fallbacks etc differently.*

**.vscode/settings.json**
```json
  "yaml.schemas": {
    "kubernetes": "",
    ".vscode/kubernetes.json": "*.yaml"
  },
```
**Setting `"kubernetes"` to empty string is required as the YAML plugin for VSCode always tries to match Kubernetes schema and if you do not do this you will get "Matches multiple schemas when only one must validate" errors.**