### PR TITLE
Update ECR parsing regex to include non-public AWS partitions

### DIFF
--- a/oci/auth/aws/auth.go
+++ b/oci/auth/aws/auth.go
@@ -37,7 +37,9 @@ import (
 	"github.com/fluxcd/pkg/oci"
 )
 
-var registryPartRe = regexp.MustCompile(`([0-9+]*).dkr.ecr(?:-fips)?\.([^/.]*)\.(amazonaws\.com[.cn]*)`)
+// This regex is sourced from the AWS ECR Credential Helper (https://github.com/awslabs/amazon-ecr-credential-helper).
+// It covers both public AWS partitions like amazonaws.com, China partitions like amazonaws.com.cn, and non-public partitions.
+var registryPartRe = regexp.MustCompile(`([0-9+]*).dkr.ecr(?:-fips)?\.([^/.]*)\.(amazonaws\.com[.cn]*|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)`)
 
 // ParseRegistry returns the AWS account ID and region and `true` if
 // the image registry/repository is hosted in AWS's Elastic Container Registry,

--- a/oci/auth/aws/auth_test.go
+++ b/oci/auth/aws/auth_test.go
@@ -77,6 +77,30 @@ func TestParseRegistry(t *testing.T) {
 			wantRegion:    "us-gov-west-1",
 			wantOK:        true,
 		},
+		{
+			registry:      "012345678901.dkr.ecr.us-secret-region.sc2s.sgov.gov",
+			wantAccountID: "012345678901",
+			wantRegion:    "us-secret-region",
+			wantOK:        true,
+		},
+		{
+			registry:      "012345678901.dkr.ecr-fips.us-ts-region.c2s.ic.gov",
+			wantAccountID: "012345678901",
+			wantRegion:    "us-ts-region",
+			wantOK:        true,
+		},
+		{
+			registry:      "012345678901.dkr.ecr.uk-region.cloud.adc-e.uk",
+			wantAccountID: "012345678901",
+			wantRegion:    "uk-region",
+			wantOK:        true,
+		},
+		{
+			registry:      "012345678901.dkr.ecr.us-ts-region.csp.hci.ic.gov",
+			wantAccountID: "012345678901",
+			wantRegion:    "us-ts-region",
+			wantOK:        true,
+		},
 		// TODO: Fix: this invalid registry is allowed by the regex.
 		// {
 		// 	registry: ".dkr.ecr.error.amazonaws.com",


### PR DESCRIPTION
Resolves #832 and references https://github.com/awslabs/amazon-ecr-credential-helper/blob/69e8c24e6fc115fd00d7c363cde156570ce73144/ecr-login/api/client.go#L40.

Public AWS Documentation about hidden partitions (non-amazonaws.com or .com.cn) is limited. Read more about AWS partitions [here](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/partitions.html). 