### PR TITLE
Introduce authentication for public.ecr.aws

### DIFF
--- a/auth/aws/provider.go
+++ b/auth/aws/provider.go
@@ -214,6 +214,12 @@ func (Provider) ParseArtifactRepository(artifactRepository string) (string, erro
 		return "", err
 	}
 
+	// Region is required to be us-east-1 for public.ecr.aws:
+	// https://docs.aws.amazon.com/AmazonECR/latest/public/public-registry-auth.html#public-registry-auth-token
+	if registry == "public.ecr.aws" {
+		return "us-east-1", nil
+	}
+
 	parts := registryRegex.FindAllStringSubmatch(registry, -1)
 	if len(parts) < 1 || len(parts[0]) < 3 {
 		return "", fmt.Errorf("invalid AWS registry: '%s'. must match %s",

--- a/auth/aws/provider_test.go
+++ b/auth/aws/provider_test.go
@@ -320,6 +320,11 @@ func TestProvider_ParseArtifactRepository(t *testing.T) {
 			artifactRepository: "gcr.io/foo/bar:baz",
 			expectValid:        false,
 		},
+		{
+			artifactRepository: "public.ecr.aws/foo/bar",
+			expectedRegion:     "us-east-1",
+			expectValid:        true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Some helm charts require authentication against the `public.ecr.aws` ECR registery e.g. [aws-node-termination-handler](https://github.com/aws/aws-node-termination-handler/tree/main/config/helm/aws-node-termination-handler).

Current flux v2.6.1 does not allow me to update my aws-node-termination-handler deployment due to this error: 
```
HelmChart 'flux-system/flux-system-aws-node-termination-handler' is not ready: unknown build error: failed to get credential from 'aws': failed to parse artifact repository 'public.ecr.aws/aws-ec2/helm': invalid AWS registry: 'public.ecr.aws'. must match ([0-9+]*).dkr.ecr(?:-fips)?\.([^/.]*)\.(amazonaws\.com[.cn]*|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)
```
So this PR fixes that error by making `public.ecr.aws` a valid AWS registry.