### PR TITLE
Add workflow for OCI AWS tests & document the setup

### DIFF
--- a/.github/workflows/integration-aws.yaml
+++ b/.github/workflows/integration-aws.yaml
@@ -29,9 +29,9 @@ jobs:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.OCI_E2E_AWS_ACCOUNT_ID }}:role/${{ secrets.OCI_E2E_AWS_ASSUME_ROLE_NAME }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.OCI_E2E_AWS_ASSUME_ROLE_NAME }}
           role-session-name: OCI_GH_Actions
-          aws-region: ${{ vars.OCI_E2E_AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
       - name: Setup QEMU
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
       - name: Setup Docker Buildx
@@ -49,11 +49,11 @@ jobs:
       - name: Run tests
         run: . .env && make test-aws
         env:
-          AWS_REGION: ${{ vars.OCI_E2E_AWS_REGION }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
           TF_VAR_cross_region: ${{ vars.OCI_E2E_TF_VAR_cross_region }}
       - name: Ensure resource cleanup
         if: ${{ always() }}
         run: . .env && make destroy-aws
         env:
-          AWS_REGION: ${{ vars.OCI_E2E_AWS_REGION }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
           TF_VAR_cross_region: ${{ vars.OCI_E2E_TF_VAR_cross_region }}

--- a/.github/workflows/integration-cleanup.yaml
+++ b/.github/workflows/integration-cleanup.yaml
@@ -79,3 +79,28 @@ jobs:
           creds: '{"clientId":"${{ secrets.CLEANUP_E2E_AZ_ARM_CLIENT_ID }}","clientSecret":"${{ secrets.CLEANUP_E2E_AZ_ARM_CLIENT_SECRET }}","subscriptionId":"${{ secrets.CLEANUP_E2E_AZ_ARM_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.CLEANUP_E2E_AZ_ARM_TENANT_ID }}"}'
       - name: Run reaper
         run: go run ./ -provider azure -retention-period 1h -tags 'ci=true' -delete
+
+  aws:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./tools/reaper
+    if: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: fluxcd/test-infra
+      - name: Setup Go
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version: 1.22.x
+          cache-dependency-path: ./tools/reaper/go.sum
+      - name: Authenticate to AWS
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.CLEANUP_E2E_AWS_ASSUME_ROLE_NAME }}
+          role-session-name: OCI_GH_Actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - name: Run reaper
+        run: go run ./ -provider azure -retention-period 1h -tags 'ci=true' -delete

--- a/oci/tests/integration/README.md
+++ b/oci/tests/integration/README.md
@@ -299,9 +299,7 @@ module "aws_gh_actions" {
   github_project         = "pkg"
   github_repo_branch_ref = "*"
 
-  github_secret_accound_id_name  = "OCI_E2E_AWS_ACCOUNT_ID"
   github_secret_assume_role_name = "OCI_E2E_AWS_ASSUME_ROLE_NAME"
-  github_variable_region_name    = "OCI_E2E_AWS_REGION"
 
   github_variable_custom = {
     "OCI_E2E_TF_VAR_cross_region" = "us-east-1"


### PR DESCRIPTION
- Add a new workflow `integration-aws` for running the OCI AWS integration tests.
- Add setup docs for configuring the AWS account and GitHub repository for running the tests.

Depends on https://github.com/fluxcd/test-infra/pull/41.

:warning: The AWS and GitHub requirements as documented in the test README under **IAM and CI setup** needs to be fulfilled before or soon after merging this. Else, the CI jobs triggered due to the workflow cron configuration would fail.

Example run: https://github.com/darkowlzz/pkg/actions/runs/9276292128/job/25523036576

Part of https://github.com/fluxcd/flux2/issues/4619