### PR TITLE
workflow: Set aws-nuke region for cleanup

### DIFF
--- a/.github/workflows/integration-cleanup.yaml
+++ b/.github/workflows/integration-cleanup.yaml
@@ -104,4 +104,4 @@ jobs:
           role-session-name: cleanup_GH_Actions
           aws-region: ${{ vars.AWS_REGION }}
       - name: Run reaper
-        run: go run ./ -provider aws -retention-period 1h -tags 'ci=true' -delete
+        run: go run ./ -provider aws-nuke -awsregions '${{ vars.AWS_REGION }},${{ vars.OCI_E2E_TF_VAR_cross_region }}' -retention-period 1h -tags 'ci=true' -delete


### PR DESCRIPTION
Set the aws-nuke target regions from the region variables in the environment.

Working run: https://github.com/fluxcd/pkg/actions/runs/10250728406/job/28357102908