### PR TITLE
kustomize: Allow empty resources in `kustomization.yaml`

### DIFF
--- a/kustomize/filters.go
+++ b/kustomize/filters.go
@@ -22,15 +22,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/fluxcd/pkg/sourceignore"
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
 	kustypes "sigs.k8s.io/kustomize/api/types"
-)
 
-const (
-	crds       = "crds"
-	resources  = "resources"
-	components = "components"
+	"github.com/fluxcd/pkg/sourceignore"
 )
 
 // filter must return true if a file should not be included in the archive after inspecting the given path
@@ -61,19 +56,19 @@ func filterKsWithIgnoreFiles(ks *kustypes.Kustomization, dirPath string, ignore 
 	}
 
 	// filter resources first
-	err = filterSlice(ks, path, &ks.Resources, resources, ignoreFileFilter(ps, ignoreDomain))
+	err = filterSlice(ks, path, &ks.Resources, resourcesField, ignoreFileFilter(ps, ignoreDomain))
 	if err != nil {
 		return err
 	}
 
 	// filter components second
-	err = filterSlice(ks, path, &ks.Components, components, ignoreFileFilter(ps, ignoreDomain))
+	err = filterSlice(ks, path, &ks.Components, componentsField, ignoreFileFilter(ps, ignoreDomain))
 	if err != nil {
 		return err
 	}
 
 	// filter crds third
-	err = filterSlice(ks, path, &ks.Crds, crds, ignoreFileFilter(ps, ignoreDomain))
+	err = filterSlice(ks, path, &ks.Crds, crdsField, ignoreFileFilter(ps, ignoreDomain))
 	if err != nil {
 		return err
 	}
@@ -91,7 +86,7 @@ func filterSlice(ks *kustypes.Kustomization, path string, s *[]string, t string,
 	for _, res := range *s {
 		// check if we have a url and skip the source file filters
 		// this is not needed for crds as they are not allowed to be urls
-		if t == crds || !isUrl(res) {
+		if t == crdsField || !isUrl(res) {
 			f := filepath.Join(path, res)
 			info, err := os.Lstat(f)
 			if err != nil {

--- a/kustomize/kustomize_generator.go
+++ b/kustomize/kustomize_generator.go
@@ -147,6 +147,12 @@ func (g *Generator) WriteFile(dirPath string, opts ...SavingOptions) (Action, er
 		return action, fmt.Errorf("%v %v", err, errf)
 	}
 
+	if action == UnchangedAction && len(kus.Resources) == 0 {
+		// if there are no resources, set the build metadata
+		// to avoid "kustomization.yaml is empty" build error
+		kus.BuildMetadata = []string{"originAnnotations"}
+	}
+
 	// apply filters if any
 	if g.filter {
 		err = filterKsWithIgnoreFiles(&kus, dirPath, g.ignore)

--- a/kustomize/kustomize_generator.go
+++ b/kustomize/kustomize_generator.go
@@ -45,8 +45,10 @@ import (
 const (
 	specField            = "spec"
 	targetNSField        = "targetNamespace"
+	resourcesField       = "resources"
 	patchesField         = "patches"
 	componentsField      = "components"
+	crdsField            = "crds"
 	patchesSMField       = "patchesStrategicMerge"
 	patchesJson6902Field = "patchesJson6902"
 	imagesField          = "images"

--- a/kustomize/kustomize_generator_test.go
+++ b/kustomize/kustomize_generator_test.go
@@ -59,6 +59,29 @@ func TestGenerator_EmptyDir(t *testing.T) {
 	g.Expect(resMap.Resources()).To(HaveLen(0))
 }
 
+func TestGenerator_NoResources(t *testing.T) {
+	g := NewWithT(t)
+	dataKS, err := os.ReadFile("./testdata/noResources/ks.yaml")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	ks, err := readYamlObjects(strings.NewReader(string(dataKS)))
+	g.Expect(err).NotTo(HaveOccurred())
+
+	tmpDir, err := testTempDir(t)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(copy.Copy("testdata/noResources", tmpDir)).To(Succeed())
+	_, err = kustomize.NewGenerator(tmpDir, ks[0]).WriteFile(tmpDir)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	resMap, err := kustomize.SecureBuild(tmpDir, tmpDir, false)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(resMap.Resources()).To(HaveLen(0))
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "kustomization.yaml"))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(data)).To(ContainSubstring("originAnnotations"))
+}
+
 func TestKustomizationGenerator(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/kustomize/testdata/noResources/ks.yaml
+++ b/kustomize/testdata/noResources/ks.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: app
+  namespace: apps
+spec:
+  interval: 4m0s
+  path: ./
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: app

--- a/kustomize/testdata/noResources/kustomization.yaml
+++ b/kustomize/testdata/noResources/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []


### PR DESCRIPTION
Fix breaking change in Kustomize >=v5.2 where a kustomization.yaml with `resources: []` results in a build error.

Fix: https://github.com/fluxcd/flux2/issues/4601