### PR TITLE
workflows/integration-*: set git and oci env vars

### DIFF
--- a/.github/workflows/integration-aws.yaml
+++ b/.github/workflows/integration-aws.yaml
@@ -41,6 +41,7 @@ jobs:
           cat > .env <<EOF
           export TF_VAR_rand=${RANDOM}
           export TF_VAR_tags='{"environment"="github", "ci"="true", "repo"="pkg", "createdat"="$(date -u +x%Y-%m-%d_%Hh%Mm%Ss)"}'
+          export TF_VAR_enable_oci=true
           EOF
       - name: Print .env for dynamic tag value reference
         run: cat .env

--- a/.github/workflows/integration-azure.yaml
+++ b/.github/workflows/integration-azure.yaml
@@ -41,6 +41,8 @@ jobs:
         run: |
           cat > .env <<EOF
           export TF_VAR_tags='{"environment"="github", "ci"="true", "repo"="pkg", "createdat"="$(date -u +x%Y-%m-%d_%Hh%Mm%Ss)"}'
+          export TF_VAR_enable_git=true
+          export TF_VAR_enable_oci=true
           EOF
       - name: Print .env for dynamic tag value reference
         run: cat .env

--- a/.github/workflows/integration-gcp.yaml
+++ b/.github/workflows/integration-gcp.yaml
@@ -57,6 +57,7 @@ jobs:
         run: |
           cat > .env <<EOF
           export TF_VAR_tags='{"environment"="github", "ci"="true", "repo"="pkg", "createdat"="$(date -u +x%Y-%m-%d_%Hh%Mm%Ss)"}'
+          export TF_VAR_enable_oci=true
           EOF
       - name: Print .env for dynamic tag value reference
         run: cat .env


### PR DESCRIPTION
With the recent changes to the integration tests, the type of tests supported by the infrastructure need to be explicitly set. OCI infrastructure is supported by all of our setup. Git infrastructure is set for Azure only. It is ineffective for now as we don't have an azure account to run the tests.

Test runs:
- GCP: https://github.com/fluxcd/pkg/actions/runs/11730115803
- AWS: https://github.com/fluxcd/pkg/actions/runs/11730370827
