### PR TITLE
ssa: Fix waiting for classes in `ApplyAllStaged`

### DIFF
--- a/ssa/manager_apply.go
+++ b/ssa/manager_apply.go
@@ -282,7 +282,7 @@ func (m *ResourceManager) ApplyAllStaged(ctx context.Context, objects []*unstruc
 		}
 		changeSet.Append(cs.Entries)
 
-		if err := m.Wait(defStage, WaitOptions{opts.WaitInterval, opts.WaitTimeout, false}); err != nil {
+		if err := m.WaitForSet(cs.ToObjMetadataSet(), WaitOptions{opts.WaitInterval, opts.WaitTimeout, false}); err != nil {
 			return changeSet, err
 		}
 	}
@@ -295,7 +295,7 @@ func (m *ResourceManager) ApplyAllStaged(ctx context.Context, objects []*unstruc
 		}
 		changeSet.Append(cs.Entries)
 
-		if err := m.Wait(classStage, WaitOptions{opts.WaitInterval, opts.WaitTimeout, false}); err != nil {
+		if err := m.WaitForSet(cs.ToObjMetadataSet(), WaitOptions{opts.WaitInterval, opts.WaitTimeout, false}); err != nil {
 			return changeSet, err
 		}
 	}

--- a/ssa/testdata/test12.yaml
+++ b/ssa/testdata/test12.yaml
@@ -16,6 +16,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: "%[1]s"
+  namespace: "%[1]s" # This field should be ignored
 parameters:
   encrypted: "false"
   fsType: ext4


### PR DESCRIPTION
Use the `WaitForSet` to correctly health check cluster-level objects. 