### PR TITLE
support string evaluation in CEL expressions

### DIFF
--- a/runtime/cel/expression.go
+++ b/runtime/cel/expression.go
@@ -136,3 +136,16 @@ func (e *Expression) EvaluateBoolean(ctx context.Context, data map[string]any) (
 	}
 	return bool(result), nil
 }
+
+// EvaluateString evaluates the expression with the given data and returns the result as a string.
+func (e *Expression) EvaluateString(ctx context.Context, data map[string]any) (string, error) {
+	val, _, err := e.prog.ContextEval(ctx, data)
+	if err != nil {
+		return "", fmt.Errorf("failed to evaluate the CEL expression '%s': %w", e.expr, err)
+	}
+	result, ok := val.(types.String)
+	if !ok {
+		return "", fmt.Errorf("failed to evaluate CEL expression as string: '%s'", e.expr)
+	}
+	return string(result), nil
+}


### PR DESCRIPTION
related: https://github.com/fluxcd/notification-controller/issues/589#issuecomment-2688342204

in order to leverage the `cel` flux package for the purposes of evaluating a commit status/id expression, it's necessary to expose a function for evaluating strings ([similar](https://github.com/fluxcd/pkg/blob/8b1f852228b117123efcc7b5708ce112801416b6/runtime/cel/expression.go#L128) to `EvaluateBoolean`)
