### PR TITLE
runtime/secrets: remove insecure parameter from TLS funcs

### DIFF
--- a/oci/tests/integration/go.mod
+++ b/oci/tests/integration/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/fluxcd/pkg/cache v0.10.0
 	github.com/fluxcd/pkg/git v0.34.0
 	github.com/fluxcd/pkg/git/gogit v0.37.0
-	github.com/fluxcd/pkg/runtime v0.75.0
+	github.com/fluxcd/pkg/runtime v0.76.0
 	github.com/fluxcd/test-infra/tftestenv v0.0.0-20250626232827-e0ca9c3f8d7b
 	github.com/go-git/go-git/v5 v5.16.2
 	github.com/google/go-containerregistry v0.20.6

--- a/runtime/secrets/reader.go
+++ b/runtime/secrets/reader.go
@@ -34,14 +34,13 @@ import (
 // TLSConfigFromSecret. It supports the same field names and legacy field handling.
 //
 // The targetURL parameter is used to set the ServerName for proper SNI support
-// in virtual hosting environments. The insecure parameter controls whether
-// to skip TLS certificate verification.
-func TLSConfigFromSecretRef(ctx context.Context, c client.Client, secretRef types.NamespacedName, targetURL string, insecure bool) (*tls.Config, error) {
+// in virtual hosting environments.
+func TLSConfigFromSecretRef(ctx context.Context, c client.Client, secretRef types.NamespacedName, targetURL string) (*tls.Config, error) {
 	secret, err := getSecret(ctx, c, secretRef)
 	if err != nil {
 		return nil, err
 	}
-	return TLSConfigFromSecret(ctx, secret, targetURL, insecure)
+	return TLSConfigFromSecret(ctx, secret, targetURL)
 }
 
 // ProxyURLFromSecretRef creates a proxy URL from a Kubernetes secret reference.

--- a/runtime/secrets/secrets.go
+++ b/runtime/secrets/secrets.go
@@ -116,22 +116,13 @@ type authMethodsConfig struct {
 // tlsConfig holds TLS-specific configuration options.
 type tlsConfig struct {
 	targetURL string
-	insecure  bool
 }
 
-// WithTLS configures TLS extraction with complete ServerName and InsecureSkipVerify settings.
-// This ensures the TLS config is immediately usable without additional completion steps.
-//
-// Unlike TLSConfigFromSecret which requires explicit URL parameters to prevent oversight,
-// WithTLS is optional for AuthMethodsFromSecret because:
-//   - AuthMethodsFromSecret typically processes mixed authentication data (Basic+TLS, etc.)
-//   - TLS certificates are commonly stored alone in dedicated secrets (certSecretRef)
-//   - Callers can use AuthMethodsFromSecret without TLS concerns, then apply TLS separately
-func WithTLS(targetURL string, insecure bool) AuthMethodsOption {
+// WithTargetURL configures TLS extraction with the specified target URL for ServerName configuration.
+func WithTargetURL(targetURL string) AuthMethodsOption {
 	return func(cfg *authMethodsConfig) {
 		cfg.tlsConfig = &tlsConfig{
 			targetURL: targetURL,
-			insecure:  insecure,
 		}
 	}
 }


### PR DESCRIPTION
ref: https://github.com/fluxcd/flux2/issues/5433#issuecomment-3127327847