### PR TITLE
[RFC-0010] Support cross-cloud object-level workload identity

### DIFF
--- a/.github/workflows/integration-cleanup.yaml
+++ b/.github/workflows/integration-cleanup.yaml
@@ -63,7 +63,7 @@ jobs:
     defaults:
       run:
         working-directory: ./tools/reaper
-    if: false
+    if: true
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -77,7 +77,7 @@ jobs:
       - name: Authenticate to Azure
         uses: Azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v1.4.6
         with:
-          creds: '{"clientId":"${{ secrets.CLEANUP_E2E_AZ_ARM_CLIENT_ID }}","clientSecret":"${{ secrets.CLEANUP_E2E_AZ_ARM_CLIENT_SECRET }}","subscriptionId":"${{ secrets.CLEANUP_E2E_AZ_ARM_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.CLEANUP_E2E_AZ_ARM_TENANT_ID }}"}'
+          creds: '{"clientId":"${{ secrets.ARM_CLIENT_ID }}","clientSecret":"${{ secrets.ARM_CLIENT_SECRET }}","subscriptionId":"${{ secrets.ARM_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.ARM_TENANT_ID }}"}'
       - name: Run reaper
         run: go run ./ -provider azure -retention-period 1h -tags 'ci=true' -delete
 

--- a/auth/aws/provider.go
+++ b/auth/aws/provider.go
@@ -111,7 +111,7 @@ func (p Provider) NewControllerToken(ctx context.Context, opts ...auth.Option) (
 }
 
 // GetAudience implements auth.Provider.
-func (Provider) GetAudience(ctx context.Context) (string, error) {
+func (Provider) GetAudience(context.Context, corev1.ServiceAccount) (string, error) {
 	return "sts.amazonaws.com", nil
 }
 

--- a/auth/aws/provider_test.go
+++ b/auth/aws/provider_test.go
@@ -203,6 +203,27 @@ func TestProvider_NewTokenForServiceAccount(t *testing.T) {
 	}
 }
 
+func TestProvider_GetAudience(t *testing.T) {
+	g := NewWithT(t)
+	aud, err := aws.Provider{}.GetAudience(context.Background(), corev1.ServiceAccount{})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(aud).To(Equal("sts.amazonaws.com"))
+}
+
+func TestProvider_GetIdentity(t *testing.T) {
+	g := NewWithT(t)
+
+	identity, err := aws.Provider{}.GetIdentity(corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"eks.amazonaws.com/role-arn": "arn:aws:iam::1234567890:role/some-role",
+			},
+		},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(identity).To(Equal("arn:aws:iam::1234567890:role/some-role"))
+}
+
 func TestProvider_NewArtifactRegistryCredentials(t *testing.T) {
 	g := NewWithT(t)
 

--- a/auth/azure/provider.go
+++ b/auth/azure/provider.go
@@ -73,7 +73,7 @@ func (p Provider) NewControllerToken(ctx context.Context, opts ...auth.Option) (
 }
 
 // GetAudience implements auth.Provider.
-func (Provider) GetAudience(context.Context) (string, error) {
+func (Provider) GetAudience(context.Context, corev1.ServiceAccount) (string, error) {
 	return "api://AzureADTokenExchange", nil
 }
 

--- a/auth/azure/provider_test.go
+++ b/auth/azure/provider_test.go
@@ -127,6 +127,28 @@ func TestProvider_NewTokenForServiceAccount(t *testing.T) {
 	}
 }
 
+func TestProvider_GetAudience(t *testing.T) {
+	g := NewWithT(t)
+	aud, err := azure.Provider{}.GetAudience(context.Background(), corev1.ServiceAccount{})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(aud).To(Equal("api://AzureADTokenExchange"))
+}
+
+func TestProvider_GetIdentity(t *testing.T) {
+	g := NewWithT(t)
+
+	identity, err := azure.Provider{}.GetIdentity(corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"azure.workload.identity/client-id": "client-id",
+				"azure.workload.identity/tenant-id": "tenant-id",
+			},
+		},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(identity).To(Equal("tenant-id/client-id"))
+}
+
 func TestProvider_NewArtifactRegistryCredentials(t *testing.T) {
 	g := NewWithT(t)
 

--- a/auth/gcp/gke_metadata_test.go
+++ b/auth/gcp/gke_metadata_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2025 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcp_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+)
+
+func startGKEMetadataServer(t *testing.T) {
+	t.Helper()
+	g := NewWithT(t)
+
+	lis, err := net.Listen("tcp", ":0")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	gkeMetadataServer := &http.Server{
+		Addr: lis.Addr().String(),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/computeMetadata/v1/project/project-id":
+				fmt.Fprintf(w, "%s", "project-id")
+			case "/computeMetadata/v1/instance/attributes/cluster-location":
+				fmt.Fprintf(w, "%s", "cluster-location")
+			case "/computeMetadata/v1/instance/attributes/cluster-name":
+				fmt.Fprintf(w, "%s", "cluster-name")
+			}
+		}),
+	}
+
+	go func() {
+		err := gkeMetadataServer.Serve(lis)
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			g.Expect(err).NotTo(HaveOccurred())
+		}
+	}()
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		err := gkeMetadataServer.Shutdown(ctx)
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+
+	t.Setenv("GCE_METADATA_HOST", lis.Addr().String())
+}

