### PR TITLE
[RFC-0010] Add integration test for GCP workload identity federation

### DIFF
--- a/auth/gcp/options.go
+++ b/auth/gcp/options.go
@@ -54,5 +54,5 @@ func getWorkloadIdentityProviderAudience(serviceAccount corev1.ServiceAccount) (
 		return "", fmt.Errorf("invalid %s annotation: '%s'. must match %s",
 			key, wip, workloadIdentityProviderPattern)
 	}
-	return fmt.Sprintf("https://iam.googleapis.com/%s", wip), nil
+	return fmt.Sprintf("//iam.googleapis.com/%s", wip), nil
 }

--- a/auth/gcp/provider_test.go
+++ b/auth/gcp/provider_test.go
@@ -97,7 +97,7 @@ func TestProvider_NewTokenForServiceAccount(t *testing.T) {
 		{
 			name: "direct access - federation",
 			conf: externalaccount.Config{
-				Audience:         "https://iam.googleapis.com/projects/1234567890/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
+				Audience:         "//iam.googleapis.com/projects/1234567890/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
 				SubjectTokenType: "urn:ietf:params:oauth:token-type:jwt",
 				TokenURL:         "https://sts.googleapis.com/v1/token",
 				TokenInfoURL:     "https://sts.googleapis.com/v1/introspect",
@@ -115,7 +115,7 @@ func TestProvider_NewTokenForServiceAccount(t *testing.T) {
 		{
 			name: "impersonation - federation",
 			conf: externalaccount.Config{
-				Audience:                       "https://iam.googleapis.com/projects/1234567890/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
+				Audience:                       "//iam.googleapis.com/projects/1234567890/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
 				SubjectTokenType:               "urn:ietf:params:oauth:token-type:jwt",
 				TokenURL:                       "https://sts.googleapis.com/v1/token",
 				ServiceAccountImpersonationURL: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/test-sa@project-id.iam.gserviceaccount.com:generateAccessToken",
@@ -197,7 +197,7 @@ func TestProvider_GetAudience(t *testing.T) {
 			annotations: map[string]string{
 				"gcp.auth.fluxcd.io/workload-identity-provider": "projects/1234567890/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
 			},
-			expected: "https://iam.googleapis.com/projects/1234567890/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
+			expected: "//iam.googleapis.com/projects/1234567890/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
 		},
 		{
 			name:     "gke",

--- a/oci/tests/integration/gcp_test.go
+++ b/oci/tests/integration/gcp_test.go
@@ -32,6 +32,10 @@ const (
 	// gcpIAMAnnotation is the key for the annotation on the kubernetes serviceaccount
 	// with the email address of the IAM service account on GCP.
 	gcpIAMAnnotation = "iam.gke.io/gcp-service-account"
+
+	// gcpWorkloadIdentityProviderAnnotation is the key for the annotation on the kubernetes serviceaccount
+	// with the name of the workload identity provider on GCP.
+	gcpWorkloadIdentityProviderAnnotation = "gcp.auth.fluxcd.io/workload-identity-provider"
 )
 
 // createKubeconfigGKE constructs kubeconfig from the terraform state output at
@@ -82,6 +86,18 @@ func getWISAAnnotationsGCP(output map[string]*tfjson.StateOutput) (map[string]st
 
 	return map[string]string{
 		gcpIAMAnnotation: saEmail,
+	}, nil
+}
+
+// getWIFederationSAAnnotationsGCP returns workload identity federation annotations for a kubernetes ServiceAccount
+func getWIFederationSAAnnotationsGCP(output map[string]*tfjson.StateOutput) (map[string]string, error) {
+	workloadIdentityProvider := output["workload_identity_provider"].Value.(string)
+	if workloadIdentityProvider == "" {
+		return nil, fmt.Errorf("no GCP workload identity provider in terraform output")
+	}
+
+	return map[string]string{
+		gcpWorkloadIdentityProviderAnnotation: workloadIdentityProvider,
 	}, nil
 }
 

--- a/oci/tests/integration/go.mod
+++ b/oci/tests/integration/go.mod
@@ -10,7 +10,7 @@ replace (
 )
 
 require (
-	github.com/fluxcd/pkg/auth v0.14.0
+	github.com/fluxcd/pkg/auth v0.16.0
 	github.com/fluxcd/pkg/git v0.31.0
 	github.com/fluxcd/pkg/git/gogit v0.33.0
 	github.com/fluxcd/test-infra/tftestenv v0.0.0-20240903092121-c783b14801d1

--- a/oci/tests/integration/job_test.go
+++ b/oci/tests/integration/job_test.go
@@ -34,6 +34,8 @@ const (
 	objectLevelWIModeDisabled objectLevelWIMode = iota
 	objectLevelWIModeDirectAccess
 	objectLevelWIModeImpersonation
+	objectLevelWIModeDirectAccessFederation
+	objectLevelWIModeImpersonationFederation
 )
 
 type objectLevelWIMode int
@@ -78,6 +80,10 @@ func testjobExecutionWithArgs(t *testing.T, args []string, opts ...jobOption) {
 				args = append(args, "-wisa-name="+wiServiceAccount)
 			case objectLevelWIModeDirectAccess:
 				args = append(args, "-wisa-name="+wiServiceAccountDirectAccess)
+			case objectLevelWIModeImpersonationFederation:
+				args = append(args, "-wisa-name="+wiServiceAccountFederation)
+			case objectLevelWIModeDirectAccessFederation:
+				args = append(args, "-wisa-name="+wiServiceAccountFederationDirectAccess)
 			}
 		}
 		job.Spec.Template.Spec.ServiceAccountName = saName

--- a/oci/tests/integration/oci_test.go
+++ b/oci/tests/integration/oci_test.go
@@ -81,6 +81,46 @@ func TestOciImageRepositoryListTagsUsingObjectLevelWorkloadIdentityWithDirectAcc
 	}
 }
 
+func TestOciImageRepositoryListTagsUsingObjectLevelWorkloadIdentityFederation(t *testing.T) {
+	if !testWIFederation {
+		t.Skip("Skipping workload identity federation test, not supported for provider")
+	}
+
+	if len(testRepos) == 0 {
+		t.Fatalf("expected testRepos to be set")
+	}
+
+	for name, repo := range testRepos {
+		t.Run(name, func(t *testing.T) {
+			args := []string{
+				"-category=oci",
+				fmt.Sprintf("-repo=%s", repo),
+			}
+			testjobExecutionWithArgs(t, args, withObjectLevelWI(objectLevelWIModeImpersonationFederation))
+		})
+	}
+}
+
+func TestOciImageRepositoryListTagsUsingObjectLevelWorkloadIdentityFederationWithDirectAccess(t *testing.T) {
+	if !testWIFederation || !testWIDirectAccess {
+		t.Skip("Skipping workload identity federation direct access test, not supported for provider")
+	}
+
+	if len(testRepos) == 0 {
+		t.Fatalf("expected testRepos to be set")
+	}
+
+	for name, repo := range testRepos {
+		t.Run(name, func(t *testing.T) {
+			args := []string{
+				"-category=oci",
+				fmt.Sprintf("-repo=%s", repo),
+			}
+			testjobExecutionWithArgs(t, args, withObjectLevelWI(objectLevelWIModeDirectAccessFederation))
+		})
+	}
+}
+
 func TestOciRepositoryRootLoginListTags(t *testing.T) {
 	if len(testRepos) == 0 {
 		t.Fatalf("expected testRepos to be set")

--- a/oci/tests/integration/terraform/gcp/main.tf
+++ b/oci/tests/integration/terraform/gcp/main.tf
@@ -7,7 +7,13 @@ provider "google" {
 resource "random_pet" "suffix" {}
 
 locals {
-  name = "flux-test-${random_pet.suffix.id}"
+  name               = "flux-test-${random_pet.suffix.id}"
+  federation_pool_id = var.enable_wi ? google_iam_workload_identity_pool.main[0].name : ""
+  gke_pool_id        = "projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${module.gke.project}.svc.id.goog"
+}
+
+data "google_project" "project" {
+  project_id = var.gcp_project_id
 }
 
 module "gke" {
@@ -40,14 +46,67 @@ resource "google_project_iam_binding" "admin-account-iam" {
   project = var.gcp_project_id
   role    = "roles/artifactregistry.repoAdmin"
   members = [
+    # This principal represents a GCP service account for testing
+    # impersonation of GCP service accounts for both the built-in
+    # Workload Identity Federation for GKE and also other Kubernetes
+    # clusters.
     "serviceAccount:${google_service_account.test[count.index].email}",
-    "serviceAccount:${var.gcp_project_id}.svc.id.goog[${var.wi_k8s_sa_ns}/${var.wi_k8s_sa_name_direct_access}]",
+
+    # This principal represents a GKE service account for testing built-in
+    # Workload Identity Federation for GKE with direct access.
+    "principal://iam.googleapis.com/${local.gke_pool_id}/subject/ns/${var.wi_k8s_sa_ns}/sa/${var.wi_k8s_sa_name_direct_access}",
+
+    # This principal represents a service account (that only happens to be
+    # from GKE, but could be from any other type of Kubernetes cluster) for
+    # testing Workload Identity Federation for other Kubernetes clusters with
+    # direct access.
+    "principal://iam.googleapis.com/${local.federation_pool_id}/subject/system:serviceaccount:${var.wi_k8s_sa_ns}:${var.wi_k8s_sa_name_federation_direct_access}",
   ]
 }
 
-resource "google_service_account_iam_member" "main" {
+resource "google_service_account_iam_binding" "main" {
   count              = var.enable_wi ? 1 : 0
   service_account_id = google_service_account.test[count.index].name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "serviceAccount:${var.gcp_project_id}.svc.id.goog[${var.wi_k8s_sa_ns}/${var.wi_k8s_sa_name}]"
+  members            = [
+    # This principal represents a GKE service account for testing built-in
+    # Workload Identity Federation for GKE with impersonation.
+    "principal://iam.googleapis.com/${local.gke_pool_id}/subject/ns/${var.wi_k8s_sa_ns}/sa/${var.wi_k8s_sa_name}",
+
+    # This principal represents a service account (that only happens to be
+    # from GKE, but could be from any other type of Kubernetes cluster) for
+    # testing Workload Identity Federation for other Kubernetes clusters with
+    # impersonation.
+    "principal://iam.googleapis.com/${local.federation_pool_id}/subject/system:serviceaccount:${var.wi_k8s_sa_ns}:${var.wi_k8s_sa_name_federation}",
+  ]
+}
+
+# The Workload Identity Pool and Provider resources are for testing
+# Workload Identity Federation for arbitrary types of Kubernetes
+# clusters. We test it with a GKE cluster for both the setup simplicity
+# (setup for a kind cluster would be more complicated, we just need
+# a cluster with a public Issuer URL like the GKE cluster itself), and
+# also to prove that it works for GKE clusters as well, which may be
+# useful in the future in case GKE blocks JWTs without pod claims
+# for the built-in Workload Identity Federation for GKE (think about
+# Workload Identity Pool and Provider as AWS EKS IRSA and built-in
+# Workload Identity Federation for GKE as AWS EKS Pod Identity).
+
+resource "google_iam_workload_identity_pool" "main" {
+  count                     = var.enable_wi ? 1 : 0
+  workload_identity_pool_id = local.name
+}
+
+resource "google_iam_workload_identity_pool_provider" "main" {
+  count                              = var.enable_wi ? 1 : 0
+  workload_identity_pool_id          = google_iam_workload_identity_pool.main[0].workload_identity_pool_id
+  workload_identity_pool_provider_id = local.name
+
+  oidc {
+    issuer_uri = "https://container.googleapis.com/v1/${module.gke.full_name}"
+  }
+
+  attribute_mapping = {
+    "google.subject" = "assertion.sub"
+  }
 }

--- a/oci/tests/integration/terraform/gcp/outputs.tf
+++ b/oci/tests/integration/terraform/gcp/outputs.tf
@@ -18,3 +18,7 @@ output "gcp_artifact_repository" {
 output "wi_iam_serviceaccount_email" {
   value = var.enable_wi ? google_service_account.test[0].email : ""
 }
+
+output "workload_identity_provider" {
+  value = var.enable_wi ? google_iam_workload_identity_pool_provider.main[0].name : ""
+}

--- a/oci/tests/integration/terraform/gcp/variables.tf
+++ b/oci/tests/integration/terraform/gcp/variables.tf
@@ -37,6 +37,16 @@ variable "wi_k8s_sa_name_direct_access" {
   description = "Name of kubernetes service account to get direct permissions in GCP (For workload identity)"
 }
 
+variable "wi_k8s_sa_name_federation" {
+  type        = string
+  description = "Name of kubernetes service account to be bound to GCP IAM service account (For workload identity federation)"
+}
+
+variable "wi_k8s_sa_name_federation_direct_access" {
+  type        = string
+  description = "Name of kubernetes service account to get direct permissions in GCP (For workload identity federation)"
+}
+
 variable "enable_wi" {
   type        = bool
   default     = false


### PR DESCRIPTION
Part of: https://github.com/fluxcd/flux2/issues/5022

Important fix for GCP WIF. While writing this test I found out that the audience string can't have the `https:` prefix. It needs to start with `//`.

This test is passing locally with my personal GCP account, but for passing in our CI it needs the GCP IAM role [`roles/iam.workloadIdentityPoolAdmin`](https://cloud.google.com/iam/docs/roles-permissions/iam#iam.workloadIdentityPoolAdmin) to be added to the GCP Service Account that we use for applying terraform in the GitHub Action.

@stefanprodan Can you please add this role to the GH Action GCP SA?

Note: We don't need a test like this for the other clouds as the code path is only different for GCP. For AWS and Azure the cross-cloud and same-cloud code path is exactly the same, and for both of them the cloud setup involves registering the Issuer URL of the cluster. This was never the case for GCP up until introducing this new test, built-in federation for GKE registers the cluster Issuer URL automatically.