### PR TITLE
Fix scanManifests to respect ignore patterns

### DIFF
--- a/kustomize/filters.go
+++ b/kustomize/filters.go
@@ -102,3 +102,39 @@ func filterSlice(ks *kustypes.Kustomization, path string, s *[]string, t string,
 	*s = (*s)[:start]
 	return nil
 }
+
+// shouldIgnoreFile returns true if the given file should be ignored based on
+// ignore patterns loaded from the base path and any additional ignore patterns provided.
+func shouldIgnoreFile(filePath, basePath, ignorePatterns string) bool {
+	if ignorePatterns == "" {
+		return false
+	}
+
+	absBase, err := filepath.Abs(basePath)
+	if err != nil {
+		return false
+	}
+
+	absFile, err := filepath.Abs(filePath)
+	if err != nil {
+		return false
+	}
+
+	ignoreDomain := strings.Split(absBase, string(filepath.Separator))
+	ps, err := sourceignore.LoadIgnorePatterns(absBase, ignoreDomain)
+	if err != nil {
+		return false
+	}
+
+	if ignorePatterns != "" {
+		ps = append(ps, sourceignore.ReadPatterns(strings.NewReader(ignorePatterns), ignoreDomain)...)
+	}
+
+	info, err := os.Lstat(absFile)
+	if err != nil {
+		return false
+	}
+
+	filter := ignoreFileFilter(ps, ignoreDomain)
+	return filter(absFile, info)
+}

--- a/kustomize/kustomize_generator.go
+++ b/kustomize/kustomize_generator.go
@@ -471,7 +471,7 @@ func (g *Generator) generateKustomization(dirPath string) (Action, string, error
 		return UnchangedAction, "", err
 	}
 
-	files, err := scanManifests(fs, abs)
+	files, err := scanManifests(fs, abs, g.ignore)
 	if err != nil {
 		return UnchangedAction, "", err
 	}
