### PR TITLE
runtime/secrets: add WithSystemCertPool for CA handling

### DIFF
--- a/oci/tests/integration/go.mod
+++ b/oci/tests/integration/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/fluxcd/pkg/cache v0.10.0
 	github.com/fluxcd/pkg/git v0.34.0
 	github.com/fluxcd/pkg/git/gogit v0.37.0
-	github.com/fluxcd/pkg/runtime v0.76.0
+	github.com/fluxcd/pkg/runtime v0.77.0
 	github.com/fluxcd/test-infra/tftestenv v0.0.0-20250626232827-e0ca9c3f8d7b
 	github.com/go-git/go-git/v5 v5.16.2
 	github.com/google/go-containerregistry v0.20.6

--- a/runtime/secrets/secrets.go
+++ b/runtime/secrets/secrets.go
@@ -110,20 +110,28 @@ type AuthMethodsOption func(*authMethodsConfig)
 
 // authMethodsConfig holds configuration for AuthMethods extraction.
 type authMethodsConfig struct {
-	tlsConfig *tlsConfig
+	tlsConfigOpts []TLSConfigOption
 }
 
 // tlsConfig holds TLS-specific configuration options.
 type tlsConfig struct {
-	targetURL string
+	targetURL         string
+	useSystemCertPool bool
 }
 
 // WithTargetURL configures TLS extraction with the specified target URL for ServerName configuration.
 func WithTargetURL(targetURL string) AuthMethodsOption {
 	return func(cfg *authMethodsConfig) {
-		cfg.tlsConfig = &tlsConfig{
-			targetURL: targetURL,
-		}
+		cfg.tlsConfigOpts = append(cfg.tlsConfigOpts, func(c *tlsConfig) {
+			c.targetURL = targetURL
+		})
+	}
+}
+
+// WithTLSSystemCertPool enables the use of system certificate pool in addition to user-provided CA certificates.
+func WithTLSSystemCertPool() AuthMethodsOption {
+	return func(cfg *authMethodsConfig) {
+		cfg.tlsConfigOpts = append(cfg.tlsConfigOpts, WithSystemCertPool())
 	}
 }
 


### PR DESCRIPTION
ref: fluxcd/flux2#5433

## Summary
Adds functional options to support different CA certificate handling modes in runtime/secrets package.

## Background
Flux controllers currently use different CA certificate handling approaches:

- **source-controller**: Extend mode (System CAs + user CA) - https://github.com/fluxcd/source-controller/blob/v1.6.0/internal/tls/config.go#L136
- **notification-controller**: Replace mode (user CA only) - https://github.com/fluxcd/notification-controller/blob/v1.6.0/internal/server/event_handlers.go#L388-L392  
- **image-reflector-controller**: Extend mode (System CAs + user CA) - https://github.com/fluxcd/image-reflector-controller/blob/v0.35.0/internal/secret/secret.go#L121-L129

This inconsistency prevents using a unified secrets package across all Flux components.

## Controller Integration Plan
- **source-controller**: Use `WithSystemCertPool()` to maintain existing extend behavior
- **image-reflector-controller**: Use `WithSystemCertPool()` to maintain existing extend behavior  
- **notification-controller**: No changes needed (already uses replace mode)