### PR TITLE
Remove requirement for ECR URL to end in amazonaws.com or amazonaws.com.cn

### DIFF
--- a/oci/auth/aws/auth.go
+++ b/oci/auth/aws/auth.go
@@ -37,7 +37,9 @@ import (
 	"github.com/fluxcd/pkg/oci"
 )
 
-var registryPartRe = regexp.MustCompile(`([0-9+]*).dkr.ecr(?:-fips)?\.([^/.]*)\.(amazonaws\.com[.cn]*)`)
+// We cannot put "amazonaws.com" at the end of the regex because some AWS partitions do not use "amazonaws.com" as their domain name.
+// However, we can assume the structure <Account ID>.dkr.ecr<-fips?>.<Region>.<Partition API domain> is consistent everywhere.
+var registryPartRe = regexp.MustCompile(`([0-9+]+).dkr.ecr(?:-fips)?\.([^/.]*)\.`)
 
 // ParseRegistry returns the AWS account ID and region and `true` if
 // the image registry/repository is hosted in AWS's Elastic Container Registry,

--- a/oci/auth/aws/auth_test.go
+++ b/oci/auth/aws/auth_test.go
@@ -77,11 +77,22 @@ func TestParseRegistry(t *testing.T) {
 			wantRegion:    "us-gov-west-1",
 			wantOK:        true,
 		},
-		// TODO: Fix: this invalid registry is allowed by the regex.
-		// {
-		// 	registry: ".dkr.ecr.error.amazonaws.com",
-		// 	wantOK:   false,
-		// },
+		{
+			registry:      "012345678901.dkr.ecr.special-region.special-partition.unknown",
+			wantAccountID: "012345678901",
+			wantRegion:    "special-region",
+			wantOK:        true,
+		},
+		{
+			registry:      "012345678901.dkr.ecr-fips.special-region.special-partition.unknown",
+			wantAccountID: "012345678901",
+			wantRegion:    "special-region",
+			wantOK:        true,
+		},
+		{
+			registry: ".dkr.ecr.error.amazonaws.com",
+			wantOK:   false,
+		},
 		{
 			registry: "gcr.io/foo/bar:baz",
 			wantOK:   false,


### PR DESCRIPTION
Resolves #832