### PR TITLE
runtime/secrets: add TokenAuth detection support

### DIFF
--- a/oci/tests/integration/go.mod
+++ b/oci/tests/integration/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/fluxcd/pkg/cache v0.10.0
 	github.com/fluxcd/pkg/git v0.34.0
 	github.com/fluxcd/pkg/git/gogit v0.37.0
-	github.com/fluxcd/pkg/runtime v0.73.0
+	github.com/fluxcd/pkg/runtime v0.74.0
 	github.com/fluxcd/test-infra/tftestenv v0.0.0-20250626232827-e0ca9c3f8d7b
 	github.com/go-git/go-git/v5 v5.16.2
 	github.com/google/go-containerregistry v0.20.6

--- a/runtime/secrets/converter.go
+++ b/runtime/secrets/converter.go
@@ -167,15 +167,13 @@ func BasicAuthFromSecret(ctx context.Context, secret *corev1.Secret) (*BasicAuth
 //
 // The function expects the secret to contain "bearerToken" field.
 // The field is required and the function will return an error if it is missing.
-func BearerAuthFromSecret(ctx context.Context, secret *corev1.Secret) (*BearerAuth, error) {
+func BearerAuthFromSecret(ctx context.Context, secret *corev1.Secret) (BearerAuth, error) {
 	tokenData, exists := secret.Data[KeyBearerToken]
 	if !exists {
-		return nil, &KeyNotFoundError{Key: KeyBearerToken, Secret: secret}
+		return "", &KeyNotFoundError{Key: KeyBearerToken, Secret: secret}
 	}
 
-	return &BearerAuth{
-		Token: string(tokenData),
-	}, nil
+	return BearerAuth(tokenData), nil
 }
 
 // SSHAuthFromSecret retrieves SSH authentication credentials from a Kubernetes secret.

--- a/runtime/secrets/converter_test.go
+++ b/runtime/secrets/converter_test.go
@@ -42,6 +42,7 @@ func TestAuthMethodsFromSecret(t *testing.T) {
 		secretData map[string][]byte
 		wantBasic  bool
 		wantBearer bool
+		wantToken  bool
 		wantSSH    bool
 		wantTLS    bool
 		wantErr    error
@@ -51,6 +52,7 @@ func TestAuthMethodsFromSecret(t *testing.T) {
 			secretData: map[string][]byte{},
 			wantBasic:  false,
 			wantBearer: false,
+			wantToken:  false,
 			wantSSH:    false,
 			wantTLS:    false,
 		},
@@ -62,6 +64,7 @@ func TestAuthMethodsFromSecret(t *testing.T) {
 			},
 			wantBasic:  true,
 			wantBearer: false,
+			wantToken:  false,
 			wantSSH:    false,
 			wantTLS:    false,
 		},
@@ -72,6 +75,7 @@ func TestAuthMethodsFromSecret(t *testing.T) {
 			},
 			wantBasic:  false,
 			wantBearer: true,
+			wantToken:  false,
 			wantSSH:    false,
 			wantTLS:    false,
 		},
@@ -83,6 +87,7 @@ func TestAuthMethodsFromSecret(t *testing.T) {
 			},
 			wantBasic:  false,
 			wantBearer: false,
+			wantToken:  false,
 			wantSSH:    true,
 			wantTLS:    false,
 		},
@@ -93,6 +98,7 @@ func TestAuthMethodsFromSecret(t *testing.T) {
 			},
 			wantBasic:  false,
 			wantBearer: false,
+			wantToken:  false,
 			wantSSH:    false,
 			wantTLS:    true,
 		},
@@ -105,6 +111,7 @@ func TestAuthMethodsFromSecret(t *testing.T) {
 			},
 			wantBasic:  true,
 			wantBearer: false,
+			wantToken:  false,
 			wantSSH:    false,
 			wantTLS:    true,
 		},
@@ -116,8 +123,33 @@ func TestAuthMethodsFromSecret(t *testing.T) {
 			},
 			wantBasic:  false,
 			wantBearer: true,
+			wantToken:  false,
 			wantSSH:    false,
 			wantTLS:    true,
+		},
+		{
+			name: "token only",
+			secretData: map[string][]byte{
+				secrets.KeyToken: []byte("api-token-123"),
+			},
+			wantBasic:  false,
+			wantBearer: false,
+			wantToken:  true,
+			wantSSH:    false,
+			wantTLS:    false,
+		},
+		{
+			name: "bearer token + basic auth",
+			secretData: map[string][]byte{
+				secrets.KeyUsername:    []byte("testuser"),
+				secrets.KeyPassword:    []byte("testpass"),
+				secrets.KeyBearerToken: []byte("token123"),
+			},
+			wantBasic:  true,
+			wantBearer: true,
+			wantToken:  false,
+			wantSSH:    false,
+			wantTLS:    false,
 		},
 		{
 			name: "all authentication methods",
@@ -125,12 +157,14 @@ func TestAuthMethodsFromSecret(t *testing.T) {
 				secrets.KeyUsername:      []byte("testuser"),
 				secrets.KeyPassword:      []byte("testpass"),
 				secrets.KeyBearerToken:   []byte("token123"),
+				secrets.KeyToken:         []byte("api-token-123"),
 				secrets.KeySSHPrivateKey: []byte(sshPrivateKey),
 				secrets.KeySSHKnownHosts: []byte(sshKnownHosts),
 				secrets.KeyCACert:        validCACert,
 			},
 			wantBasic:  true,
 			wantBearer: true,
+			wantToken:  true,
 			wantSSH:    true,
 			wantTLS:    true,
 		},
