### PR TITLE
runtime/controller: Fix watch configs for empty label selector

### DIFF
--- a/oci/tests/integration/go.mod
+++ b/oci/tests/integration/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/fluxcd/pkg/cache v0.10.0
 	github.com/fluxcd/pkg/git v0.34.0
 	github.com/fluxcd/pkg/git/gogit v0.37.0
-	github.com/fluxcd/pkg/runtime v0.70.0
+	github.com/fluxcd/pkg/runtime v0.71.0
 	github.com/fluxcd/test-infra/tftestenv v0.0.0-20250626232827-e0ca9c3f8d7b
 	github.com/go-git/go-git/v5 v5.16.2
 	github.com/google/go-containerregistry v0.20.6

--- a/runtime/controller/watch.go
+++ b/runtime/controller/watch.go
@@ -88,7 +88,7 @@ func GetWatchSelector(opts WatchOptions) (labels.Selector, error) {
 // GetWatchConfigsPredicate parses the label selector option from WatchOptions
 // and returns the controller-runtime predicate ready for setting up the watch.
 func GetWatchConfigsPredicate(opts WatchOptions) (predicate.Predicate, error) {
-	selector := labels.Nothing()
+	selector := labels.Everything()
 
 	if opts.ConfigsLabelSelector != "" {
 		var err error

--- a/runtime/controller/watch_test.go
+++ b/runtime/controller/watch_test.go
@@ -149,24 +149,28 @@ func TestGetWatchConfigsPredicate(t *testing.T) {
 		arguments          []string
 		shouldMatchDefault bool
 		shouldMatchCustom  bool
+		shouldMatchEmpty   bool
 	}{
 		{
 			name:               "default selector",
 			arguments:          []string{},
 			shouldMatchDefault: true,
 			shouldMatchCustom:  false,
+			shouldMatchEmpty:   false,
 		},
 		{
 			name:               "custom selector",
 			arguments:          []string{"--watch-configs-label-selector=app=my-app"},
 			shouldMatchDefault: false,
 			shouldMatchCustom:  true,
+			shouldMatchEmpty:   false,
 		},
 		{
 			name:               "empty selector",
 			arguments:          []string{"--watch-configs-label-selector="},
-			shouldMatchDefault: false,
-			shouldMatchCustom:  false,
+			shouldMatchDefault: true,
+			shouldMatchCustom:  true,
+			shouldMatchEmpty:   true,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -203,7 +207,7 @@ func TestGetWatchConfigsPredicate(t *testing.T) {
 			// Test empty labels.
 			ev.Object.SetLabels(map[string]string{})
 			ok = pred.Create(ev)
-			g.Expect(ok).To(BeFalse())
+			g.Expect(ok).To(Equal(tt.shouldMatchEmpty))
 		})
 	}
 }


### PR DESCRIPTION
Part of: https://github.com/fluxcd/flux2/issues/5446