--- a/auth/gcp/options.go
+++ b/auth/gcp/options.go
@@ -39,3 +39,20 @@ func getServiceAccountEmail(serviceAccount corev1.ServiceAccount) (string, error
 	}
 	return email, nil
 }
+
+const workloadIdentityProviderPattern = `^https://iam\.googleapis\.com/projects/\d{1,30}/locations/global/workloadIdentityPools/[^/]{1,100}/providers/[^/]{1,100}$`
+
+var workloadIdentityProviderRegex = regexp.MustCompile(workloadIdentityProviderPattern)
+
+func getWorkloadIdentityProvider(serviceAccount corev1.ServiceAccount) (string, error) {
+	const key = "gcp.auth.fluxcd.io/workload-identity-provider"
+	wip := serviceAccount.Annotations[key]
+	if wip == "" {
+		return "", nil
+	}
+	if !workloadIdentityProviderRegex.MatchString(wip) {
+		return "", fmt.Errorf("invalid %s annotation: '%s'. must match %s",
+			key, wip, workloadIdentityProviderPattern)
+	}
+	return wip, nil
+}

--- a/auth/get_token.go
+++ b/auth/get_token.go
@@ -58,7 +58,7 @@ func GetToken(ctx context.Context, provider Provider, opts ...Option) (Token, er
 
 		// Get provider audience.
 		var err error
-		providerAudience, err := provider.GetAudience(ctx)
+		providerAudience, err := provider.GetAudience(ctx, serviceAccount)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get provider audience: %w", err)
 		}

--- a/auth/get_token_test.go
+++ b/auth/get_token_test.go
@@ -75,7 +75,10 @@ func (m *mockProvider) NewControllerToken(ctx context.Context, opts ...auth.Opti
 	return m.returnControllerToken, nil
 }
 
