### PR TITLE
chartutil: Fix sort not recursing for slices

### DIFF
--- a/chartutil/encode.go
+++ b/chartutil/encode.go
@@ -19,8 +19,8 @@ package chartutil
 import (
 	"io"
 
+	goyaml "go.yaml.in/yaml/v2"
 	"sigs.k8s.io/yaml"
-	goyaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 // PreEncoder allows for pre-processing of the YAML data before encoding.

--- a/chartutil/go.mod
+++ b/chartutil/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/onsi/gomega v1.37.0
 	github.com/opencontainers/go-digest v1.0.0
+	go.yaml.in/yaml/v2 v2.4.2
 	helm.sh/helm/v3 v3.18.4
 	k8s.io/api v0.33.2
 	k8s.io/apimachinery v0.33.2
@@ -50,7 +51,6 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
-	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect

--- a/chartutil/sort.go
+++ b/chartutil/sort.go
@@ -19,8 +19,18 @@ package chartutil
 import (
 	"sort"
 
-	goyaml "sigs.k8s.io/yaml/goyaml.v2"
+	goyaml "go.yaml.in/yaml/v2"
 )
+
+func sortSlice(s []interface{}) {
+	for _, item := range s {
+		if nestedMS, ok := item.(goyaml.MapSlice); ok {
+			SortMapSlice(nestedMS)
+		} else if nestedSlice, ok := item.([]interface{}); ok {
+			sortSlice(nestedSlice)
+		}
+	}
+}
 
 // SortMapSlice recursively sorts the given goyaml.MapSlice by key.
 // It can be used in combination with Encode to sort YAML by key
@@ -34,11 +44,7 @@ func SortMapSlice(ms goyaml.MapSlice) {
 		if nestedMS, ok := item.Value.(goyaml.MapSlice); ok {
 			SortMapSlice(nestedMS)
 		} else if nestedSlice, ok := item.Value.([]interface{}); ok {
-			for _, vItem := range nestedSlice {
-				if nestedMS, ok := vItem.(goyaml.MapSlice); ok {
-					SortMapSlice(nestedMS)
-				}
-			}
+			sortSlice(nestedSlice)
 		}
 	}
 }

--- a/chartutil/sort_test.go
+++ b/chartutil/sort_test.go
@@ -20,8 +20,8 @@ import (
 	"bytes"
 	"testing"
 
+	goyaml "go.yaml.in/yaml/v2"
 	"sigs.k8s.io/yaml"
-	goyaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 func TestSortMapSlice(t *testing.T) {
@@ -124,6 +124,54 @@ func TestSortMapSlice(t *testing.T) {
 					"r": "value-r",
 				},
 				"e": []interface{}{"strawberry", "banana"},
+				"f": []interface{}{
+					[]interface{}{
+						map[string]interface{}{
+							"f1": map[string]interface{}{
+								"f1q": "value-f1q",
+								"f1p": "value-f1p",
+								"f1r": "value-f1r",
+							},
+						},
+						map[string]interface{}{
+							"f2": map[string]interface{}{
+								"f2q": "value-f2q",
+								"f2p": "value-f2p",
+								"f2r": "value-f2r",
+							},
+						},
+						map[string]interface{}{
+							"f3": map[string]interface{}{
+								"f3q": "value-f3q",
+								"f3p": "value-f3p",
+								"f3r": "value-f3r",
+							},
+						},
+					},
+					[]interface{}{
+						map[string]interface{}{
+							"F1": map[string]interface{}{
+								"F1q": "value-F1q",
+								"F1p": "value-F1p",
+								"F1r": "value-F1r",
+							},
+						},
+						map[string]interface{}{
+							"F2": map[string]interface{}{
+								"F2q": "value-F2q",
+								"F2p": "value-F2p",
+								"F2r": "value-F2r",
+							},
+						},
+						map[string]interface{}{
+							"F3": map[string]interface{}{
+								"F3q": "value-F3q",
+								"F3p": "value-F3p",
+								"F3r": "value-F3r",
+							},
+						},
+					},
+				},
 			},
 			want: map[string]interface{}{
 				"a": map[string]interface{}{
@@ -146,6 +194,54 @@ func TestSortMapSlice(t *testing.T) {
 					"r": "value-r",
 				},
 				"e": []interface{}{"strawberry", "banana"},
+				"f": []interface{}{
+					[]interface{}{
+						map[string]interface{}{
+							"f1": map[string]interface{}{
+								"f1p": "value-f1p",
+								"f1q": "value-f1q",
+								"f1r": "value-f1r",
+							},
+						},
+						map[string]interface{}{
+							"f2": map[string]interface{}{
+								"f2p": "value-f2p",
+								"f2q": "value-f2q",
+								"f2r": "value-f2r",
+							},
+						},
+						map[string]interface{}{
+							"f3": map[string]interface{}{
+								"f3p": "value-f3p",
+								"f3q": "value-f3q",
+								"f3r": "value-f3r",
+							},
+						},
+					},
+					[]interface{}{
+						map[string]interface{}{
+							"F1": map[string]interface{}{
+								"F1p": "value-F1p",
+								"F1q": "value-F1q",
+								"F1r": "value-F1r",
+							},
+						},
+						map[string]interface{}{
+							"F2": map[string]interface{}{
+								"F2p": "value-F2p",
+								"F2q": "value-F2q",
+								"F2r": "value-F2r",
+							},
+						},
+						map[string]interface{}{
+							"F3": map[string]interface{}{
+								"F3p": "value-F3p",
+								"F3q": "value-F3q",
+								"F3r": "value-F3r",
+							},
+						},
+					},
+				},
 			},
 		},
 		{


### PR DESCRIPTION
With chart values that contain double nested slices, sort will fail.

This patch contains:
- a test that contain a map with double nested slices
- a fix for this bug.

Without this patch, this will fail:

```
{
  "a": [[
    "p": "v-p"
    "r": "v-r"
    "q": v-q"
  ]]
}
```