### PR TITLE
workflows: add id-token permission for cleanup job

### DIFF
--- a/.github/workflows/integration-cleanup.yaml
+++ b/.github/workflows/integration-cleanup.yaml
@@ -5,7 +5,8 @@ on:
   schedule:
     - cron: "0 * * * *"
 
-permissions: {}
+permissions:
+  id-token: write # Required for obtaining AWS OIDC federated credential.
 
 env:
   GCRGC_VERSION: 0.4.8
@@ -100,7 +101,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.CLEANUP_E2E_AWS_ASSUME_ROLE_NAME }}
-          role-session-name: OCI_GH_Actions
+          role-session-name: cleanup_GH_Actions
           aws-region: ${{ vars.AWS_REGION }}
       - name: Run reaper
         run: go run ./ -provider azure -retention-period 1h -tags 'ci=true' -delete


### PR DESCRIPTION
cleanup job for AWS uses OIDC federated credential, which requires id-token.

Also, rename the role session name to be more accurate.