### PR TITLE
runtime/secrets: Add `MakeGitHubAppSecret` & `MakeSSHSecret`

### DIFF
--- a/runtime/secrets/applier.go
+++ b/runtime/secrets/applier.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2025 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secrets
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ApplyOptions configures the Kubernetes secret apply operations.
+type ApplyOptions struct {
+	owner       string
+	labels      map[string]string
+	annotations map[string]string
+	immutable   *bool
+	force       bool
+}
+
+// ApplyOption configures an ApplyOptions.
+type ApplyOption func(*ApplyOptions)
+
+// WithOwner sets the field owner for server-side apply.
+func WithOwner(owner string) ApplyOption {
+	return func(o *ApplyOptions) {
+		o.owner = owner
+	}
+}
+
+// WithLabels sets labels to be applied to the secret.
+func WithLabels(labels map[string]string) ApplyOption {
+	return func(o *ApplyOptions) {
+		o.labels = labels
+	}
+}
+
+// WithAnnotations sets annotations to be applied to the secret.
+func WithAnnotations(annotations map[string]string) ApplyOption {
+	return func(o *ApplyOptions) {
+		o.annotations = annotations
+	}
+}
+
+// WithImmutable sets the immutable flag for the secret.
+func WithImmutable(immutable bool) ApplyOption {
+	return func(o *ApplyOptions) {
+		o.immutable = &immutable
+	}
+}
+
+// WithForce enables force apply, which can result in the deletion of existing
+// secrets that are immutable or have a different type.
+func WithForce() ApplyOption {
+	return func(o *ApplyOptions) {
+		o.force = true
+	}
+}
+
+// Apply applies a Kubernetes secret using server-side apply with configurable options.
+// If the secret already exists and is immutable, the object is deleted first.
+func Apply(ctx context.Context, c client.Client, secret *corev1.Secret, opts ...ApplyOption) error {
+	options := &ApplyOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	// Set labels from options.
+	if options.labels != nil {
+		if secret.Labels == nil {
+			secret.Labels = make(map[string]string)
+		}
+		for k, v := range options.labels {
+			secret.Labels[k] = v
+		}
+	}
+
+	// Set annotations from options.
+	if options.annotations != nil {
+		if secret.Annotations == nil {
+			secret.Annotations = make(map[string]string)
+		}
+		for k, v := range options.annotations {
+			secret.Annotations[k] = v
+		}
+	}
+
+	// Set the immutable flag from options.
+	if options.immutable != nil {
+		secret.Immutable = options.immutable
+	}
+
+	// Convert StringData to Data to ensure compatibility with server-side apply.
+	if len(secret.StringData) > 0 {
+		if secret.Data == nil {
+			secret.Data = make(map[string][]byte, len(secret.StringData))
+		}
+		for k, v := range secret.StringData {
+			secret.Data[k] = []byte(v)
+		}
+		secret.StringData = nil
+	}
+
+	// Ensure the secret has a type set, defaulting to Opaque if not specified.
+	if secret.Type == "" {
+		secret.Type = corev1.SecretTypeOpaque
+	}
+
+	// Check if the secret already exists.
+	existing := &corev1.Secret{}
+	mustDelete := false
+	if err := c.Get(ctx, client.ObjectKeyFromObject(secret), existing); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("could not get existing secret: %w", err)
+		}
+	} else {
+		// If the existing secret is immutable or has a different type, mark it for deletion.
+		if (existing.Immutable != nil && *existing.Immutable) || existing.Type != secret.Type {
+			mustDelete = true
+		}
+	}
+
+	// Delete the existing secret if necessary.
+	if mustDelete && options.force {
+		if err := c.Delete(ctx, existing); err != nil {
+			return fmt.Errorf("could not delete existing secret: %w", err)
+		}
+	}
+
+	// Set the GroupVersionKind which is required for server-side apply.
+	secret.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
+
+	// Apply the secret using server-side apply.
+	patchOps := []client.PatchOption{
+		client.ForceOwnership,
+	}
+	if options.owner != "" {
+		patchOps = append(patchOps, client.FieldOwner(options.owner))
+	}
+	return c.Patch(ctx, secret, client.Apply, patchOps...)
+}

