### PR TITLE
Return a DiffTypeExclude when exclusion annotation is set in cluster

### DIFF
--- a/ssa/jsondiff/unstructured.go
+++ b/ssa/jsondiff/unstructured.go
@@ -137,6 +137,11 @@ func Unstructured(ctx context.Context, c client.Client, obj *unstructured.Unstru
 		return nil, err
 	}
 
+	// Short-circuit if an annotation is set to ignore the resource in-cluster.
+	if utils.AnyInMetadata(existingObj, o.ExclusionSelector) {
+		return NewDiffForUnstructured(obj, nil, DiffTypeExclude, nil), nil
+	}
+
 	dryRunObj := obj.DeepCopy()
 	patchOpts := []client.PatchOption{
 		client.DryRunAll,


### PR DESCRIPTION
We want to enable this behaviour for use cases where different controllers must coordinate in order to mutate a resource.

ref: https://github.com/fluxcd/helm-controller/issues/922