### PR TITLE
ci: Fix missing permissions for `preview-release` workflow

### DIFF
--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -1,4 +1,4 @@
-name: Preview Release
+name: preview-release
 
 on:
   workflow_dispatch:
@@ -6,6 +6,8 @@ on:
 jobs:
   preview-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Drop permissions to minimum required `contents: read`