@@ -516,7 +516,7 @@ func (g *Generator) generateKustomization(dirPath string) (Action, string, error
 // scanManifests walks through the given base path parsing all the files and
 // collecting a list of all the yaml file paths which can be used as
 // kustomization resources.
-func scanManifests(fs filesys.FileSystem, base string) ([]string, error) {
+func scanManifests(fs filesys.FileSystem, base string, ignorePatterns string) ([]string, error) {
 	var paths []string
 	pvd := provider.NewDefaultDepProvider()
 	rf := pvd.GetResourceFactory()
@@ -542,6 +542,10 @@ func scanManifests(fs filesys.FileSystem, base string) ([]string, error) {
 
 		extension := filepath.Ext(path)
 		if extension != ".yaml" && extension != ".yml" {
+			return
+		}
+
+		if shouldIgnoreFile(path, base, ignorePatterns) {
 			return
 		}
 

--- a/kustomize/kustomize_generator_whitebox_test.go
+++ b/kustomize/kustomize_generator_whitebox_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kustomize
 
 import (
+	"sort"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -56,9 +57,68 @@ func TestScanManifests(t *testing.T) {
 			g := NewWithT(t)
 			fs := filesys.MakeFsOnDisk()
 
-			paths, err := scanManifests(fs, tt.base)
+			paths, err := scanManifests(fs, tt.base, "")
 			g.Expect(paths).To(Equal(tt.wantPaths))
 			g.Expect(err != nil).To(Equal(tt.wantErr))
+		})
+	}
+}
+
+func TestScanManifests_WithIgnorePatterns(t *testing.T) {
+	tests := []struct {
+		name           string
+		base           string
+		ignorePatterns string
+		wantPaths      []string
+		wantErr        bool
+	}{
+		{
+			name:      "basic directory - no ignore patterns",
+			base:      "./testdata/ignore-tests/basic",
+			wantPaths: []string{"testdata/ignore-tests/basic/deployment.yaml"},
+		},
+		{
+			name:           "with .sops.yaml - no ignore patterns (should fail)",
+			base:           "./testdata/ignore-tests/with-sops",
+			ignorePatterns: "",
+			wantErr:        true, // .sops.yaml should cause parsing error
+		},
+		{
+			name:           "with .sops.yaml - ignore .sops.yaml",
+			base:           "./testdata/ignore-tests/with-sops",
+			ignorePatterns: ".sops.yaml",
+			wantPaths:      []string{"testdata/ignore-tests/with-sops/deployment.yaml"},
+		},
+		{
+			name:           "with .gitlab-ci.yml - no ignore patterns (should fail)",
+			base:           "./testdata/ignore-tests/with-gitlab-ci",
+			ignorePatterns: "",
+			wantErr:        true, // .gitlab-ci.yml should cause parsing error
+		},
+		{
+			name:           "with .gitlab-ci.yml - ignore .gitlab-ci.yml",
+			base:           "./testdata/ignore-tests/with-gitlab-ci",
+			ignorePatterns: ".gitlab-ci.yml",
+			wantPaths:      []string{"testdata/ignore-tests/with-gitlab-ci/deployment.yaml"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			fs := filesys.MakeFsOnDisk()
+
+			paths, err := scanManifests(fs, tt.base, tt.ignorePatterns)
+
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+			sort.Strings(paths)
+			sort.Strings(tt.wantPaths)
+			g.Expect(paths).To(Equal(tt.wantPaths))
 		})
 	}
 }

--- a/kustomize/testdata/ignore-tests/basic/deployment.yaml
+++ b/kustomize/testdata/ignore-tests/basic/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - name: app
+        image: nginx:latest
+        

--- a/kustomize/testdata/ignore-tests/with-gitlab-ci/.gitlab-ci.yml
+++ b/kustomize/testdata/ignore-tests/with-gitlab-ci/.gitlab-ci.yml
@@ -1,0 +1,9 @@
+stages:
+  - test
+  - deploy
+
+test:
+  stage: test
+  script:
+    - echo "running tests"
+    

--- a/kustomize/testdata/ignore-tests/with-gitlab-ci/deployment.yaml
+++ b/kustomize/testdata/ignore-tests/with-gitlab-ci/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - name: app
+        image: nginx:latest
+        

--- a/kustomize/testdata/ignore-tests/with-sops/.sops.yaml
+++ b/kustomize/testdata/ignore-tests/with-sops/.sops.yaml
@@ -1,0 +1,2 @@
+creation_rules:
+  - encrypted_regex: '^(data|stringData)$'

--- a/kustomize/testdata/ignore-tests/with-sops/deployment.yaml
+++ b/kustomize/testdata/ignore-tests/with-sops/deployment.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - name: app
+        image: nginx:latest


### PR DESCRIPTION
Fixes #4921 by passing the ignorePaths string into the `scanManifests` function - and added a new function `shouldIgnoreFile` to process if it should be ignored based on the pattern. I added some test coverage but I can add more, or expand the tests. Let me know if this is the right approach @matheuscscp 

I compiled flux and imported the package locally and this was working compared to the release flux:
```
~/OpenSource/flux/flux2-fork fix/ignore-paths-diff !2 ?3 ❯ ./bin/flux diff kustomization test-app --path ./test-ignore --ignore-paths ".sops.yaml" --namespace test-flux-k-diff                          ⎈ default
✓  Kustomization diffing...
► Kustomization/test-flux-k-diff/test-app drifted

metadata
  + one map entry added:
    labels:
    │ kustomize.toolkit.fluxcd.io/name: test-app
    │ kustomize.toolkit.fluxcd.io/namespace: test-flux-k-diff

⚠️ identified at least one change, exiting with non-zero exit code
~/OpenSource/flux/flux2-fork fix/ignore-paths-diff !2 ?3 ❯ flux diff kustomization test-app --path ./test-ignore --ignore-paths ".sops.yaml" --namespace test-flux-k-diff                                ⎈ default
✓  Kustomization diffing...
✗ failed to generate kustomization.yaml: failed to decode Kubernetes YAML from /Users/danguns/OpenSource/flux/flux2-fork/test-ignore/.github/workflows/ci.yml: missing Resource metadata <nil> <nil>
~/OpenSource/flux/flux2-fork fix/ignore-paths-diff !2 ?3 ❯ 
```