### PR TITLE
Fix support for public.ecr.aws

### DIFF
--- a/.github/workflows/integration-aws.yaml
+++ b/.github/workflows/integration-aws.yaml
@@ -20,6 +20,7 @@ jobs:
         auth-mode:
         - node-identity
         - workload-identity
+      fail-fast: false
     defaults:
       run:
         working-directory: ./oci/tests/integration
@@ -38,7 +39,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.OCI_E2E_AWS_ASSUME_ROLE_NAME }}
           role-session-name: OCI_GH_Actions
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: us-east-1
       - name: Setup QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - name: Setup Docker Buildx
@@ -56,13 +57,13 @@ jobs:
       - name: Run tests
         run: . .env && make test-aws
         env:
-          AWS_REGION: ${{ vars.AWS_REGION }}
-          TF_VAR_cross_region: ${{ vars.OCI_E2E_TF_VAR_cross_region }}
+          AWS_REGION: us-east-1
+          TF_VAR_cross_region: us-east-2
           TF_VAR_enable_wi: ${{ (matrix.auth-mode == 'workload-identity' && 'true') || 'false' }}
       - name: Ensure resource cleanup
         if: ${{ always() }}
         run: . .env && make destroy-aws
         env:
-          AWS_REGION: ${{ vars.AWS_REGION }}
-          TF_VAR_cross_region: ${{ vars.OCI_E2E_TF_VAR_cross_region }}
+          AWS_REGION: us-east-1
+          TF_VAR_cross_region: us-east-2
           TF_VAR_enable_wi: ${{ (matrix.auth-mode == 'workload-identity' && 'true') || 'false' }}