--- a/runtime/secrets/applier_test.go
+++ b/runtime/secrets/applier_test.go
@@ -1,0 +1,521 @@
+/*
+Copyright 2025 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secrets_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/fluxcd/pkg/runtime/secrets"
+)
+
+func TestApply(t *testing.T) {
+	namespace, err := env.CreateNamespace(context.Background(), "test-apply")
+	if err != nil {
+		t.Fatalf("failed to create test namespace: %v", err)
+	}
+	ns := namespace.Name
+	immutable := true
+
+	tests := []struct {
+		name           string
+		secret         *corev1.Secret
+		existingSecret *corev1.Secret
+		expectError    bool
+		errMsg         string
+		validateFunc   func(g *WithT, secret *corev1.Secret)
+	}{
+		{
+			name: "apply new secret with string data",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: ns,
+				},
+				Type: corev1.SecretTypeOpaque,
+				StringData: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			validateFunc: func(g *WithT, s *corev1.Secret) {
+				g.Expect(s.StringData).To(BeNil())
+				g.Expect(s.Data).To(HaveLen(2))
+				g.Expect(s.Data["key1"]).To(Equal([]byte("value1")))
+				g.Expect(s.Data["key2"]).To(Equal([]byte("value2")))
+			},
+		},
+		{
+			name: "apply new secret with both string data and data",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret-mixed",
+					Namespace: ns,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					"existing": []byte("data"),
+				},
+				StringData: map[string]string{
+					"new": "string-data",
+				},
+			},
+			validateFunc: func(g *WithT, s *corev1.Secret) {
+				g.Expect(s.StringData).To(BeNil())
+				g.Expect(s.Data).To(HaveLen(2))
+				g.Expect(s.Data["existing"]).To(Equal([]byte("data")))
+				g.Expect(s.Data["new"]).To(Equal([]byte("string-data")))
+			},
+		},
+		{
+			name: "apply secret with only data (no string data)",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret-data-only",
+					Namespace: ns,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					"key": []byte("value"),
+				},
+			},
+			validateFunc: func(g *WithT, s *corev1.Secret) {
+				g.Expect(s.StringData).To(BeNil())
+				g.Expect(s.Data).To(HaveLen(1))
+				g.Expect(s.Data["key"]).To(Equal([]byte("value")))
+			},
+		},
+		{
+			name: "apply secret that merges existing mutable secret",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-mutable",
+					Namespace: ns,
+				},
+				Type: corev1.SecretTypeOpaque,
+				StringData: map[string]string{
+					"test1": "new",
+				},
+			},
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-mutable",
+					Namespace: ns,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					"test1": []byte("old"),
+					"test2": []byte("old"),
+				},
+				Immutable: nil, // mutable secret
+			},
+			validateFunc: func(g *WithT, s *corev1.Secret) {
+				g.Expect(s.Data).To(HaveLen(2))
+				g.Expect(s.Data["test1"]).To(Equal([]byte("new")))
+				g.Expect(s.Data["test2"]).To(Equal([]byte("old")))
+			},
+		},
+		{
+			name: "apply secret that replaces existing immutable secret",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-immutable",
+					Namespace: ns,
+				},
+				Type: corev1.SecretTypeOpaque,
+				StringData: map[string]string{
+					"new": "data",
+				},
+				Immutable: &immutable,
+			},
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-immutable",
+					Namespace: ns,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					"old": []byte("immutable-data"),
+				},
+				Immutable: &immutable,
+			},
+			validateFunc: func(g *WithT, s *corev1.Secret) {
+				g.Expect(s.Data).To(HaveLen(1))
+				g.Expect(s.Data["new"]).To(Equal([]byte("data")))
+			},
+		},
+		{
+			name: "apply secret that replaces existing secret with different type",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-type",
+					Namespace: ns,
+				},
+				Type: corev1.SecretTypeBasicAuth,
+				Data: map[string][]byte{
+					"username": []byte("val"),
+					"password": []byte("val"),
+				},
+				Immutable: &immutable,
+			},
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-type",
+					Namespace: ns,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					"old": []byte("data"),
+				},
+			},
+			validateFunc: func(g *WithT, s *corev1.Secret) {
+				g.Expect(s.Data).To(HaveLen(2))
+				g.Expect(s.Data["username"]).To(Equal([]byte("val")))
+				g.Expect(s.Data["password"]).To(Equal([]byte("val")))
+			},
+		},
+		{
+			name: "fails to apply immutable secret with different data",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-immutable-fail",
+					Namespace: ns,
+				},
+				Type: corev1.SecretTypeOpaque,
+				StringData: map[string]string{
+					"new": "data",
+				},
+			},
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-immutable-fail",
+					Namespace: ns,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					"old": []byte("immutable-data"),
+				},
+				Immutable: &immutable,
+			},
+			expectError: true,
+			errMsg:      "field is immutable",
+		},
+		{
+			name: "fails to apply secret with different type",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-auth-fail",
+					Namespace: ns,
+				},
+				Type: corev1.SecretTypeOpaque,
+				StringData: map[string]string{
+					"new": "data",
+				},
+			},
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-auth-fail",
+					Namespace: ns,
+				},
+				Type: corev1.SecretTypeBasicAuth,
+				Data: map[string][]byte{
+					"username": []byte("val"),
+					"password": []byte("val"),
+				},
+			},
+			expectError: true,
+			errMsg:      "field is immutable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			// Create the existing secret if provided
+			if tt.existingSecret != nil {
+				err := env.Create(context.Background(), tt.existingSecret)
+				g.Expect(err).To(Not(HaveOccurred()))
+				g.Eventually(func() error {
+					s := &corev1.Secret{}
+					return env.Get(context.Background(), client.ObjectKeyFromObject(tt.existingSecret), s)
+				}, timeout).ShouldNot(HaveOccurred())
+			}
+
+			// Set the options for applying the secret
+			opts := []secrets.ApplyOption{
+				secrets.WithOwner("test-owner"),
+			}
+			if tt.secret.Immutable != nil {
+				opts = append(opts, secrets.WithImmutable(*tt.secret.Immutable), secrets.WithForce())
+			}
+
+			// Apply the secret
+			err = secrets.Apply(context.Background(), env, tt.secret, opts...)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				if tt.errMsg != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.errMsg))
+				}
+				return
+			}
+
+			g.Expect(err).To(Not(HaveOccurred()))
+
+			// Verify the secret was applied correctly
+			appliedSecret := &corev1.Secret{}
+			g.Eventually(func() error {
+				return env.Get(context.Background(), client.ObjectKeyFromObject(tt.secret), appliedSecret)
+			}, timeout).ShouldNot(HaveOccurred())
+
+			// Run validation function on the applied secret
+			if tt.validateFunc != nil {
+				tt.validateFunc(g, appliedSecret)
+			}
+		})
+	}
+}
+
+func TestApply_Options(t *testing.T) {
+	namespace, err := env.CreateNamespace(context.Background(), "test-options")
+	if err != nil {
+		t.Fatalf("failed to create test namespace: %v", err)
+	}
+	ns := namespace.Name
+
+	tests := []struct {
+		name         string
+		secret       *corev1.Secret
+		options      []secrets.ApplyOption
+		validateFunc func(g *WithT, secret *corev1.Secret)
+	}{
+		{
+			name: "apply secret with labels",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret-labels",
+					Namespace: ns,
+				},
+				Type: corev1.SecretTypeOpaque,
+				StringData: map[string]string{
+					"key": "value",
+				},
+			},
+			options: []secrets.ApplyOption{
+				secrets.WithOwner("test-owner"),
+				secrets.WithLabels(map[string]string{
+					"app":     "my-app",
+					"version": "v1.0.0",
+				}),
+			},
+			validateFunc: func(g *WithT, secret *corev1.Secret) {
+				g.Expect(secret.Labels).To(HaveLen(2))
+				g.Expect(secret.Labels["app"]).To(Equal("my-app"))
+				g.Expect(secret.Labels["version"]).To(Equal("v1.0.0"))
+			},
+		},
+		{
+			name: "apply secret with annotations",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret-annotations",
+					Namespace: ns,
+				},
+				Type: corev1.SecretTypeOpaque,
+				StringData: map[string]string{
+					"key": "value",
+				},
+			},
+			options: []secrets.ApplyOption{
+				secrets.WithOwner("test-owner"),
+				secrets.WithAnnotations(map[string]string{
+					"created-by": "automation",
+					"purpose":    "testing",
+				}),
+			},
+			validateFunc: func(g *WithT, secret *corev1.Secret) {
+				g.Expect(secret.Annotations).To(HaveLen(2))
+				g.Expect(secret.Annotations["created-by"]).To(Equal("automation"))
+				g.Expect(secret.Annotations["purpose"]).To(Equal("testing"))
+			},
+		},
+		{
+			name: "apply secret with immutable flag",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret-immutable",
+					Namespace: ns,
+				},
+				Type: corev1.SecretTypeOpaque,
+				StringData: map[string]string{
+					"key": "value",
+				},
+			},
+			options: []secrets.ApplyOption{
+				secrets.WithOwner("test-owner"),
+				secrets.WithImmutable(true),
+			},
+			validateFunc: func(g *WithT, secret *corev1.Secret) {
+				g.Expect(secret.Immutable).ToNot(BeNil())
+				g.Expect(*secret.Immutable).To(BeTrue())
+			},
+		},
+		{
+			name: "apply secret with all options",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret-all-options",
+					Namespace: ns,
+				},
+				Type: corev1.SecretTypeOpaque,
+				StringData: map[string]string{
+					"username": "admin",
+					"password": "secret",
+				},
+			},
+			options: []secrets.ApplyOption{
+				secrets.WithOwner("custom-owner"),
+				secrets.WithLabels(map[string]string{
+					"app":        "test-app",
+					"component":  "auth",
+					"managed-by": "automation",
+				}),
+				secrets.WithAnnotations(map[string]string{
+					"description":  "Test secret with all options",
+					"created-at":   "2025-01-01",
+					"last-updated": "2025-01-01",
+				}),
+				secrets.WithImmutable(true),
+			},
+			validateFunc: func(g *WithT, secret *corev1.Secret) {
+				// Validate labels
+				g.Expect(secret.Labels).To(HaveLen(3))
+				g.Expect(secret.Labels["app"]).To(Equal("test-app"))
+				g.Expect(secret.Labels["component"]).To(Equal("auth"))
+				g.Expect(secret.Labels["managed-by"]).To(Equal("automation"))
+
+				// Validate annotations
+				g.Expect(secret.Annotations).To(HaveLen(3))
+				g.Expect(secret.Annotations["description"]).To(Equal("Test secret with all options"))
+				g.Expect(secret.Annotations["created-at"]).To(Equal("2025-01-01"))
+				g.Expect(secret.Annotations["last-updated"]).To(Equal("2025-01-01"))
+
+				// Validate immutable flag
+				g.Expect(secret.Immutable).ToNot(BeNil())
+				g.Expect(*secret.Immutable).To(BeTrue())
+
+				// Validate data
+				g.Expect(secret.Data).To(HaveLen(2))
+				g.Expect(secret.Data["username"]).To(Equal([]byte("admin")))
+				g.Expect(secret.Data["password"]).To(Equal([]byte("secret")))
+			},
+		},
+		{
+			name: "apply secret with existing labels and annotations (merge)",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret-merge",
+					Namespace: ns,
+					Labels: map[string]string{
+						"existing-label": "existing-value",
+					},
+					Annotations: map[string]string{
+						"existing-annotation": "existing-value",
+					},
+				},
+				Type: corev1.SecretTypeOpaque,
+				StringData: map[string]string{
+					"key": "value",
+				},
+			},
+			options: []secrets.ApplyOption{
+				secrets.WithOwner("test-owner"),
+				secrets.WithLabels(map[string]string{
+					"new-label": "new-value",
+				}),
+				secrets.WithAnnotations(map[string]string{
+					"new-annotation": "new-value",
+				}),
+			},
+			validateFunc: func(g *WithT, secret *corev1.Secret) {
+				// Validate merged labels
+				g.Expect(secret.Labels).To(HaveLen(2))
+				g.Expect(secret.Labels["existing-label"]).To(Equal("existing-value"))
+				g.Expect(secret.Labels["new-label"]).To(Equal("new-value"))
+
+				// Validate merged annotations
+				g.Expect(secret.Annotations).To(HaveLen(2))
+				g.Expect(secret.Annotations["existing-annotation"]).To(Equal("existing-value"))
+				g.Expect(secret.Annotations["new-annotation"]).To(Equal("new-value"))
+			},
+		},
+		{
+			name: "apply secret with no options (default behavior)",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret-no-options",
+					Namespace: ns,
+				},
+				Type: corev1.SecretTypeOpaque,
+				StringData: map[string]string{
+					"key": "value",
+				},
+			},
+			options: []secrets.ApplyOption{
+				secrets.WithOwner("test-owner"), // Owner is required for server-side apply
+			},
+			validateFunc: func(g *WithT, secret *corev1.Secret) {
+				// Should have no labels or annotations from options
+				g.Expect(secret.Labels).To(BeNil())
+				g.Expect(secret.Annotations).To(BeNil())
+				g.Expect(secret.Immutable).To(BeNil())
+				// Data should still be converted
+				g.Expect(secret.Data).To(HaveLen(1))
+				g.Expect(secret.Data["key"]).To(Equal([]byte("value")))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			// Apply the secret with options
+			err := secrets.Apply(context.Background(), env, tt.secret, tt.options...)
+
+			g.Expect(err).To(Not(HaveOccurred()))
+
+			// Verify the secret was applied correctly
+			appliedSecret := &corev1.Secret{}
+			g.Eventually(func() error {
+				return env.Get(context.Background(), client.ObjectKeyFromObject(tt.secret), appliedSecret)
+			}, timeout).ShouldNot(HaveOccurred())
+
+			// Run validation function if provided (validate both input transformation and cluster state)
+			if tt.validateFunc != nil {
+				tt.validateFunc(g, tt.secret)     // Validate input secret transformation
+				tt.validateFunc(g, appliedSecret) // Validate cluster secret state
+			}
+		})
+	}
+}

--- a/runtime/secrets/converter.go
+++ b/runtime/secrets/converter.go
@@ -52,9 +52,9 @@ func TLSConfigFromSecret(ctx context.Context, secret *corev1.Secret) (*tls.Confi
 // proxy URL. Optional "username" and "password" fields can be provided
 // for proxy authentication.
 func ProxyURLFromSecret(ctx context.Context, secret *corev1.Secret) (*url.URL, error) {
-	addressData, exists := secret.Data[AddressKey]
+	addressData, exists := secret.Data[KeyAddress]
 	if !exists {
-		return nil, &KeyNotFoundError{Key: AddressKey, Secret: secret}
+		return nil, &KeyNotFoundError{Key: KeyAddress, Secret: secret}
 	}
 
 	address := string(addressData)
@@ -69,8 +69,8 @@ func ProxyURLFromSecret(ctx context.Context, secret *corev1.Secret) (*url.URL, e
 		return nil, fmt.Errorf("secret '%s': failed to parse proxy address '%s': %w", ref, address, err)
 	}
 
-	username, hasUsername := secret.Data[UsernameKey]
-	password, hasPassword := secret.Data[PasswordKey]
+	username, hasUsername := secret.Data[KeyUsername]
+	password, hasPassword := secret.Data[KeyPassword]
 
 	if hasUsername && hasPassword {
 		proxyURL.User = url.UserPassword(string(username), string(password))
@@ -86,14 +86,14 @@ func ProxyURLFromSecret(ctx context.Context, secret *corev1.Secret) (*url.URL, e
 // The function expects the secret to contain "username" and "password" fields.
 // Both fields are required and the function will return an error if either is missing.
 func BasicAuthFromSecret(ctx context.Context, secret *corev1.Secret) (string, string, error) {
-	usernameData, exists := secret.Data[UsernameKey]
+	usernameData, exists := secret.Data[KeyUsername]
 	if !exists {
-		return "", "", &KeyNotFoundError{Key: UsernameKey, Secret: secret}
+		return "", "", &KeyNotFoundError{Key: KeyUsername, Secret: secret}
 	}
 
-	passwordData, exists := secret.Data[PasswordKey]
+	passwordData, exists := secret.Data[KeyPassword]
 	if !exists {
-		return "", "", &KeyNotFoundError{Key: PasswordKey, Secret: secret}
+		return "", "", &KeyNotFoundError{Key: KeyPassword, Secret: secret}
 	}
 
 	return string(usernameData), string(passwordData), nil

--- a/runtime/secrets/converter_test.go
+++ b/runtime/secrets/converter_test.go
@@ -48,9 +48,9 @@ func TestTLSConfigFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("tls-secret"),
 				withData(map[string][]byte{
-					secrets.TLSCertKey:       tlsCert,
-					secrets.TLSPrivateKeyKey: tlsKey,
-					secrets.CACertKey:        caCert,
+					secrets.KeyTLSCert:       tlsCert,
+					secrets.KeyTLSPrivateKey: tlsKey,
+					secrets.KeyCACert:        caCert,
 				}),
 			),
 		},
@@ -59,8 +59,8 @@ func TestTLSConfigFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("tls-secret"),
 				withData(map[string][]byte{
-					secrets.TLSCertKey:       tlsCert,
-					secrets.TLSPrivateKeyKey: tlsKey,
+					secrets.KeyTLSCert:       tlsCert,
+					secrets.KeyTLSPrivateKey: tlsKey,
 				}),
 			),
 		},
@@ -69,9 +69,9 @@ func TestTLSConfigFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("tls-secret"),
 				withData(map[string][]byte{
-					secrets.LegacyTLSCertFileKey:   tlsCert,
-					secrets.LegacyTLSPrivateKeyKey: tlsKey,
-					secrets.LegacyCACertKey:        caCert,
+					secrets.LegacyKeyTLSCert:       tlsCert,
+					secrets.LegacyKeyTLSPrivateKey: tlsKey,
+					secrets.LegacyKeyCACert:        caCert,
 				}),
 			),
 			expectedFields: map[string]string{
@@ -85,9 +85,9 @@ func TestTLSConfigFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("tls-secret"),
 				withData(map[string][]byte{
-					secrets.TLSCertKey:       tlsCert,
-					secrets.TLSPrivateKeyKey: tlsKey,
-					secrets.LegacyCACertKey:  caCert,
+					secrets.KeyTLSCert:       tlsCert,
+					secrets.KeyTLSPrivateKey: tlsKey,
+					secrets.LegacyKeyCACert:  caCert,
 				}),
 			),
 			expectedFields: map[string]string{
@@ -99,12 +99,12 @@ func TestTLSConfigFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("tls-secret"),
 				withData(map[string][]byte{
-					secrets.TLSCertKey:             tlsCert,
-					secrets.TLSPrivateKeyKey:       tlsKey,
-					secrets.CACertKey:              caCert,
-					secrets.LegacyTLSCertFileKey:   []byte("ignored"),
-					secrets.LegacyTLSPrivateKeyKey: []byte("ignored"),
-					secrets.LegacyCACertKey:        []byte("ignored"),
+					secrets.KeyTLSCert:             tlsCert,
+					secrets.KeyTLSPrivateKey:       tlsKey,
+					secrets.KeyCACert:              caCert,
+					secrets.LegacyKeyTLSCert:       []byte("ignored"),
+					secrets.LegacyKeyTLSPrivateKey: []byte("ignored"),
+					secrets.LegacyKeyCACert:        []byte("ignored"),
 				}),
 			),
 		},
@@ -113,8 +113,8 @@ func TestTLSConfigFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("tls-secret"),
 				withData(map[string][]byte{
-					secrets.TLSCertKey:       []byte("invalid-cert-data"),
-					secrets.TLSPrivateKeyKey: []byte("invalid-key-data"),
+					secrets.KeyTLSCert:       []byte("invalid-cert-data"),
+					secrets.KeyTLSPrivateKey: []byte("invalid-key-data"),
 				}),
 			),
 			errMsg: "failed to parse TLS certificate and key",
@@ -124,9 +124,9 @@ func TestTLSConfigFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("tls-secret"),
 				withData(map[string][]byte{
-					secrets.TLSCertKey:       tlsCert,
-					secrets.TLSPrivateKeyKey: tlsKey,
-					secrets.CACertKey:        []byte("invalid-ca-data"),
+					secrets.KeyTLSCert:       tlsCert,
+					secrets.KeyTLSPrivateKey: tlsKey,
+					secrets.KeyCACert:        []byte("invalid-ca-data"),
 				}),
 			),
 			errMsg: "failed to parse CA certificate",
@@ -136,7 +136,7 @@ func TestTLSConfigFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("tls-secret"),
 				withData(map[string][]byte{
-					secrets.CACertKey: caCert,
+					secrets.KeyCACert: caCert,
 				}),
 			),
 		},
@@ -145,7 +145,7 @@ func TestTLSConfigFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("tls-secret"),
 				withData(map[string][]byte{
-					secrets.TLSCertKey: tlsCert,
+					secrets.KeyTLSCert: tlsCert,
 				}),
 			),
 			errMsg: "secret 'default/tls-secret' contains 'tls.crt' but missing 'tls.key'",
@@ -155,7 +155,7 @@ func TestTLSConfigFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("tls-secret"),
 				withData(map[string][]byte{
-					secrets.TLSPrivateKeyKey: tlsKey,
+					secrets.KeyTLSPrivateKey: tlsKey,
 				}),
 			),
 			errMsg: "secret 'default/tls-secret' contains 'tls.key' but missing 'tls.crt'",
@@ -198,8 +198,8 @@ func TestTLSConfigFromSecret(t *testing.T) {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(tlsConfig).ToNot(BeNil())
 
-				hasCert := len(tt.secret.Data[secrets.TLSCertKey]) > 0 || len(tt.secret.Data[secrets.LegacyTLSCertFileKey]) > 0
-				hasKey := len(tt.secret.Data[secrets.TLSPrivateKeyKey]) > 0 || len(tt.secret.Data[secrets.LegacyTLSPrivateKeyKey]) > 0
+				hasCert := len(tt.secret.Data[secrets.KeyTLSCert]) > 0 || len(tt.secret.Data[secrets.LegacyKeyTLSCert]) > 0
+				hasKey := len(tt.secret.Data[secrets.KeyTLSPrivateKey]) > 0 || len(tt.secret.Data[secrets.LegacyKeyTLSPrivateKey]) > 0
 				hasCertPair := hasCert && hasKey
 
 				if hasCertPair {
@@ -211,7 +211,7 @@ func TestTLSConfigFromSecret(t *testing.T) {
 					g.Expect(tlsConfig.Certificates).To(BeEmpty())
 				}
 
-				hasCA := len(tt.secret.Data[secrets.CACertKey]) > 0 || len(tt.secret.Data[secrets.LegacyCACertKey]) > 0
+				hasCA := len(tt.secret.Data[secrets.KeyCACert]) > 0 || len(tt.secret.Data[secrets.LegacyKeyCACert]) > 0
 				if hasCA {
 					g.Expect(tlsConfig.RootCAs).ToNot(BeNil())
 				}
@@ -261,9 +261,9 @@ func TestProxyURLFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("proxy-secret"),
 				withData(map[string][]byte{
-					secrets.AddressKey:  []byte("http://proxy.example.com:8080"),
-					secrets.UsernameKey: []byte("user"),
-					secrets.PasswordKey: []byte("pass"),
+					secrets.KeyAddress:  []byte("http://proxy.example.com:8080"),
+					secrets.KeyUsername: []byte("user"),
+					secrets.KeyPassword: []byte("pass"),
 				}),
 			),
 			wantURL: "http://user:pass@proxy.example.com:8080",
@@ -273,8 +273,8 @@ func TestProxyURLFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("proxy-secret"),
 				withData(map[string][]byte{
-					secrets.AddressKey:  []byte("http://proxy.example.com:8080"),
-					secrets.UsernameKey: []byte("user"),
+					secrets.KeyAddress:  []byte("http://proxy.example.com:8080"),
+					secrets.KeyUsername: []byte("user"),
 				}),
 			),
 			wantURL: "http://user@proxy.example.com:8080",
@@ -284,7 +284,7 @@ func TestProxyURLFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("proxy-secret"),
 				withData(map[string][]byte{
-					secrets.AddressKey: []byte("http://proxy.example.com:8080"),
+					secrets.KeyAddress: []byte("http://proxy.example.com:8080"),
 				}),
 			),
 			wantURL: "http://proxy.example.com:8080",
@@ -294,7 +294,7 @@ func TestProxyURLFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("proxy-secret"),
 				withData(map[string][]byte{
-					secrets.AddressKey: []byte("https://secure-proxy.example.com:8443"),
+					secrets.KeyAddress: []byte("https://secure-proxy.example.com:8443"),
 				}),
 			),
 			wantURL: "https://secure-proxy.example.com:8443",
@@ -304,8 +304,8 @@ func TestProxyURLFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("proxy-secret"),
 				withData(map[string][]byte{
-					secrets.UsernameKey: []byte("user"),
-					secrets.PasswordKey: []byte("pass"),
+					secrets.KeyUsername: []byte("user"),
+					secrets.KeyPassword: []byte("pass"),
 				}),
 			),
 			errMsg: `secret 'default/proxy-secret': key 'address' not found`,
@@ -315,7 +315,7 @@ func TestProxyURLFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("proxy-secret"),
 				withData(map[string][]byte{
-					secrets.AddressKey: []byte(""),
+					secrets.KeyAddress: []byte(""),
 				}),
 			),
 			errMsg: "secret 'default/proxy-secret': proxy address is empty",
@@ -325,7 +325,7 @@ func TestProxyURLFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("proxy-secret"),
 				withData(map[string][]byte{
-					secrets.AddressKey: []byte("://invalid-url"),
+					secrets.KeyAddress: []byte("://invalid-url"),
 				}),
 			),
 			errMsg: "secret 'default/proxy-secret': failed to parse proxy address",
@@ -366,8 +366,8 @@ func TestBasicAuthFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("auth-secret"),
 				withData(map[string][]byte{
-					secrets.UsernameKey: []byte("user"),
-					secrets.PasswordKey: []byte("pass"),
+					secrets.KeyUsername: []byte("user"),
+					secrets.KeyPassword: []byte("pass"),
 				}),
 			),
 			wantUsername: "user",
@@ -378,8 +378,8 @@ func TestBasicAuthFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("auth-secret"),
 				withData(map[string][]byte{
-					secrets.UsernameKey: []byte(""),
-					secrets.PasswordKey: []byte(""),
+					secrets.KeyUsername: []byte(""),
+					secrets.KeyPassword: []byte(""),
 				}),
 			),
 			wantUsername: "",
@@ -390,8 +390,8 @@ func TestBasicAuthFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("auth-secret"),
 				withData(map[string][]byte{
-					secrets.UsernameKey: []byte("user@domain.com"),
-					secrets.PasswordKey: []byte("p@ssw0rd!@#$%"),
+					secrets.KeyUsername: []byte("user@domain.com"),
+					secrets.KeyPassword: []byte("p@ssw0rd!@#$%"),
 				}),
 			),
 			wantUsername: "user@domain.com",
@@ -402,7 +402,7 @@ func TestBasicAuthFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("auth-secret"),
 				withData(map[string][]byte{
-					secrets.PasswordKey: []byte("pass"),
+					secrets.KeyPassword: []byte("pass"),
 				}),
 			),
 			errMsg: `secret 'default/auth-secret': key 'username' not found`,
@@ -412,7 +412,7 @@ func TestBasicAuthFromSecret(t *testing.T) {
 			secret: testSecret(
 				withName("auth-secret"),
 				withData(map[string][]byte{
-					secrets.UsernameKey: []byte("user"),
+					secrets.KeyUsername: []byte("user"),
 				}),
 			),
 			errMsg: `secret 'default/auth-secret': key 'password' not found`,

--- a/runtime/secrets/error.go
+++ b/runtime/secrets/error.go
@@ -84,11 +84,11 @@ func enhanceSecretValidationError(err error, secret *corev1.Secret) error {
 
 	switch tlsErr.Type {
 	case ErrMissingPrivateKey:
-		return fmt.Errorf("secret '%s' contains '%s' but missing '%s'", ref, TLSCertKey, TLSPrivateKeyKey)
+		return fmt.Errorf("secret '%s' contains '%s' but missing '%s'", ref, KeyTLSCert, KeyTLSPrivateKey)
 	case ErrMissingCertificate:
-		return fmt.Errorf("secret '%s' contains '%s' but missing '%s'", ref, TLSPrivateKeyKey, TLSCertKey)
+		return fmt.Errorf("secret '%s' contains '%s' but missing '%s'", ref, KeyTLSPrivateKey, KeyTLSCert)
 	case ErrNoCertificatePairOrCA:
-		return fmt.Errorf("secret '%s' must contain either '%s' or both '%s' and '%s'", ref, CACertKey, TLSCertKey, TLSPrivateKeyKey)
+		return fmt.Errorf("secret '%s' must contain either '%s' or both '%s' and '%s'", ref, KeyCACert, KeyTLSCert, KeyTLSPrivateKey)
 	default:
 		return err
 	}

--- a/runtime/secrets/factory.go
+++ b/runtime/secrets/factory.go
@@ -92,10 +92,10 @@ func MakeTLSSecret(name, namespace string, opts ...TLSSecretOption) (*corev1.Sec
 // The function requires both username and password to be non-empty.
 // The resulting secret will be of type kubernetes.io/basic-auth.
 func MakeBasicAuthSecret(name, namespace, username, password string) (*corev1.Secret, error) {
-	if err := validateRequired(username, "username"); err != nil {
+	if err := validateRequired(username, UsernameKey); err != nil {
 		return nil, err
 	}
-	if err := validateRequired(password, "password"); err != nil {
+	if err := validateRequired(password, PasswordKey); err != nil {
 		return nil, err
 	}
 
@@ -111,7 +111,7 @@ func MakeBasicAuthSecret(name, namespace, username, password string) (*corev1.Se
 // Optional username and password can be provided for proxy authentication.
 // The resulting secret will be of type Opaque.
 func MakeProxySecret(name, namespace, address, username, password string) (*corev1.Secret, error) {
-	if err := validateRequired(address, "address"); err != nil {
+	if err := validateRequired(address, AddressKey); err != nil {
 		return nil, err
 	}
 
@@ -138,7 +138,7 @@ func MakeProxySecret(name, namespace, address, username, password string) (*core
 // The function requires a non-empty token value.
 // The resulting secret will be of type Opaque with the token stored under the "bearerToken" key.
 func MakeBearerTokenSecret(name, namespace, token string) (*corev1.Secret, error) {
-	if err := validateRequired(token, "token"); err != nil {
+	if err := validateRequired(token, BearerTokenKey); err != nil {
 		return nil, err
 	}
 
@@ -153,7 +153,7 @@ func MakeBearerTokenSecret(name, namespace, token string) (*corev1.Secret, error
 // The resulting secret will be of type Opaque with the token stored under the "token" key.
 // This is suitable for various API tokens like GitHub, Slack, Telegram, etc.
 func MakeTokenSecret(name, namespace, token string) (*corev1.Secret, error) {
-	if err := validateRequired(token, "token"); err != nil {
+	if err := validateRequired(token, TokenKey); err != nil {
 		return nil, err
 	}
 
@@ -209,4 +209,33 @@ func MakeRegistrySecret(name, namespace, server, username, password string) (*co
 	return makeSecret(name, namespace, corev1.SecretTypeDockerConfigJson, map[string]string{
 		corev1.DockerConfigJsonKey: string(configData),
 	}), nil
+}
+
+// MakeGitHubAppSecret creates a Kubernetes secret for GitHub App authentication.
+//
+// The function requires appID, installationID, and privateKey to be non-empty.
+// Optional baseURL can be provided for GitHub Enterprise Server instances.
+// The resulting secret will be of type Opaque.
+func MakeGitHubAppSecret(name, namespace, appID, installationID, privateKey, baseURL string) (*corev1.Secret, error) {
+	if err := validateRequired(appID, GitHubAppIDKey); err != nil {
+		return nil, err
+	}
+	if err := validateRequired(installationID, GitHubAppInstallationIDKey); err != nil {
+		return nil, err
+	}
+	if err := validateRequired(privateKey, GitHubAppPrivateKey); err != nil {
+		return nil, err
+	}
+
+	data := map[string]string{
+		GitHubAppIDKey:             appID,
+		GitHubAppInstallationIDKey: installationID,
+		GitHubAppPrivateKey:        privateKey,
+	}
+
+	if baseURL != "" {
+		data[GitHubAppBaseUrlKey] = baseURL
+	}
+
+	return makeSecret(name, namespace, corev1.SecretTypeOpaque, data), nil
 }

--- a/runtime/secrets/factory.go
+++ b/runtime/secrets/factory.go
@@ -239,3 +239,31 @@ func MakeGitHubAppSecret(name, namespace, appID, installationID, privateKey, bas
 
 	return makeSecret(name, namespace, corev1.SecretTypeOpaque, data), nil
 }
+
+// MakeSSHSecret creates a Kubernetes secret for Git over SSH authentication.
+//
+// The function requires privateKey and knownHosts to be non-empty.
+// Optionally, the publicKey and private key password can be provided.
+// The resulting secret will be of type Opaque.
+func MakeSSHSecret(name, namespace, privateKey, publicKey, knownHosts, password string) (*corev1.Secret, error) {
+	if err := validateRequired(privateKey, SSHPrivateKey); err != nil {
+		return nil, err
+	}
+	if err := validateRequired(knownHosts, SSHKnownHostsKey); err != nil {
+		return nil, err
+	}
+
+	data := map[string]string{
+		SSHPrivateKey:    privateKey,
+		SSHKnownHostsKey: knownHosts,
+	}
+
+	if publicKey != "" {
+		data[SSHPublicKey] = publicKey
+	}
+	if password != "" {
+		data[PasswordKey] = password
+	}
+
+	return makeSecret(name, namespace, corev1.SecretTypeOpaque, data), nil
+}

--- a/runtime/secrets/factory.go
+++ b/runtime/secrets/factory.go
@@ -92,16 +92,16 @@ func MakeTLSSecret(name, namespace string, opts ...TLSSecretOption) (*corev1.Sec
 // The function requires both username and password to be non-empty.
 // The resulting secret will be of type kubernetes.io/basic-auth.
 func MakeBasicAuthSecret(name, namespace, username, password string) (*corev1.Secret, error) {
-	if err := validateRequired(username, UsernameKey); err != nil {
+	if err := validateRequired(username, KeyUsername); err != nil {
 		return nil, err
 	}
-	if err := validateRequired(password, PasswordKey); err != nil {
+	if err := validateRequired(password, KeyPassword); err != nil {
 		return nil, err
 	}
 
 	return makeSecret(name, namespace, corev1.SecretTypeBasicAuth, map[string]string{
-		UsernameKey: username,
-		PasswordKey: password,
+		KeyUsername: username,
+		KeyPassword: password,
 	}), nil
 }
 
@@ -111,7 +111,7 @@ func MakeBasicAuthSecret(name, namespace, username, password string) (*corev1.Se
 // Optional username and password can be provided for proxy authentication.
 // The resulting secret will be of type Opaque.
 func MakeProxySecret(name, namespace, address, username, password string) (*corev1.Secret, error) {
-	if err := validateRequired(address, AddressKey); err != nil {
+	if err := validateRequired(address, KeyAddress); err != nil {
 		return nil, err
 	}
 
@@ -120,14 +120,14 @@ func MakeProxySecret(name, namespace, address, username, password string) (*core
 	}
 
 	data := map[string]string{
-		AddressKey: address,
+		KeyAddress: address,
 	}
 
 	if username != "" {
-		data[UsernameKey] = username
+		data[KeyUsername] = username
 	}
 	if password != "" {
-		data[PasswordKey] = password
+		data[KeyPassword] = password
 	}
 
 	return makeSecret(name, namespace, corev1.SecretTypeOpaque, data), nil
@@ -138,12 +138,12 @@ func MakeProxySecret(name, namespace, address, username, password string) (*core
 // The function requires a non-empty token value.
 // The resulting secret will be of type Opaque with the token stored under the "bearerToken" key.
 func MakeBearerTokenSecret(name, namespace, token string) (*corev1.Secret, error) {
-	if err := validateRequired(token, BearerTokenKey); err != nil {
+	if err := validateRequired(token, KeyBearerToken); err != nil {
 		return nil, err
 	}
 
 	return makeSecret(name, namespace, corev1.SecretTypeOpaque, map[string]string{
-		BearerTokenKey: token,
+		KeyBearerToken: token,
 	}), nil
 }
 
@@ -153,12 +153,12 @@ func MakeBearerTokenSecret(name, namespace, token string) (*corev1.Secret, error
 // The resulting secret will be of type Opaque with the token stored under the "token" key.
 // This is suitable for various API tokens like GitHub, Slack, Telegram, etc.
 func MakeTokenSecret(name, namespace, token string) (*corev1.Secret, error) {
-	if err := validateRequired(token, TokenKey); err != nil {
+	if err := validateRequired(token, KeyToken); err != nil {
 		return nil, err
 	}
 
 	return makeSecret(name, namespace, corev1.SecretTypeOpaque, map[string]string{
-		TokenKey: token,
+		KeyToken: token,
 	}), nil
 }
 
@@ -217,24 +217,24 @@ func MakeRegistrySecret(name, namespace, server, username, password string) (*co
 // Optional baseURL can be provided for GitHub Enterprise Server instances.
 // The resulting secret will be of type Opaque.
 func MakeGitHubAppSecret(name, namespace, appID, installationID, privateKey, baseURL string) (*corev1.Secret, error) {
-	if err := validateRequired(appID, GitHubAppIDKey); err != nil {
+	if err := validateRequired(appID, KeyGitHubAppID); err != nil {
 		return nil, err
 	}
-	if err := validateRequired(installationID, GitHubAppInstallationIDKey); err != nil {
+	if err := validateRequired(installationID, KeyGitHubAppInstallationID); err != nil {
 		return nil, err
 	}
-	if err := validateRequired(privateKey, GitHubAppPrivateKey); err != nil {
+	if err := validateRequired(privateKey, KeyGitHubAppPrivateKey); err != nil {
 		return nil, err
 	}
 
 	data := map[string]string{
-		GitHubAppIDKey:             appID,
-		GitHubAppInstallationIDKey: installationID,
-		GitHubAppPrivateKey:        privateKey,
+		KeyGitHubAppID:             appID,
+		KeyGitHubAppInstallationID: installationID,
+		KeyGitHubAppPrivateKey:     privateKey,
 	}
 
 	if baseURL != "" {
-		data[GitHubAppBaseUrlKey] = baseURL
+		data[KeyGitHubAppBaseURL] = baseURL
 	}
 
 	return makeSecret(name, namespace, corev1.SecretTypeOpaque, data), nil
@@ -246,23 +246,23 @@ func MakeGitHubAppSecret(name, namespace, appID, installationID, privateKey, bas
 // Optionally, the publicKey and private key password can be provided.
 // The resulting secret will be of type Opaque.
 func MakeSSHSecret(name, namespace, privateKey, publicKey, knownHosts, password string) (*corev1.Secret, error) {
-	if err := validateRequired(privateKey, SSHPrivateKey); err != nil {
+	if err := validateRequired(privateKey, KeySSHPrivateKey); err != nil {
 		return nil, err
 	}
-	if err := validateRequired(knownHosts, SSHKnownHostsKey); err != nil {
+	if err := validateRequired(knownHosts, KeySSHKnownHosts); err != nil {
 		return nil, err
 	}
 
 	data := map[string]string{
-		SSHPrivateKey:    privateKey,
-		SSHKnownHostsKey: knownHosts,
+		KeySSHPrivateKey: privateKey,
+		KeySSHKnownHosts: knownHosts,
 	}
 
 	if publicKey != "" {
-		data[SSHPublicKey] = publicKey
+		data[KeySSHPublicKey] = publicKey
 	}
 	if password != "" {
-		data[PasswordKey] = password
+		data[KeyPassword] = password
 	}
 
 	return makeSecret(name, namespace, corev1.SecretTypeOpaque, data), nil

--- a/runtime/secrets/factory_test.go
+++ b/runtime/secrets/factory_test.go
@@ -45,9 +45,9 @@ func TestMakeTLSSecret(t *testing.T) {
 			namespace:  testNS,
 			options:    []secrets.TLSSecretOption{secrets.WithCertKeyPair(tlsCert, tlsKey), secrets.WithCAData(caCert)},
 			expectedData: map[string][]byte{
-				secrets.TLSCertKey:       tlsCert,
-				secrets.TLSPrivateKeyKey: tlsKey,
-				secrets.CACertKey:        caCert,
+				secrets.KeyTLSCert:       tlsCert,
+				secrets.KeyTLSPrivateKey: tlsKey,
+				secrets.KeyCACert:        caCert,
 			},
 			expectedType: corev1.SecretTypeTLS,
 		},
@@ -57,8 +57,8 @@ func TestMakeTLSSecret(t *testing.T) {
 			namespace:  testNS,
 			options:    []secrets.TLSSecretOption{secrets.WithCertKeyPair(tlsCert, tlsKey)},
 			expectedData: map[string][]byte{
-				secrets.TLSCertKey:       tlsCert,
-				secrets.TLSPrivateKeyKey: tlsKey,
+				secrets.KeyTLSCert:       tlsCert,
+				secrets.KeyTLSPrivateKey: tlsKey,
 			},
 			expectedType: corev1.SecretTypeTLS,
 		},
@@ -68,7 +68,7 @@ func TestMakeTLSSecret(t *testing.T) {
 			namespace:  testNS,
 			options:    []secrets.TLSSecretOption{secrets.WithCAData(caCert)},
 			expectedData: map[string][]byte{
-				secrets.CACertKey: caCert,
+				secrets.KeyCACert: caCert,
 			},
 			expectedType: corev1.SecretTypeOpaque,
 		},
@@ -181,8 +181,8 @@ func TestMakeBasicAuthSecret(t *testing.T) {
 				g.Expect(secret.Name).To(Equal(tt.secretName))
 				g.Expect(secret.Namespace).To(Equal(tt.namespace))
 				g.Expect(secret.Type).To(Equal(corev1.SecretTypeBasicAuth))
-				g.Expect(secret.StringData[secrets.UsernameKey]).To(Equal(tt.username))
-				g.Expect(secret.StringData[secrets.PasswordKey]).To(Equal(tt.password))
+				g.Expect(secret.StringData[secrets.KeyUsername]).To(Equal(tt.username))
+				g.Expect(secret.StringData[secrets.KeyPassword]).To(Equal(tt.password))
 			}
 		})
 	}
@@ -209,9 +209,9 @@ func TestMakeProxySecret(t *testing.T) {
 			username:   "user",
 			password:   "pass",
 			expectedData: map[string][]byte{
-				secrets.AddressKey:  []byte("http://proxy.example.com:8080"),
-				secrets.UsernameKey: []byte("user"),
-				secrets.PasswordKey: []byte("pass"),
+				secrets.KeyAddress:  []byte("http://proxy.example.com:8080"),
+				secrets.KeyUsername: []byte("user"),
+				secrets.KeyPassword: []byte("pass"),
 			},
 		},
 		{
@@ -222,7 +222,7 @@ func TestMakeProxySecret(t *testing.T) {
 			username:   "",
 			password:   "",
 			expectedData: map[string][]byte{
-				secrets.AddressKey: []byte("http://proxy.example.com:8080"),
+				secrets.KeyAddress: []byte("http://proxy.example.com:8080"),
 			},
 		},
 		{
@@ -233,8 +233,8 @@ func TestMakeProxySecret(t *testing.T) {
 			username:   "user",
 			password:   "",
 			expectedData: map[string][]byte{
-				secrets.AddressKey:  []byte("http://proxy.example.com:8080"),
-				secrets.UsernameKey: []byte("user"),
+				secrets.KeyAddress:  []byte("http://proxy.example.com:8080"),
+				secrets.KeyUsername: []byte("user"),
 			},
 		},
 		{
@@ -321,7 +321,7 @@ func TestMakeBearerTokenSecret(t *testing.T) {
 				g.Expect(secret.Name).To(Equal(tt.secretName))
 				g.Expect(secret.Namespace).To(Equal(tt.namespace))
 				g.Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
-				g.Expect(secret.StringData[secrets.BearerTokenKey]).To(Equal(tt.token))
+				g.Expect(secret.StringData[secrets.KeyBearerToken]).To(Equal(tt.token))
 			}
 		})
 	}
@@ -386,7 +386,7 @@ func TestMakeTokenSecret(t *testing.T) {
 				g.Expect(secret.Name).To(Equal(tt.secretName))
 				g.Expect(secret.Namespace).To(Equal(tt.namespace))
 				g.Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
-				g.Expect(secret.StringData[secrets.TokenKey]).To(Equal(tt.token))
+				g.Expect(secret.StringData[secrets.KeyToken]).To(Equal(tt.token))
 			}
 		})
 	}
@@ -530,10 +530,10 @@ func TestMakeGitHubAppSecret(t *testing.T) {
 			privateKey:     "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA...",
 			baseURL:        "https://github.enterprise.com",
 			expectedData: map[string][]byte{
-				secrets.GitHubAppIDKey:             []byte("123456"),
-				secrets.GitHubAppInstallationIDKey: []byte("7891011"),
-				secrets.GitHubAppPrivateKey:        []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA..."),
-				secrets.GitHubAppBaseUrlKey:        []byte("https://github.enterprise.com"),
+				secrets.KeyGitHubAppID:             []byte("123456"),
+				secrets.KeyGitHubAppInstallationID: []byte("7891011"),
+				secrets.KeyGitHubAppPrivateKey:     []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA..."),
+				secrets.KeyGitHubAppBaseURL:        []byte("https://github.enterprise.com"),
 			},
 		},
 		{
@@ -545,9 +545,9 @@ func TestMakeGitHubAppSecret(t *testing.T) {
 			privateKey:     "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA...",
 			baseURL:        "",
 			expectedData: map[string][]byte{
-				secrets.GitHubAppIDKey:             []byte("123456"),
-				secrets.GitHubAppInstallationIDKey: []byte("7891011"),
-				secrets.GitHubAppPrivateKey:        []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA..."),
+				secrets.KeyGitHubAppID:             []byte("123456"),
+				secrets.KeyGitHubAppInstallationID: []byte("7891011"),
+				secrets.KeyGitHubAppPrivateKey:     []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA..."),
 			},
 		},
 		{
@@ -629,10 +629,10 @@ func TestMakeSSHSecret(t *testing.T) {
 			knownHosts: "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABI...",
 			password:   "passphrase123",
 			expectedData: map[string][]byte{
-				secrets.SSHPrivateKey:    []byte("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAA..."),
-				secrets.SSHPublicKey:     []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAB..."),
-				secrets.SSHKnownHostsKey: []byte("github.com ssh-rsa AAAAB3NzaC1yc2EAAAABI..."),
-				secrets.PasswordKey:      []byte("passphrase123"),
+				secrets.KeySSHPrivateKey: []byte("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAA..."),
+				secrets.KeySSHPublicKey:  []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAB..."),
+				secrets.KeySSHKnownHosts: []byte("github.com ssh-rsa AAAAB3NzaC1yc2EAAAABI..."),
+				secrets.KeyPassword:      []byte("passphrase123"),
 			},
 		},
 		{
@@ -644,8 +644,8 @@ func TestMakeSSHSecret(t *testing.T) {
 			knownHosts: "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABI...",
 			password:   "",
 			expectedData: map[string][]byte{
-				secrets.SSHPrivateKey:    []byte("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAA..."),
-				secrets.SSHKnownHostsKey: []byte("github.com ssh-rsa AAAAB3NzaC1yc2EAAAABI..."),
+				secrets.KeySSHPrivateKey: []byte("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAA..."),
+				secrets.KeySSHKnownHosts: []byte("github.com ssh-rsa AAAAB3NzaC1yc2EAAAABI..."),
 			},
 		},
 		{
@@ -657,9 +657,9 @@ func TestMakeSSHSecret(t *testing.T) {
 			knownHosts: "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABI...",
 			password:   "",
 			expectedData: map[string][]byte{
-				secrets.SSHPrivateKey:    []byte("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAA..."),
-				secrets.SSHPublicKey:     []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAB..."),
-				secrets.SSHKnownHostsKey: []byte("github.com ssh-rsa AAAAB3NzaC1yc2EAAAABI..."),
+				secrets.KeySSHPrivateKey: []byte("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAA..."),
+				secrets.KeySSHPublicKey:  []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAB..."),
+				secrets.KeySSHKnownHosts: []byte("github.com ssh-rsa AAAAB3NzaC1yc2EAAAABI..."),
 			},
 		},
 		{
@@ -671,9 +671,9 @@ func TestMakeSSHSecret(t *testing.T) {
 			knownHosts: "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABI...",
 			password:   "secret-passphrase",
 			expectedData: map[string][]byte{
-				secrets.SSHPrivateKey:    []byte("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAA..."),
-				secrets.SSHKnownHostsKey: []byte("github.com ssh-rsa AAAAB3NzaC1yc2EAAAABI..."),
-				secrets.PasswordKey:      []byte("secret-passphrase"),
+				secrets.KeySSHPrivateKey: []byte("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAA..."),
+				secrets.KeySSHKnownHosts: []byte("github.com ssh-rsa AAAAB3NzaC1yc2EAAAABI..."),
+				secrets.KeyPassword:      []byte("secret-passphrase"),
 			},
 		},
 		{

--- a/runtime/secrets/reader_test.go
+++ b/runtime/secrets/reader_test.go
@@ -49,9 +49,9 @@ func TestTLSConfigFromSecretRef(t *testing.T) {
 			secret: testSecret(
 				withName("tls-secret"),
 				withData(map[string][]byte{
-					secrets.TLSCertKey:       tlsCert,
-					secrets.TLSPrivateKeyKey: tlsKey,
-					secrets.CACertKey:        caCert,
+					secrets.KeyTLSCert:       tlsCert,
+					secrets.KeyTLSPrivateKey: tlsKey,
+					secrets.KeyCACert:        caCert,
 				}),
 			),
 		},
@@ -85,8 +85,8 @@ func TestTLSConfigFromSecretRef(t *testing.T) {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(tlsConfig).ToNot(BeNil())
 
-				hasCert := len(tt.secret.Data[secrets.TLSCertKey]) > 0 || len(tt.secret.Data[secrets.LegacyTLSCertFileKey]) > 0
-				hasKey := len(tt.secret.Data[secrets.TLSPrivateKeyKey]) > 0 || len(tt.secret.Data[secrets.LegacyTLSPrivateKeyKey]) > 0
+				hasCert := len(tt.secret.Data[secrets.KeyTLSCert]) > 0 || len(tt.secret.Data[secrets.LegacyKeyTLSCert]) > 0
+				hasKey := len(tt.secret.Data[secrets.KeyTLSPrivateKey]) > 0 || len(tt.secret.Data[secrets.LegacyKeyTLSPrivateKey]) > 0
 				hasCertPair := hasCert && hasKey
 
 				if hasCertPair {
@@ -98,7 +98,7 @@ func TestTLSConfigFromSecretRef(t *testing.T) {
 					g.Expect(tlsConfig.Certificates).To(BeEmpty())
 				}
 
-				hasCA := len(tt.secret.Data[secrets.CACertKey]) > 0 || len(tt.secret.Data[secrets.LegacyCACertKey]) > 0
+				hasCA := len(tt.secret.Data[secrets.KeyCACert]) > 0 || len(tt.secret.Data[secrets.LegacyKeyCACert]) > 0
 				if hasCA {
 					g.Expect(tlsConfig.RootCAs).ToNot(BeNil())
 				}
@@ -124,9 +124,9 @@ func TestProxyURLFromSecretRef(t *testing.T) {
 			secret: testSecret(
 				withName("proxy-secret"),
 				withData(map[string][]byte{
-					secrets.AddressKey:  []byte("http://proxy.example.com:8080"),
-					secrets.UsernameKey: []byte("user"),
-					secrets.PasswordKey: []byte("pass"),
+					secrets.KeyAddress:  []byte("http://proxy.example.com:8080"),
+					secrets.KeyUsername: []byte("user"),
+					secrets.KeyPassword: []byte("pass"),
 				}),
 			),
 			wantURL: "http://user:pass@proxy.example.com:8080",

--- a/runtime/secrets/secrets.go
+++ b/runtime/secrets/secrets.go
@@ -27,48 +27,48 @@ import (
 )
 
 const (
-	// TLSCertKey is the standard key for TLS certificate data in secrets.
-	TLSCertKey = corev1.TLSCertKey
-	// TLSPrivateKeyKey is the standard key for TLS private key data in secrets.
-	TLSPrivateKeyKey = corev1.TLSPrivateKeyKey
-	// CACertKey is the standard key for CA certificate data in secrets.
-	CACertKey = "ca.crt"
+	// KeyTLSCert is the standard key for TLS certificate data in secrets.
+	KeyTLSCert = corev1.TLSCertKey
+	// KeyTLSPrivateKey is the standard key for TLS private key data in secrets.
+	KeyTLSPrivateKey = corev1.TLSPrivateKeyKey
+	// KeyCACert is the standard key for CA certificate data in secrets.
+	KeyCACert = "ca.crt"
 
-	// LegacyTLSCertFileKey is the legacy key for TLS certificate data in secrets.
-	LegacyTLSCertFileKey = "certFile"
-	// LegacyTLSPrivateKeyKey is the legacy key for TLS private key data in secrets.
-	LegacyTLSPrivateKeyKey = "keyFile"
-	// LegacyCACertKey is the legacy key for CA certificate data in secrets.
-	LegacyCACertKey = "caFile"
+	// LegacyKeyTLSCert is the legacy key for TLS certificate data in secrets.
+	LegacyKeyTLSCert = "certFile"
+	// LegacyKeyTLSPrivateKey is the legacy key for TLS private key data in secrets.
+	LegacyKeyTLSPrivateKey = "keyFile"
+	// LegacyKeyCACert is the legacy key for CA certificate data in secrets.
+	LegacyKeyCACert = "caFile"
 
-	// UsernameKey is the key for username data in basic auth secrets.
-	UsernameKey = "username"
-	// PasswordKey is the key for password data in basic auth secrets.
-	PasswordKey = "password"
+	// KeyUsername is the key for username data in basic auth secrets.
+	KeyUsername = "username"
+	// KeyPassword is the key for password data in basic auth secrets.
+	KeyPassword = "password"
 
-	// AddressKey is the key for proxy address data in proxy secrets.
-	AddressKey = "address"
+	// KeyAddress is the key for proxy address data in proxy secrets.
+	KeyAddress = "address"
 
-	// BearerTokenKey is the key for bearer token data in secrets.
-	BearerTokenKey = "bearerToken"
-	// TokenKey is the key for generic API token data in secrets.
-	TokenKey = "token"
+	// KeyBearerToken is the key for bearer token data in secrets.
+	KeyBearerToken = "bearerToken"
+	// KeyToken is the key for generic API token data in secrets.
+	KeyToken = "token"
 
-	// GitHubAppIDKey is the key for GitHub App ID data in secrets.
-	GitHubAppIDKey = "githubAppID"
-	// GitHubAppInstallationIDKey is the key for GitHub App installation ID data in secrets.
-	GitHubAppInstallationIDKey = "githubAppInstallationID"
-	// GitHubAppPrivateKey is the key for GitHub App private key data in secrets.
-	GitHubAppPrivateKey = "githubAppPrivateKey"
-	// GitHubAppBaseUrlKey is the key for GitHub App base URL data in secrets.
-	GitHubAppBaseUrlKey = "githubAppBaseURL"
+	// KeyGitHubAppID is the key for GitHub App ID data in secrets.
+	KeyGitHubAppID = "githubAppID"
+	// KeyGitHubAppInstallationID is the key for GitHub App installation ID data in secrets.
+	KeyGitHubAppInstallationID = "githubAppInstallationID"
+	// KeyGitHubAppPrivateKey is the key for GitHub App private key data in secrets.
+	KeyGitHubAppPrivateKey = "githubAppPrivateKey"
+	// KeyGitHubAppBaseURL is the key for GitHub App base URL data in secrets.
+	KeyGitHubAppBaseURL = "githubAppBaseURL"
 
-	// SSHPrivateKey is the key for SSH private key data in secrets.
-	SSHPrivateKey = "identity"
-	// SSHPublicKey is the key for SSH public key data in secrets.
-	SSHPublicKey = "identity.pub"
-	// SSHKnownHostsKey is the key for SSH known hosts data in secrets.
-	SSHKnownHostsKey = "known_hosts"
+	// KeySSHPrivateKey is the key for SSH private key data in secrets.
+	KeySSHPrivateKey = "identity"
+	// KeySSHPublicKey is the key for SSH public key data in secrets.
+	KeySSHPublicKey = "identity.pub"
+	// KeySSHKnownHosts is the key for SSH known hosts data in secrets.
+	KeySSHKnownHosts = "known_hosts"
 )
 
 // tlsCertificateData holds TLS certificate, key, and optional CA data
@@ -81,9 +81,9 @@ type tlsCertificateData struct {
 // newTLSCertificateData creates tlsCertificateData from a Kubernetes secret.
 func newTLSCertificateData(secret *corev1.Secret, logger logr.Logger) (*tlsCertificateData, error) {
 	data := &tlsCertificateData{
-		cert:   getSecretData(secret, TLSCertKey, LegacyTLSCertFileKey, logger),
-		key:    getSecretData(secret, TLSPrivateKeyKey, LegacyTLSPrivateKeyKey, logger),
-		caCert: getSecretData(secret, CACertKey, LegacyCACertKey, logger),
+		cert:   getSecretData(secret, KeyTLSCert, LegacyKeyTLSCert, logger),
+		key:    getSecretData(secret, KeyTLSPrivateKey, LegacyKeyTLSPrivateKey, logger),
+		caCert: getSecretData(secret, KeyCACert, LegacyKeyCACert, logger),
 	}
 
 	if err := data.validate(); err != nil {
@@ -136,15 +136,15 @@ func (t *tlsCertificateData) toSecret(name, namespace string) *corev1.Secret {
 	var secretType corev1.SecretType
 
 	if t.hasCertPair() {
-		secretData[TLSCertKey] = string(t.cert)
-		secretData[TLSPrivateKeyKey] = string(t.key)
+		secretData[KeyTLSCert] = string(t.cert)
+		secretData[KeyTLSPrivateKey] = string(t.key)
 		secretType = corev1.SecretTypeTLS
 	} else {
 		secretType = corev1.SecretTypeOpaque
 	}
 
 	if t.hasCA() {
-		secretData[CACertKey] = string(t.caCert)
+		secretData[KeyCACert] = string(t.caCert)
 	}
 
 	return &corev1.Secret{

--- a/runtime/secrets/secrets.go
+++ b/runtime/secrets/secrets.go
@@ -53,6 +53,15 @@ const (
 	BearerTokenKey = "bearerToken"
 	// TokenKey is the key for generic API token data in secrets.
 	TokenKey = "token"
+
+	// GitHubAppIDKey is the key for GitHub App ID data in secrets.
+	GitHubAppIDKey = "githubAppID"
+	// GitHubAppInstallationIDKey is the key for GitHub App installation ID data in secrets.
+	GitHubAppInstallationIDKey = "githubAppInstallationID"
+	// GitHubAppPrivateKey is the key for GitHub App private key data in secrets.
+	GitHubAppPrivateKey = "githubAppPrivateKey"
+	// GitHubAppBaseUrlKey is the key for GitHub App base URL data in secrets.
+	GitHubAppBaseUrlKey = "githubAppBaseURL"
 )
 
 // tlsCertificateData holds TLS certificate, key, and optional CA data

--- a/runtime/secrets/secrets.go
+++ b/runtime/secrets/secrets.go
@@ -62,6 +62,13 @@ const (
 	GitHubAppPrivateKey = "githubAppPrivateKey"
 	// GitHubAppBaseUrlKey is the key for GitHub App base URL data in secrets.
 	GitHubAppBaseUrlKey = "githubAppBaseURL"
+
+	// SSHPrivateKey is the key for SSH private key data in secrets.
+	SSHPrivateKey = "identity"
+	// SSHPublicKey is the key for SSH public key data in secrets.
+	SSHPublicKey = "identity.pub"
+	// SSHKnownHostsKey is the key for SSH known hosts data in secrets.
+	SSHKnownHostsKey = "known_hosts"
 )
 
 // tlsCertificateData holds TLS certificate, key, and optional CA data

--- a/runtime/secrets/secrets_test.go
+++ b/runtime/secrets/secrets_test.go
@@ -58,21 +58,9 @@ func withName(name string) func(*corev1.Secret) {
 	}
 }
 
-func withNamespace(namespace string) func(*corev1.Secret) {
-	return func(s *corev1.Secret) {
-		s.Namespace = namespace
-	}
-}
-
 func withData(data map[string][]byte) func(*corev1.Secret) {
 	return func(s *corev1.Secret) {
 		s.Data = data
-	}
-}
-
-func withType(secretType corev1.SecretType) func(*corev1.Secret) {
-	return func(s *corev1.Secret) {
-		s.Type = secretType
 	}
 }
 

--- a/runtime/secrets/suite_test.go
+++ b/runtime/secrets/suite_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2025 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secrets_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/fluxcd/pkg/runtime/testenv"
+)
+
+const timeout = time.Second * 20
+
+var (
+	env *testenv.Environment
+	ctx = ctrl.SetupSignalHandler()
+)
+
+func TestMain(m *testing.M) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(corev1.AddToScheme(scheme))
+
+	env = testenv.New(
+		testenv.WithScheme(scheme),
+	)
+
+	go func() {
+		fmt.Println("Starting the test environment")
+		if err := env.Start(ctx); err != nil {
+			panic(fmt.Sprintf("Failed to start the test environment manager: %v", err))
+		}
+	}()
+	<-env.Manager.Elected()
+
+	code := m.Run()
+
+	fmt.Println("Stopping the test environment")
+	if err := env.Stop(); err != nil {
+		panic(fmt.Sprintf("Failed to stop the test environment: %v", err))
+	}
+
+	os.Exit(code)
+}


### PR DESCRIPTION
Implement `MakeGitHubAppSecret`, `MakeSSHSecret` and add tests.

In addition, this PR adds a helper for applying secrets with Kubernetes SSA.