### PR TITLE
fix: Support rsa-sha2-512 and rsa-sha2-256 host key algos when ssh-rsa is supported

### DIFF
--- a/.github/workflows/integration-azure.yaml
+++ b/.github/workflows/integration-azure.yaml
@@ -50,6 +50,22 @@ jobs:
         run: cat .env
       - name: Build test app
         run: make docker-build
+      - name: Prepare Git SSH secrets
+        run: |
+          mkdir -p azure
+          cat <<EOF > azure/identity
+          $GIT_SSH_IDENTITY
+          EOF
+          cat <<EOF > azure/identity.pub
+          $GIT_SSH_IDENTITY_PUB
+          EOF
+          cat <<EOF > azure/known_hosts
+          $GIT_SSH_KNOWN_HOSTS
+          EOF
+        env:
+          GIT_SSH_IDENTITY: ${{ secrets.GIT_SSH_IDENTITY }}
+          GIT_SSH_IDENTITY_PUB: ${{ secrets.GIT_SSH_IDENTITY_PUB }}
+          GIT_SSH_KNOWN_HOSTS: ${{ secrets.GIT_SSH_KNOWN_HOSTS }}
       - name: Run tests
         run: . .env && make test-azure
         env:

--- a/git/gogit/transport.go
+++ b/git/gogit/transport.go
@@ -146,6 +146,12 @@ func (a *CustomPublicKeys) ClientConfig() (*gossh.ClientConfig, error) {
 		config.Config.KeyExchanges = git.KexAlgos
 	}
 
+	// Whenever ssh-rsa is being used, prioritise sha2-512 and sha2-256.
+	// TODO: deprecate SHA1 signing scheme.
+	if len(a.hkAlgos) == 1 && a.hkAlgos[0] == "ssh-rsa" {
+		a.hkAlgos = append([]string{"rsa-sha2-512", "rsa-sha2-256"}, a.hkAlgos[0])
+	}
+
 	config.HostKeyAlgorithms = a.hkAlgos
 	if len(git.HostKeyAlgos) > 0 {
 		config.HostKeyAlgorithms = git.HostKeyAlgos

--- a/git/internal/e2e/go.mod
+++ b/git/internal/e2e/go.mod
@@ -14,7 +14,7 @@ replace (
 require (
 	github.com/fluxcd/go-git-providers v0.22.0
 	github.com/fluxcd/pkg/git v0.32.0
-	github.com/fluxcd/pkg/git/gogit v0.35.0
+	github.com/fluxcd/pkg/git/gogit v0.35.1
 	github.com/fluxcd/pkg/gittestserver v0.17.0
 	github.com/fluxcd/pkg/ssh v0.19.0
 	github.com/go-git/go-git/v5 v5.16.2

--- a/oci/tests/integration/git_test.go
+++ b/oci/tests/integration/git_test.go
@@ -46,6 +46,28 @@ func TestGitCloneUsingProvider(t *testing.T) {
 	})
 }
 
+func TestGitCloneUsingSSH(t *testing.T) {
+	if !testGit {
+		t.Skip("Skipping git test, not supported for provider")
+	}
+
+	ctx := context.TODO()
+	tmpDir := t.TempDir()
+
+	if err := setUpGitRepository(ctx, tmpDir); err != nil {
+		t.Fatalf("failed setting up GitRepository: %v", err)
+	}
+	t.Run("Git ssh credential test", func(t *testing.T) {
+		args := []string{
+			"-category=git",
+			"-git-ssh=true",
+			fmt.Sprintf("-provider=%s", *targetProvider),
+			fmt.Sprintf("-repo=%s", gitSSHURL),
+		}
+		testjobExecutionWithArgs(t, args)
+	})
+}
+
 func TestGitCloneUsingObjectLevelWorkloadIdentity(t *testing.T) {
 	if !testGit {
 		t.Skip("Skipping git test, not supported for provider")

--- a/oci/tests/integration/go.mod
+++ b/oci/tests/integration/go.mod
@@ -11,10 +11,10 @@ replace (
 )
 
 require (
-	github.com/fluxcd/pkg/auth v0.17.0
+	github.com/fluxcd/pkg/auth v0.18.0
 	github.com/fluxcd/pkg/git v0.32.0
-	github.com/fluxcd/pkg/git/gogit v0.35.0
-	github.com/fluxcd/test-infra/tftestenv v0.0.0-20250607120203-534ab0587f45
+	github.com/fluxcd/pkg/git/gogit v0.35.1
+	github.com/fluxcd/test-infra/tftestenv v0.0.0-20250626232827-e0ca9c3f8d7b
 	github.com/go-git/go-git/v5 v5.16.2
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/uuid v1.6.0

--- a/oci/tests/integration/go.sum
+++ b/oci/tests/integration/go.sum
@@ -102,8 +102,8 @@ github.com/fluxcd/pkg/gittestserver v0.17.0 h1:JlBvWZQTDOI+np5Z+084m3DkeAH1hMusE
 github.com/fluxcd/pkg/gittestserver v0.17.0/go.mod h1:E/40EmLoXcMqd6gLuLDC9F6KJxqHVGbBBeMNKk5XdxU=
 github.com/fluxcd/pkg/version v0.7.0 h1:jZT5I6WFy1KlM40nHCSqlHmjC1VT1/DfmbAdOkIVVJc=
 github.com/fluxcd/pkg/version v0.7.0/go.mod h1:3BjQDJXIZJmeJLXnfa2yG/sNAT1t5oeLAPfnSjOHNuA=
-github.com/fluxcd/test-infra/tftestenv v0.0.0-20250607120203-534ab0587f45 h1:dj9mhMYJ+OUXIo+43ToBYwrRb0os8oPfrBtrdZkhVxY=
-github.com/fluxcd/test-infra/tftestenv v0.0.0-20250607120203-534ab0587f45/go.mod h1:liFlLEXgambGVdWSJ4JzbIHf1Vjpp1HwUyPazPIVZug=
+github.com/fluxcd/test-infra/tftestenv v0.0.0-20250626232827-e0ca9c3f8d7b h1:FSPtvaVgL8azcyweqLmD71elAw4vozuXH/QvsJQ7tg0=
+github.com/fluxcd/test-infra/tftestenv v0.0.0-20250626232827-e0ca9c3f8d7b/go.mod h1:liFlLEXgambGVdWSJ4JzbIHf1Vjpp1HwUyPazPIVZug=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=

--- a/oci/tests/integration/terraform/azure/outputs.tf
+++ b/oci/tests/integration/terraform/azure/outputs.tf
@@ -30,3 +30,11 @@ output "git_repo_url" {
 output "azure_devops_project_id" {
   value = var.enable_wi ? module.devops[0].project_id : ""
 }
+
+output "azure_devops_project_name" {
+  value = local.project_name
+}
+
+output "azure_devops_repo_name" {
+  value = local.repo_name
+}


### PR DESCRIPTION
This PR fixes a regression in host key negotiation when the algorithms `rsa-sha2-512` or `rsa-sha2-256` are required.

This regression was introduced in [this](https://github.com/fluxcd/pkg/pull/943) PR, which was a fix for another regression, this one in the `go-git` dependency. Context [here](https://github.com/fluxcd/flux2/issues/5385).

This PR also introduces integration tests for Azure DevOps with SSH, which would have caught the regression this PR is fixing.