@@ -196,6 +230,7 @@ func TestAuthMethodsFromSecret(t *testing.T) {
 
 			g.Expect(result.HasBasicAuth()).To(Equal(tt.wantBasic))
 			g.Expect(result.HasBearerAuth()).To(Equal(tt.wantBearer))
+			g.Expect(result.HasTokenAuth()).To(Equal(tt.wantToken))
 			g.Expect(result.HasSSH()).To(Equal(tt.wantSSH))
 			g.Expect(result.HasTLS()).To(Equal(tt.wantTLS))
 
@@ -208,6 +243,11 @@ func TestAuthMethodsFromSecret(t *testing.T) {
 			if tt.wantBearer {
 				g.Expect(result.Bearer).ToNot(BeEmpty())
 				g.Expect(string(result.Bearer)).To(Equal("token123"))
+			}
+
+			if tt.wantToken {
+				g.Expect(result.Token).ToNot(BeEmpty())
+				g.Expect(string(result.Token)).To(Equal("api-token-123"))
 			}
 
 			if tt.wantSSH {
@@ -703,6 +743,64 @@ func TestBearerAuthFromSecret(t *testing.T) {
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(string(bearerAuth)).To(Equal(tt.wantToken))
+			}
+		})
+	}
+}
+
+func TestTokenAuthFromSecret(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		secret    *corev1.Secret
+		wantToken string
+		errMsg    string
+	}{
+		{
+			name: "valid token",
+			secret: testSecret(
+				withName("token-secret"),
+				withData(map[string][]byte{
+					secrets.KeyToken: []byte("api-token-123"),
+				}),
+			),
+			wantToken: "api-token-123",
+		},
+		{
+			name: "empty token",
+			secret: testSecret(
+				withName("token-secret"),
+				withData(map[string][]byte{
+					secrets.KeyToken: []byte(""),
+				}),
+			),
+			wantToken: "",
+		},
+		{
+			name: "missing token key",
+			secret: testSecret(
+				withName("token-secret"),
+				withData(map[string][]byte{}),
+			),
+			errMsg: `secret 'default/token-secret': key 'token' not found`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			ctx := context.Background()
+
+			tokenAuth, err := secrets.TokenAuthFromSecret(ctx, tt.secret)
+
+			if tt.errMsg != "" {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.errMsg)))
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(string(tokenAuth)).To(Equal(tt.wantToken))
 			}
 		})
 	}

--- a/runtime/secrets/converter_test.go
+++ b/runtime/secrets/converter_test.go
@@ -206,8 +206,8 @@ func TestAuthMethodsFromSecret(t *testing.T) {
 			}
 
 			if tt.wantBearer {
-				g.Expect(result.Bearer).ToNot(BeNil())
-				g.Expect(result.Bearer.Token).To(Equal("token123"))
+				g.Expect(result.Bearer).ToNot(BeEmpty())
+				g.Expect(string(result.Bearer)).To(Equal("token123"))
 			}
 
 			if tt.wantSSH {
@@ -702,7 +702,7 @@ func TestBearerAuthFromSecret(t *testing.T) {
 				g.Expect(err).To(MatchError(ContainSubstring(tt.errMsg)))
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(bearerAuth.Token).To(Equal(tt.wantToken))
+				g.Expect(string(bearerAuth)).To(Equal(tt.wantToken))
 			}
 		})
 	}

--- a/runtime/secrets/secrets.go
+++ b/runtime/secrets/secrets.go
@@ -75,6 +75,7 @@ const (
 type AuthMethods struct {
 	Basic  *BasicAuth
 	Bearer BearerAuth
+	Token  TokenAuth
 	SSH    *SSHAuth
 	TLS    *tls.Config
 }
@@ -87,6 +88,11 @@ func (am *AuthMethods) HasBasicAuth() bool {
 // HasBearerAuth returns true if bearer token authentication is available.
 func (am *AuthMethods) HasBearerAuth() bool {
 	return am.Bearer != ""
+}
+
+// HasTokenAuth returns true if token authentication is available.
+func (am *AuthMethods) HasTokenAuth() bool {
+	return am.Token != ""
 }
 
 // HasSSH returns true if SSH authentication is available.
@@ -195,6 +201,9 @@ type BasicAuth struct {
 
 // BearerAuth holds bearer token authentication credentials.
 type BearerAuth string
+
+// TokenAuth holds generic token authentication credentials.
+type TokenAuth string
 
 // SSHAuth holds SSH authentication credentials.
 type SSHAuth struct {

--- a/runtime/secrets/secrets.go
+++ b/runtime/secrets/secrets.go
@@ -74,7 +74,7 @@ const (
 // AuthMethods holds all available authentication methods detected from a secret.
 type AuthMethods struct {
 	Basic  *BasicAuth
-	Bearer *BearerAuth
+	Bearer BearerAuth
 	SSH    *SSHAuth
 	TLS    *tls.Config
 }
@@ -86,7 +86,7 @@ func (am *AuthMethods) HasBasicAuth() bool {
 
 // HasBearerAuth returns true if bearer token authentication is available.
 func (am *AuthMethods) HasBearerAuth() bool {
-	return am.Bearer != nil
+	return am.Bearer != ""
 }
 
 // HasSSH returns true if SSH authentication is available.
@@ -194,9 +194,7 @@ type BasicAuth struct {
 }
 
 // BearerAuth holds bearer token authentication credentials.
-type BearerAuth struct {
-	Token string
-}
+type BearerAuth string
 
 // SSHAuth holds SSH authentication credentials.
 type SSHAuth struct {


### PR DESCRIPTION
## Summary

Add `TokenAuth` detection support to `AuthMethodsFromSecret`. This was missing from #983 when `AuthMethodsFromSecret` was added - generic token authentication detection was overlooked.

Also simplify `BearerAuth` and `TokenAuth` from struct to string type since they don't need struct wrapping.