### PR TITLE
allow proxy during SSH host key scan in FluxCD CLI

### DIFF
--- a/ssh/go.mod
+++ b/ssh/go.mod
@@ -3,15 +3,16 @@ module github.com/fluxcd/pkg/ssh
 go 1.26.0
 
 require (
+	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/onsi/gomega v1.40.0
 	golang.org/x/crypto v0.47.0
+	golang.org/x/net v0.49.0
 )
 
 require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 )

--- a/ssh/go.mod
+++ b/ssh/go.mod
@@ -3,7 +3,7 @@ module github.com/fluxcd/pkg/ssh
 go 1.26.0
 
 require (
-	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
+	github.com/firefart/gosocks v0.4.2
 	github.com/onsi/gomega v1.40.0
 	golang.org/x/crypto v0.47.0
 	golang.org/x/net v0.49.0

--- a/ssh/go.sum
+++ b/ssh/go.sum
@@ -1,3 +1,5 @@
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=

--- a/ssh/go.sum
+++ b/ssh/go.sum
@@ -1,6 +1,6 @@
-github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
-github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/firefart/gosocks v0.4.2 h1:HduMZGxEVsBFEHa57rNwqg8S8M878Pe2Og1TfQKaIR8=
+github.com/firefart/gosocks v0.4.2/go.mod h1:9k5AYic+qFxo1W9hxw3vFbRTBEVIT3nWepdFvqv0uc4=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/ssh/host_key_test.go
+++ b/ssh/host_key_test.go
@@ -1,3 +1,5 @@
+//go:build !proxy
+
 /*
 Copyright 2022 The Flux authors
 
@@ -17,32 +19,35 @@ limitations under the License.
 package ssh
 
 import (
+	"context"
+	"fmt"
 	"net"
+	"os"
+	"os/exec"
 	"testing"
 	"time"
 
+	"github.com/armon/go-socks5"
 	. "github.com/onsi/gomega"
 	"golang.org/x/crypto/ssh"
 )
 
-func TestScanHost(t *testing.T) {
-	g := NewWithT(t)
+func startSSH(listener net.Listener, cfg *ssh.ServerConfig, g *WithT) {
+	conn, err := listener.Accept()
+	g.Expect(err).ToNot(HaveOccurred())
 
-	startSSH := func(listener net.Listener, cfg *ssh.ServerConfig) {
-		conn, err := listener.Accept()
-		g.Expect(err).ToNot(HaveOccurred())
-
-		sConn, _, _, err := ssh.NewServerConn(conn, cfg)
-		if err != nil {
-			// the only expected error
-			g.Expect(err.Error()).To(ContainSubstring("no common algorithm for host key"))
-			return
-		}
-
-		sConn.Close()
-		listener.Close()
+	sConn, _, _, err := ssh.NewServerConn(conn, cfg)
+	if err != nil {
+		// the only expected error
+		g.Expect(err.Error()).To(ContainSubstring("no common algorithm for host key"))
+		return
 	}
 
+	sConn.Close()
+	listener.Close()
+}
+
+func TestScanHost(t *testing.T) {
 	tests := []struct {
 		keyType        KeyPairType
 		sshKeyTypeName string
@@ -83,7 +88,7 @@ func TestScanHost(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 			sshConfig.AddHostKey(signer)
 
-			go startSSH(listener, sshConfig)
+			go startSSH(listener, sshConfig, g)
 
 			kh, err := ScanHostKey(serverAddr, 5*time.Second, []string{tt.sshKeyTypeName}, false)
 			if tt.wantErr == "" {
@@ -99,4 +104,72 @@ func TestScanHost(t *testing.T) {
 			listener.Close()
 		})
 	}
+}
+
+// this test is partially based on a go-git's TestSOCKS5Proxy
+// see https://github.com/go-git/go-git/blob/5f90b841aef24f235002e2fc71bfb1e142f804cf/plumbing/transport/ssh/proxy_test.go#L21
+func TestScanHostWithProxy(t *testing.T) {
+	g := NewWithT(t)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	serverAddr := listener.Addr().String()
+	g.Expect(serverAddr).ToNot(BeEmpty())
+
+	sshConfig := &ssh.ServerConfig{
+		NoClientAuth: true,
+	}
+
+	// Generate new keypair for the server to use for HostKeys.
+	hkp, err := GenerateKeyPair(RSA_4096)
+	g.Expect(err).NotTo(HaveOccurred())
+	p, err := ssh.ParseRawPrivateKey(hkp.PrivateKey)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Add key to server.
+	signer, err := ssh.NewSignerFromKey(p)
+	g.Expect(err).NotTo(HaveOccurred())
+	sshConfig.AddHostKey(signer)
+
+	go startSSH(listener, sshConfig, g)
+
+	rule := new(testProxyRule)
+	socksServer, err := socks5.New(&socks5.Config{
+		Rules: rule,
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	socksListener, err := net.Listen("tcp", "127.0.0.1:0")
+	g.Expect(err).ToNot(HaveOccurred())
+	go socksServer.Serve(socksListener)
+
+	// we can't set ENV only for this test
+	// because Golang proxy package caches ENV checks
+	// and there is no method to reset this cache outside of proxy package
+	// https://cs.opensource.google/go/x/net/+/refs/tags/v0.57.0:proxy/proxy.go;l=132
+	// so we have to run an additional process
+	// and then check the request counter in our socks server
+	cmd := exec.Command("go", "test", "-tags=proxy")
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("SSH_HOST=%s", serverAddr),
+		fmt.Sprintf("ALL_PROXY=socks5://127.0.0.1:%d", socksListener.Addr().(*net.TCPAddr).Port),
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Child process failed with %v. Output: %s", err, string(output))
+	}
+
+	g.Expect(rule.proxiedRequests).Should(BeNumerically(">", 0))
+	listener.Close()
+	socksListener.Close()
+}
+
+type testProxyRule struct {
+	proxiedRequests int
+}
+
+func (r *testProxyRule) Allow(_ context.Context, _ *socks5.Request) (context.Context, bool) {
+	r.proxiedRequests++
+	return context.Background(), true
 }

--- a/ssh/host_key_test.go
+++ b/ssh/host_key_test.go
@@ -21,13 +21,14 @@ package ssh
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
 	"testing"
 	"time"
 
-	"github.com/armon/go-socks5"
+	socks "github.com/firefart/gosocks"
 	. "github.com/onsi/gomega"
 	"golang.org/x/crypto/ssh"
 )
@@ -134,14 +135,19 @@ func TestScanHostWithProxy(t *testing.T) {
 
 	go startSSH(listener, sshConfig, g)
 
-	rule := new(testProxyRule)
-	socksServer, err := socks5.New(&socks5.Config{
-		Rules: rule,
-	})
+	handler := &CustomHandler{
+		DefaultHandler: socks.DefaultHandler{
+			Timeout: 1 * time.Second,
+		},
+	}
+	socksAddress := "127.0.0.1:1080"
+	socksProxy := socks.Proxy{
+		ServerAddr:   socksAddress,
+		Proxyhandler: handler,
+		Timeout:      1 * time.Second,
+	}
 	g.Expect(err).NotTo(HaveOccurred())
-	socksListener, err := net.Listen("tcp", "127.0.0.1:0")
-	g.Expect(err).ToNot(HaveOccurred())
-	go socksServer.Serve(socksListener)
+	socksProxy.Start(context.TODO())
 
 	// we can't set ENV only for this test
 	// because Golang proxy package caches ENV checks
@@ -152,7 +158,7 @@ func TestScanHostWithProxy(t *testing.T) {
 	cmd := exec.Command("go", "test", "-tags=proxy")
 	cmd.Env = append(os.Environ(),
 		fmt.Sprintf("SSH_HOST=%s", serverAddr),
-		fmt.Sprintf("ALL_PROXY=socks5://127.0.0.1:%d", socksListener.Addr().(*net.TCPAddr).Port),
+		fmt.Sprintf("ALL_PROXY=socks5://%s", socksAddress),
 	)
 
 	output, err := cmd.CombinedOutput()
@@ -160,16 +166,17 @@ func TestScanHostWithProxy(t *testing.T) {
 		t.Fatalf("Child process failed with %v. Output: %s", err, string(output))
 	}
 
-	g.Expect(rule.proxiedRequests).Should(BeNumerically(">", 0))
+	g.Expect(handler.proxiedRequests).Should(BeNumerically(">", 0))
 	listener.Close()
-	socksListener.Close()
+	socksProxy.Stop()
 }
 
-type testProxyRule struct {
+type CustomHandler struct {
+	socks.DefaultHandler
 	proxiedRequests int
 }
 
-func (r *testProxyRule) Allow(_ context.Context, _ *socks5.Request) (context.Context, bool) {
-	r.proxiedRequests++
-	return context.Background(), true
+func (h *CustomHandler) Init(ctx context.Context, request socks.Request) (context.Context, io.ReadWriteCloser, *socks.Error) {
+	h.proxiedRequests += 1
+	return h.DefaultHandler.Init(ctx, request)
 }

--- a/ssh/proxy_test.go
+++ b/ssh/proxy_test.go
@@ -1,0 +1,18 @@
+//go:build proxy
+
+package ssh
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestWithProxy(t *testing.T) {
+	g := NewWithT(t)
+	kh, err := ScanHostKey(os.Getenv("SSH_HOST"), 5*time.Second, []string{"ssh-rsa"}, false)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(kh)).To(ContainSubstring("ssh-rsa"))
+}


### PR DESCRIPTION
`ssh.Dial` uses `net.DialTimeout` under the hood [src](https://cs.opensource.google/go/x/crypto/+/refs/tags/v0.29.0:ssh/client.go;l=176)
and there is no possibility to use a proxy when running command like `flux create source git --url ssh://git@example.com/repository.git` (unlike for the [source controller](https://fluxcd.io/flux/installation/configuration/proxy-setting/#git-repository-access-via-socks5-ssh-proxy) with `ALL_PROXY`)

so I replaced `ssh.Dial` with its almost full internal implementation
except `net.DialTimeout` replaced with `proxy.Dial`
like it is done in [go-git](https://github.com/go-git/go-git/blob/v5.0.0/plumbing/transport/ssh/common.go#L147)