### PR TITLE
runtime: downgrade github.com/google/cel-go and cel.dev/expr

### DIFF
--- a/runtime/go.mod
+++ b/runtime/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/fluxcd/pkg/apis/kustomize v1.9.0
 	github.com/fluxcd/pkg/apis/meta v1.10.0
 	github.com/go-logr/logr v1.4.2
-	github.com/google/cel-go v0.23.1
+	github.com/google/cel-go v0.22.0
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/kylelemons/godebug v1.1.0
@@ -41,7 +41,7 @@ require (
 replace gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.1
 
 require (
-	cel.dev/expr v0.19.1 // indirect
+	cel.dev/expr v0.18.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect

--- a/runtime/go.sum
+++ b/runtime/go.sum
@@ -1,5 +1,5 @@
-cel.dev/expr v0.19.1 h1:NciYrtDRIR0lNCnH1LFJegdjspNx9fI59O7TWcua/W4=
-cel.dev/expr v0.19.1/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
+cel.dev/expr v0.18.0 h1:CJ6drgk+Hf96lkLikr4rFf19WrU0BOWEihyZnI2TAzo=
+cel.dev/expr v0.18.0/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
@@ -61,8 +61,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
-github.com/google/cel-go v0.23.1 h1:91ThhEZlBcE5rB2adBVXqvDoqdL8BG2oyhd0bK1I/r4=
-github.com/google/cel-go v0.23.1/go.mod h1:52Pb6QsDbC5kvgxvZhiL9QX1oZEkcUF/ZqaPx1J5Wwo=
+github.com/google/cel-go v0.22.0 h1:b3FJZxpiv1vTMo2/5RDUqAHPxkT8mmMfJIrq1llbf7g=
+github.com/google/cel-go v0.22.0/go.mod h1:BuznPXXfQDpXKWQ9sPW3TzlAJN5zzFe+i9tIs0yC4s8=
 github.com/google/gnostic-models v0.6.9 h1:MU/8wDLif2qCXZmzncUQ/BOfxWfthHi63KqpoNbWqVw=
 github.com/google/gnostic-models v0.6.9/go.mod h1:CiWsm0s6BSQd1hRn8/QmxqB6BesYcbSZxsz9b0KuDBw=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=


### PR DESCRIPTION
Downgrade these deps to versions used in k8s.io/apiserver:
- https://github.com/kubernetes/apiserver/blob/v0.32.1/go.mod#L21
- https://github.com/kubernetes/apiserver/blob/v0.32.1/go.mod#L70

Reason: this change prevents compilation error when the project's dependencies (or the project itself) imports both `k8s.io/apiserver/pkg/cel/environment` and `github.com/fluxcd/pkg/runtime/*`. 

Reproduction:
```go
package main

import (
	"fmt"

	"github.com/fluxcd/pkg/runtime/client"
	"k8s.io/apiserver/pkg/cel/environment"
)

func main() {
	_ = environment.StoredExpressions
	_ = client.GetConfigOrDie
	fmt.Println("exit")
}
```

`go.mod`:
```go
module github.com/aerfio/repoduction

go 1.23.5

require (
	github.com/fluxcd/pkg/runtime v0.53.0
	k8s.io/apiserver v0.32.1
)


require (
	cel.dev/expr v0.19.1 // indirect
	github.com/google/cel-go v0.23.1 // indirect
        // other indirect deps
)
```

compiling this simple app results in:
```
# k8s.io/apiserver/pkg/cel/environment
/Users/aerfio/go/pkg/mod/k8s.io/apiserver@v0.32.1/pkg/cel/environment/base.go:176:19: cannot use ext.TwoVarComprehensions (value of type func(options ...ext.TwoVarComprehensionsOption) "github.com/google/cel-go/cel".EnvOption) as func() "github.com/google/cel-go/cel".EnvOption value in argument to UnversionedLib
```

Trying to force correct deps also fails:
```
❯ go get -u github.com/google/cel-go@v0.22.0 cel.dev/expr@v0.18.0 github.com/fluxcd/pkg/runtime@v0.53.0
go: github.com/fluxcd/pkg/runtime@v0.53.0 requires github.com/google/cel-go@v0.23.1, not github.com/google/cel-go@v0.22.0
```