### PR TITLE
kustomize: Add support for `namePrefix` and `nameSuffix`

### DIFF
--- a/kustomize/kustomize_generator.go
+++ b/kustomize/kustomize_generator.go
@@ -52,6 +52,8 @@ const (
 	patchesSMField       = "patchesStrategicMerge"
 	patchesJson6902Field = "patchesJson6902"
 	imagesField          = "images"
+	namePrefixField      = "namePrefix"
+	nameSuffixField      = "nameSuffix"
 )
 
 // Action is the action that was taken on the kustomization file
@@ -171,6 +173,24 @@ func (g *Generator) WriteFile(dirPath string, opts ...SavingOptions) (Action, er
 	}
 	if ok {
 		kus.Namespace = tg
+	}
+
+	nprefix, ok, err := g.getNestedString(specField, namePrefixField)
+	if err != nil {
+		errf := CleanDirectory(dirPath, action)
+		return action, fmt.Errorf("%v %v", err, errf)
+	}
+	if ok {
+		kus.NamePrefix = nprefix
+	}
+
+	nsuffix, ok, err := g.getNestedString(specField, nameSuffixField)
+	if err != nil {
+		errf := CleanDirectory(dirPath, action)
+		return action, fmt.Errorf("%v %v", err, errf)
+	}
+	if ok {
+		kus.NameSuffix = nsuffix
 	}
 
 	patches, err := g.getPatches()

--- a/kustomize/testdata/name/ks.yaml
+++ b/kustomize/testdata/name/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: test-name
+  namespace: test-namespace
+spec:
+  targetNamespace: test-namespace
+  namePrefix: prefix-
+  nameSuffix: -suffix
+  interval: 4m0s
+  path: ./
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: app

--- a/kustomize/testdata/name/kustomization.yaml
+++ b/kustomize/testdata/name/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+  - name: test-configmap
+    literals:
+      - foo=bar
+      - baz=qux


### PR DESCRIPTION
Part of: https://github.com/fluxcd/kustomize-controller/issues/1133