### PR TITLE
tools: Fix module bump detection for bumps that cause other bumps

### DIFF
--- a/cmd/cli/pkg_prepare_release.go
+++ b/cmd/cli/pkg_prepare_release.go
@@ -50,7 +50,7 @@ func runPrepareRelease(cmd *cobra.Command, args []string) error {
 	res.PrintBumps()
 
 	// Prompt for confirmation to apply changes.
-	fmt.Println("\nConfirm applying changes above to file system? (Y/n, only uppercase Y will apply)")
+	fmt.Println("\nConfirm applying changes above to file system? (Y/n, only uppercase Y will confirm)")
 	var response string
 	fmt.Scanln(&response)
 	if response != "Y" {

--- a/cmd/cli/pkg_release.go
+++ b/cmd/cli/pkg_release.go
@@ -53,7 +53,7 @@ func runRelease(cmd *cobra.Command, args []string) error {
 	res.PrintTags()
 
 	// Prompt for confirmation to push the tags.
-	fmt.Println("\nConfirm pushing tags above to Git repository? (Y/n, only uppercase Y will apply)")
+	fmt.Println("\nConfirm pushing tags above to Git repository? (Y/n, only uppercase Y will confirm)")
 	var response string
 	fmt.Scanln(&response)
 	if response != "Y" {


### PR DESCRIPTION
When changing something in the `git` module, both `git` and `git/gogit` should be released because `git/gogit` depends on `git`. Even if `git/gogit` has not changed between its latest tag and HEAD, it should still be released because it received the bump of `git`.

This PR fixes this edge case:

```
make prep
Bumped git: 0.33.0 => 0.34.0 in modules: git/gogit, git/internal/e2e, oci/tests/integration
Bumped git/gogit: 0.36.0 => 0.37.0 in modules: git/internal/e2e, oci/tests/integration

Confirm applying changes above to file system? (Y/n, only uppercase Y will confirm)
n
Aborting changes.
```