### PR TITLE
chore: add function to group entries by action in changeset output

### DIFF
--- a/ssa/changeset.go
+++ b/ssa/changeset.go
@@ -76,6 +76,14 @@ func (c *ChangeSet) String() string {
 	return strings.TrimSuffix(b.String(), "\n")
 }
 
+func (c *ChangeSet) ToGroupedMap() map[Action][]string {
+	res := make(map[Action][]string)
+	for _, entry := range c.Entries {
+		res[entry.Action] = append(res[entry.Action], entry.Subject)
+	}
+	return res
+}
+
 func (c *ChangeSet) ToMap() map[string]Action {
 	res := make(map[string]Action, len(c.Entries))
 	for _, entry := range c.Entries {


### PR DESCRIPTION
This can then be used to improve cardinality of logs in kustomize-controller.
I have tested and will make a PR to kustomize-controller which does this:  
```
log.Info("server-side apply for cluster definitions completed", "output", changeSet.ToMap())
+                       log.Info("server-side apply for cluster definitions completed", "output", changeSet.ToGroupedMap()
```

It helps with https://github.com/fluxcd/flux2/issues/4036 