-func (m *mockProvider) GetAudience(ctx context.Context) (string, error) {
+func (m *mockProvider) GetAudience(ctx context.Context, serviceAccount corev1.ServiceAccount) (string, error) {
+	m.t.Helper()
+	g := NewWithT(m.t)
+	g.Expect(serviceAccount).To(Equal(m.paramServiceAccount))
 	return m.returnAudience, nil
 }
 

--- a/auth/provider.go
+++ b/auth/provider.go
@@ -38,7 +38,7 @@ type Provider interface {
 	// ServiceAccounts should have. This is usually a string that represents
 	// the cloud provider's STS service, or some entity in the provider for
 	// which the OIDC tokens are targeted to.
-	GetAudience(ctx context.Context) (string, error)
+	GetAudience(ctx context.Context, serviceAccount corev1.ServiceAccount) (string, error)
 
 	// GetIdentity takes a ServiceAccount and returns the identity which the
 	// ServiceAccount wants to impersonate, by looking at annotations.

--- a/git/go.mod
+++ b/git/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/ProtonMail/go-crypto v1.2.0
 	github.com/bradleyfalzon/ghinstallation/v2 v2.15.0
 	github.com/cyphar/filepath-securejoin v0.4.1
-	github.com/fluxcd/pkg/auth v0.12.0
+	github.com/fluxcd/pkg/auth v0.13.0
 	github.com/fluxcd/pkg/cache v0.9.0
 	github.com/fluxcd/pkg/ssh v0.18.0
 	github.com/onsi/gomega v1.37.0

--- a/git/gogit/go.mod
+++ b/git/gogit/go.mod
@@ -17,9 +17,9 @@ require (
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/elazarl/goproxy v1.7.2
 	github.com/fluxcd/gitkit v0.6.0
-	github.com/fluxcd/pkg/auth v0.12.0
+	github.com/fluxcd/pkg/auth v0.13.0
 	github.com/fluxcd/pkg/cache v0.9.0
-	github.com/fluxcd/pkg/git v0.29.0
+	github.com/fluxcd/pkg/git v0.30.0
 	github.com/fluxcd/pkg/gittestserver v0.17.0
 	github.com/fluxcd/pkg/ssh v0.18.0
 	github.com/fluxcd/pkg/version v0.7.0

--- a/git/internal/e2e/go.mod
+++ b/git/internal/e2e/go.mod
@@ -14,7 +14,7 @@ replace (
 
 require (
 	github.com/fluxcd/go-git-providers v0.22.0
-	github.com/fluxcd/pkg/git v0.29.0
+	github.com/fluxcd/pkg/git v0.30.0
 	github.com/fluxcd/pkg/git/gogit v0.23.0
 	github.com/fluxcd/pkg/gittestserver v0.17.0
 	github.com/fluxcd/pkg/ssh v0.18.0
@@ -46,7 +46,7 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fluxcd/gitkit v0.6.0 // indirect
-	github.com/fluxcd/pkg/auth v0.12.0 // indirect
+	github.com/fluxcd/pkg/auth v0.13.0 // indirect
 	github.com/fluxcd/pkg/cache v0.9.0 // indirect
 	github.com/fluxcd/pkg/version v0.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect

--- a/oci/go.mod
+++ b/oci/go.mod
@@ -12,7 +12,7 @@ replace (
 require (
 	github.com/Masterminds/semver/v3 v3.3.0
 	github.com/distribution/distribution/v3 v3.0.0
-	github.com/fluxcd/pkg/auth v0.12.0
+	github.com/fluxcd/pkg/auth v0.13.0
 	github.com/fluxcd/pkg/sourceignore v0.12.0
 	github.com/fluxcd/pkg/tar v0.12.0
 	github.com/fluxcd/pkg/version v0.7.0

--- a/oci/tests/integration/go.mod
+++ b/oci/tests/integration/go.mod
@@ -11,8 +11,8 @@ replace (
 )
 
 require (
-	github.com/fluxcd/pkg/auth v0.12.0
-	github.com/fluxcd/pkg/git v0.29.0
+	github.com/fluxcd/pkg/auth v0.13.0
+	github.com/fluxcd/pkg/git v0.30.0
 	github.com/fluxcd/pkg/git/gogit v0.23.0
 	github.com/fluxcd/test-infra/tftestenv v0.0.0-20240903092121-c783b14801d1
 	github.com/go-git/go-git/v5 v5.16.0


### PR DESCRIPTION
Part of: https://github.com/fluxcd/flux2/issues/5022

Only support for non-GKE clusters getting access to GCP resources was missing. To support this we introduce the following service account annotation:

```
gcp.auth.fluxcd.io/workload-identity-provider
```

The value of this annotation must match the following pattern:

```
^https://iam.googleapis.com/projects/\d{1,30}/locations/global/workloadIdentityPools/[^/]{1,100}/providers/[^/]{1,100}$
```

Now for getting access to GCP resources EKS/AKS/`kind` users can annotate their `ServiceAccount` with this new annotation and register the Issuer URL of their cluster in GCP as a Workload Identity Provider following these docs:

https://cloud.google.com/iam/docs/workload-identity-federation-with-kubernetes