### PR TITLE
Cache credentials tokens

### DIFF
--- a/oci/auth/login/login.go
+++ b/oci/auth/login/login.go
@@ -113,24 +113,34 @@ func (m *Manager) WithACRClient(c *azure.Client) *Manager {
 // For generic registry provider, it is no-op.
 func (m *Manager) Login(ctx context.Context, url string, ref name.Reference, opts ProviderOptions) (authn.Authenticator, error) {
 	log := log.FromContext(ctx)
+	provider := ImageRegistryProvider(url, ref)
+	var (
+		key string
+		err error
+	)
 	if opts.Cache != nil {
-		auth, exists, err := getObjectFromCache(opts.Cache, url)
+		key, err = m.keyFromURL(url, provider)
 		if err != nil {
-			log.Error(err, "failed to get auth object from cache")
-		}
-		if exists {
-			return auth, nil
+			log.Error(err, "failed to get cache key")
+		} else {
+			auth, exists, err := getObjectFromCache(opts.Cache, key)
+			if err != nil {
+				log.Error(err, "failed to get auth object from cache")
+			}
+			if exists {
+				return auth, nil
+			}
 		}
 	}
 
-	switch ImageRegistryProvider(url, ref) {
+	switch provider {
 	case oci.ProviderAWS:
 		auth, expiresAt, err := m.ecr.LoginWithExpiry(ctx, opts.AwsAutoLogin, url)
 		if err != nil {
 			return nil, err
 		}
 		if opts.Cache != nil {
-			err := cacheObject(opts.Cache, auth, url, expiresAt)
+			err := cacheObject(opts.Cache, auth, key, expiresAt)
 			if err != nil {
 				log.Error(err, "failed to cache auth object")
 			}
@@ -142,7 +152,7 @@ func (m *Manager) Login(ctx context.Context, url string, ref name.Reference, opt
 			return nil, err
 		}
 		if opts.Cache != nil {
-			err := cacheObject(opts.Cache, auth, url, expiresAt)
+			err := cacheObject(opts.Cache, auth, key, expiresAt)
 			if err != nil {
 				log.Error(err, "failed to cache auth object")
 			}
@@ -154,7 +164,7 @@ func (m *Manager) Login(ctx context.Context, url string, ref name.Reference, opt
 			return nil, err
 		}
 		if opts.Cache != nil {
-			err := cacheObject(opts.Cache, auth, url, expiresAt)
+			err := cacheObject(opts.Cache, auth, key, expiresAt)
 			if err != nil {
 				log.Error(err, "failed to cache auth object")
 			}
@@ -197,4 +207,29 @@ func (m *Manager) OIDCLogin(ctx context.Context, registryURL string, opts Provid
 		return m.acr.OIDCLogin(ctx, fmt.Sprintf("%s://%s", u.Scheme, u.Host))
 	}
 	return nil, nil
+}
+
+// keyFromURL returns a key for the cache based on the URL and provider.
+// Use this when you don't want to cache the full URL,
+// but instead want to cache based on the provider secific way of identifying
+// the authentication principal, i.e. the Domain for AWS and Azure, Project for GCP.
+func (m *Manager) keyFromURL(ref string, provider oci.Provider) (string, error) {
+	if !strings.Contains(ref, "://") {
+		ref = fmt.Sprintf("//%s", ref)
+	}
+	u, err := url.Parse(ref)
+	if err != nil {
+		return "", err
+	}
+	switch provider {
+	case oci.ProviderAWS, oci.ProviderAzure:
+		return u.Host, nil
+	case oci.ProviderGCP:
+		paths := strings.Split(u.Path, "/")
+		if len(paths) > 1 {
+			return fmt.Sprintf("%s/%s", u.Host, paths[1]), nil
+		}
+		return u.Host, nil
+	}
+	return "", nil
 }


### PR DESCRIPTION
We currently use the full `image url` as key for the cache. The new change introduced here reduce cardinality and permit reusing a cached credentials based on `aws region`, `gcp project` and `azure endpoint`.