### PR TITLE
runtime/secrets: Set GVK on generated secrets

### DIFF
--- a/runtime/secrets/factory.go
+++ b/runtime/secrets/factory.go
@@ -38,7 +38,7 @@ func validateRequired[T emptyCheckable](value T, fieldName string) error {
 }
 
 func makeSecret(name, namespace string, secretType corev1.SecretType, data map[string]string) *corev1.Secret {
-	return &corev1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -46,6 +46,8 @@ func makeSecret(name, namespace string, secretType corev1.SecretType, data map[s
 		Type:       secretType,
 		StringData: data,
 	}
+	secret.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
+	return secret
 }
 
 // TLSSecretOption configures a TLS secret.

--- a/runtime/secrets/factory_test.go
+++ b/runtime/secrets/factory_test.go
@@ -115,6 +115,8 @@ func TestMakeTLSSecret(t *testing.T) {
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(secret).ToNot(BeNil())
+				g.Expect(secret.Kind).To(Equal("Secret"))
+				g.Expect(secret.APIVersion).To(Equal("v1"))
 				g.Expect(secret.Name).To(Equal(tt.secretName))
 				g.Expect(secret.Namespace).To(Equal(tt.namespace))
 				g.Expect(secret.Type).To(Equal(tt.expectedType))
@@ -178,6 +180,8 @@ func TestMakeBasicAuthSecret(t *testing.T) {
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(secret).ToNot(BeNil())
+				g.Expect(secret.Kind).To(Equal("Secret"))
+				g.Expect(secret.APIVersion).To(Equal("v1"))
 				g.Expect(secret.Name).To(Equal(tt.secretName))
 				g.Expect(secret.Namespace).To(Equal(tt.namespace))
 				g.Expect(secret.Type).To(Equal(corev1.SecretTypeBasicAuth))
@@ -266,6 +270,8 @@ func TestMakeProxySecret(t *testing.T) {
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(secret).ToNot(BeNil())
+				g.Expect(secret.Kind).To(Equal("Secret"))
+				g.Expect(secret.APIVersion).To(Equal("v1"))
 				g.Expect(secret.Name).To(Equal(tt.secretName))
 				g.Expect(secret.Namespace).To(Equal(tt.namespace))
 				g.Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
@@ -318,6 +324,8 @@ func TestMakeBearerTokenSecret(t *testing.T) {
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(secret).ToNot(BeNil())
+				g.Expect(secret.Kind).To(Equal("Secret"))
+				g.Expect(secret.APIVersion).To(Equal("v1"))
 				g.Expect(secret.Name).To(Equal(tt.secretName))
 				g.Expect(secret.Namespace).To(Equal(tt.namespace))
 				g.Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
@@ -383,6 +391,8 @@ func TestMakeTokenSecret(t *testing.T) {
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(secret).ToNot(BeNil())
+				g.Expect(secret.Kind).To(Equal("Secret"))
+				g.Expect(secret.APIVersion).To(Equal("v1"))
 				g.Expect(secret.Name).To(Equal(tt.secretName))
 				g.Expect(secret.Namespace).To(Equal(tt.namespace))
 				g.Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
@@ -498,6 +508,8 @@ func TestMakeRegistrySecret(t *testing.T) {
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(secret).ToNot(BeNil())
+				g.Expect(secret.Kind).To(Equal("Secret"))
+				g.Expect(secret.APIVersion).To(Equal("v1"))
 				g.Expect(secret.Name).To(Equal(tt.secretName))
 				g.Expect(secret.Namespace).To(Equal(tt.namespace))
 				g.Expect(secret.Type).To(Equal(corev1.SecretTypeDockerConfigJson))
@@ -592,6 +604,8 @@ func TestMakeGitHubAppSecret(t *testing.T) {
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(secret).ToNot(BeNil())
+				g.Expect(secret.Kind).To(Equal("Secret"))
+				g.Expect(secret.APIVersion).To(Equal("v1"))
 				g.Expect(secret.Name).To(Equal(tt.secretName))
 				g.Expect(secret.Namespace).To(Equal(tt.namespace))
 				g.Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
@@ -711,6 +725,8 @@ func TestMakeSSHSecret(t *testing.T) {
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(secret).ToNot(BeNil())
+				g.Expect(secret.Kind).To(Equal("Secret"))
+				g.Expect(secret.APIVersion).To(Equal("v1"))
 				g.Expect(secret.Name).To(Equal(tt.secretName))
 				g.Expect(secret.Namespace).To(Equal(tt.namespace))
 				g.Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))

--- a/runtime/secrets/secrets.go
+++ b/runtime/secrets/secrets.go
@@ -147,7 +147,7 @@ func (t *tlsCertificateData) toSecret(name, namespace string) *corev1.Secret {
 		secretData[KeyCACert] = string(t.caCert)
 	}
 
-	return &corev1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -155,6 +155,8 @@ func (t *tlsCertificateData) toSecret(name, namespace string) *corev1.Secret {
 		Type:       secretType,
 		StringData: secretData,
 	}
+	secret.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
+	return secret
 }
 
 // getSecretData retrieves data from secret with fallback support for legacy keys.


### PR DESCRIPTION
The generated secrets were missing `apiVersion` and `kind`.