--- a/auth/aws/implementation.go
+++ b/auth/aws/implementation.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	"github.com/aws/aws-sdk-go-v2/service/ecrpublic"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
@@ -29,7 +30,8 @@ import (
 type Implementation interface {
 	LoadDefaultConfig(ctx context.Context, optFns ...func(*config.LoadOptions) error) (aws.Config, error)
 	AssumeRoleWithWebIdentity(ctx context.Context, params *sts.AssumeRoleWithWebIdentityInput, options sts.Options) (*sts.AssumeRoleWithWebIdentityOutput, error)
-	GetAuthorizationToken(ctx context.Context, cfg aws.Config) (*ecr.GetAuthorizationTokenOutput, error)
+	GetAuthorizationToken(ctx context.Context, cfg aws.Config) (any, error)
+	GetPublicAuthorizationToken(ctx context.Context, cfg aws.Config) (any, error)
 }
 
 type implementation struct{}
@@ -42,6 +44,10 @@ func (implementation) AssumeRoleWithWebIdentity(ctx context.Context, params *sts
 	return sts.New(options).AssumeRoleWithWebIdentity(ctx, params)
 }
 
-func (implementation) GetAuthorizationToken(ctx context.Context, cfg aws.Config) (*ecr.GetAuthorizationTokenOutput, error) {
+func (implementation) GetAuthorizationToken(ctx context.Context, cfg aws.Config) (any, error) {
 	return ecr.NewFromConfig(cfg).GetAuthorizationToken(ctx, &ecr.GetAuthorizationTokenInput{})
+}
+
+func (implementation) GetPublicAuthorizationToken(ctx context.Context, cfg aws.Config) (any, error) {
+	return ecrpublic.NewFromConfig(cfg).GetAuthorizationToken(ctx, &ecrpublic.GetAuthorizationTokenInput{})
 }

--- a/auth/go.mod
+++ b/auth/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.29.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.67
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.43.3
+	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.19
 	github.com/coreos/go-oidc/v3 v3.14.1
 	github.com/fluxcd/pkg/cache v0.9.0

--- a/auth/go.sum
+++ b/auth/go.sum
@@ -28,6 +28,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.43.3 h1:YyH8Hk73bYzdbvf6S8NF5z/fb/1stpiMnFSfL6jSfRA=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.43.3/go.mod h1:iQ1skgw1XRK+6Lgkb0I9ODatAP72WoTILh0zXQ5DtbU=
+github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.33.0 h1:wA2O6pZ2r5smqJunFP4hp7qptMW4EQxs8O6RVHPulOE=
+github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.33.0/go.mod h1:RZL7ov7c72wSmoM8bIiVxRHgcVdzhNkVW2J36C8RF4s=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 h1:eAh2A4b5IzM/lum78bZ590jy36+d/aFLgKF/4Vd1xPE=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3/go.mod h1:0yKJC/kb8sAnmlYa6Zs3QVYqaC8ug2AbnNChv5Ox3uA=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 h1:dM9/92u2F1JbDaGooxTq18wmmFzbJRfXfVfy96/1CXM=

--- a/oci/tests/integration/aws_test.go
+++ b/oci/tests/integration/aws_test.go
@@ -65,6 +65,17 @@ func registryLoginECR(ctx context.Context, output map[string]*tfjson.StateOutput
 	}
 	testRepos["ecr_cross_region"] = testCrossRepo
 
+	// Test the public ECR repository.
+	// We test this only with WI because it's harder to add some required permissions to the node IAM role
+	// through the EKS Terraform module we use.
+	if enableWI {
+		publicRepoURL := output["ecrpublic_repository_url"].Value.(string)
+		if err := tftestenv.RegistryLoginECRPublic(ctx); err != nil {
+			return nil, err
+		}
+		testRepos["ecrpublic"] = publicRepoURL
+	}
+
 	// Log into the test app repository to be able to push to it.
 	// This image is not used in testing and need not be included in
 	// testRepos.

--- a/oci/tests/integration/go.mod
+++ b/oci/tests/integration/go.mod
@@ -10,10 +10,10 @@ replace (
 )
 
 require (
-	github.com/fluxcd/pkg/auth v0.16.0
+	github.com/fluxcd/pkg/auth v0.17.0
 	github.com/fluxcd/pkg/git v0.31.0
 	github.com/fluxcd/pkg/git/gogit v0.33.0
-	github.com/fluxcd/test-infra/tftestenv v0.0.0-20240903092121-c783b14801d1
+	github.com/fluxcd/test-infra/tftestenv v0.0.0-20250607120203-534ab0587f45
 	github.com/go-git/go-git/v5 v5.16.2
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/uuid v1.6.0
@@ -46,6 +46,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.43.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.33.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.3 // indirect

--- a/oci/tests/integration/go.sum
+++ b/oci/tests/integration/go.sum
@@ -43,6 +43,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.43.3 h1:YyH8Hk73bYzdbvf6S8NF5z/fb/1stpiMnFSfL6jSfRA=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.43.3/go.mod h1:iQ1skgw1XRK+6Lgkb0I9ODatAP72WoTILh0zXQ5DtbU=
+github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.33.0 h1:wA2O6pZ2r5smqJunFP4hp7qptMW4EQxs8O6RVHPulOE=
+github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.33.0/go.mod h1:RZL7ov7c72wSmoM8bIiVxRHgcVdzhNkVW2J36C8RF4s=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 h1:eAh2A4b5IzM/lum78bZ590jy36+d/aFLgKF/4Vd1xPE=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3/go.mod h1:0yKJC/kb8sAnmlYa6Zs3QVYqaC8ug2AbnNChv5Ox3uA=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 h1:dM9/92u2F1JbDaGooxTq18wmmFzbJRfXfVfy96/1CXM=
@@ -102,8 +104,8 @@ github.com/fluxcd/pkg/ssh v0.18.0 h1:SB0RrZ/YZIla3chTUulsfVmiCzJv5pEWfHM3dHMC8AU
 github.com/fluxcd/pkg/ssh v0.18.0/go.mod h1:G5o0ZD7iR3KFoG5gPnFelX243ciI/PIiVW7J4eBrt5Y=
 github.com/fluxcd/pkg/version v0.7.0 h1:jZT5I6WFy1KlM40nHCSqlHmjC1VT1/DfmbAdOkIVVJc=
 github.com/fluxcd/pkg/version v0.7.0/go.mod h1:3BjQDJXIZJmeJLXnfa2yG/sNAT1t5oeLAPfnSjOHNuA=
-github.com/fluxcd/test-infra/tftestenv v0.0.0-20240903092121-c783b14801d1 h1:zrw5yeR/KxxLL2afNnO8GiD/ThOAC/pOMGg+klKs58I=
-github.com/fluxcd/test-infra/tftestenv v0.0.0-20240903092121-c783b14801d1/go.mod h1:liFlLEXgambGVdWSJ4JzbIHf1Vjpp1HwUyPazPIVZug=
+github.com/fluxcd/test-infra/tftestenv v0.0.0-20250607120203-534ab0587f45 h1:dj9mhMYJ+OUXIo+43ToBYwrRb0os8oPfrBtrdZkhVxY=
+github.com/fluxcd/test-infra/tftestenv v0.0.0-20250607120203-534ab0587f45/go.mod h1:liFlLEXgambGVdWSJ4JzbIHf1Vjpp1HwUyPazPIVZug=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=

--- a/oci/tests/integration/terraform/aws/main.tf
+++ b/oci/tests/integration/terraform/aws/main.tf
@@ -23,6 +23,12 @@ module "test_ecr" {
   tags = var.tags
 }
 
+resource "aws_ecrpublic_repository" "test_ecr_public" {
+  repository_name = local.name
+  tags            = var.tags
+  force_destroy   = true
+}
+
 module "test_ecr_cross_reg" {
   source = "git::https://github.com/fluxcd/test-infra.git//tf-modules/aws/ecr"
 
@@ -50,6 +56,39 @@ resource "aws_iam_role" "assume_role" {
     NAMESPACE = var.wi_k8s_sa_ns,
     SA_NAME   = var.wi_k8s_sa_name
   })
-  managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"]
-  tags                = var.tags
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "wi_read_ecr" {
+  count = var.enable_wi ? 1 : 0
+
+  role       = aws_iam_role.assume_role[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_iam_role_policy_attachment" "wi_role_policy" {
+  count = var.enable_wi ? 1 : 0
+
+  role       = aws_iam_role.assume_role[0].name
+  policy_arn = aws_iam_policy.wi_role_policy[0].arn
+}
+
+resource "aws_iam_policy" "wi_role_policy" {
+  count = var.enable_wi ? 1 : 0
+
+  name = "${local.name}-wi-policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr-public:GetAuthorizationToken",
+          "sts:GetServiceBearerToken",
+        ]
+        Resource = "*"
+      },
+    ],
+  })
 }

--- a/oci/tests/integration/terraform/aws/outputs.tf
+++ b/oci/tests/integration/terraform/aws/outputs.tf
@@ -43,3 +43,7 @@ output "ecr_test_app_repo_url" {
 output "aws_wi_iam_arn" {
   value = var.enable_wi ? aws_iam_role.assume_role[0].arn : ""
 }
+
+output "ecrpublic_repository_url" {
+  value = aws_ecrpublic_repository.test_ecr_public.repository_uri
+}


### PR DESCRIPTION
I tested the current code for public.ecr.aws and it doesn't work. It's probably because public ECR has a different endpoint and we were trying to reach it through the Go SDK for normal ECR, but there's a dedicated Go SDK for public ECR. This PR is fixing this by using the appropriate Go SDK.

xref: #936 