### PR TITLE
workflows: Use setup-terraform install latest

### DIFF
--- a/.github/workflows/integration-aws.yaml
+++ b/.github/workflows/integration-aws.yaml
@@ -26,6 +26,8 @@ jobs:
         with:
           go-version: 1.23.x
           cache-dependency-path: oci/tests/integration/go.sum
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:

--- a/.github/workflows/integration-azure.yaml
+++ b/.github/workflows/integration-azure.yaml
@@ -29,6 +29,8 @@ jobs:
         with:
           go-version: 1.23.x
           cache-dependency-path: oci/tests/integration/go.sum
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
       - name: Authenticate to Azure
         uses: Azure/login@a65d910e8af852a8061c627c456678983e180302 # v1.4.6
         with:

--- a/.github/workflows/integration-gcp.yaml
+++ b/.github/workflows/integration-gcp.yaml
@@ -29,6 +29,8 @@ jobs:
         with:
           go-version: 1.23.x
           cache-dependency-path: oci/tests/integration/go.sum
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
         id: 'auth'


### PR DESCRIPTION
Terraform v1.10.0 had a bug in `apply` when reading variables from environment, refer https://github.com/hashicorp/terraform/issues/36106 for details. This resulted in all of our CI setup that uses terraform to fail with the following error:

```
Error: Can't change variable when applying a saved plan

The variable tags cannot be set using the -var and -var-file options when
applying a saved plan file, because a saved plan includes the variable values
that were set when it was created. The saved plan specifies
"{\"environment\"=\"github\", \"ci\"=\"true\", \"repo\"=\"pkg\",
\"createdat\"=\"x2024-12-10_12h09m54s\"}" as the value whereas during apply
the value object with 4 attributes was set by an environment variable. To
declare an ephemeral variable which is not saved in the plan file, use
ephemeral = true.
```

Terraform v1.10.1 fixes this. But in all of our CI, we use `ubuntu-latest` (22.04), which was updated to terraform v1.10.0 as of last week, refer https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md.

Use `setup-terraform` to install the latest version of terraform.
Unlike Go, which is used on a daily basic by all the Flux developers, the terraform code and infrastructure gets maintenance updates occasionally. Hence, keeping it on a rolling version, which would make any failure due to incompatibility more visible for now.

CI results:
- GCP https://github.com/fluxcd/pkg/actions/runs/12258563799
- AWS https://github.com/fluxcd/pkg/actions/runs/12258684393/job/34199032690