### PR TITLE
runtime/secrets: add TLSConfigOption support to TLSConfigFromSecretRef

### DIFF
--- a/oci/tests/integration/go.mod
+++ b/oci/tests/integration/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/fluxcd/pkg/cache v0.10.0
 	github.com/fluxcd/pkg/git v0.34.0
 	github.com/fluxcd/pkg/git/gogit v0.37.0
-	github.com/fluxcd/pkg/runtime v0.77.0
+	github.com/fluxcd/pkg/runtime v0.78.0
 	github.com/fluxcd/test-infra/tftestenv v0.0.0-20250626232827-e0ca9c3f8d7b
 	github.com/go-git/go-git/v5 v5.16.2
 	github.com/google/go-containerregistry v0.20.6

--- a/runtime/secrets/reader.go
+++ b/runtime/secrets/reader.go
@@ -35,12 +35,15 @@ import (
 //
 // The targetURL parameter is used to set the ServerName for proper SNI support
 // in virtual hosting environments.
-func TLSConfigFromSecretRef(ctx context.Context, c client.Client, secretRef types.NamespacedName, targetURL string) (*tls.Config, error) {
+//
+// Optional TLSConfigOption parameters can be used to configure CA certificate handling:
+//   - WithSystemCertPool(): Include system certificates in addition to user-provided CA
+func TLSConfigFromSecretRef(ctx context.Context, c client.Client, secretRef types.NamespacedName, targetURL string, opts ...TLSConfigOption) (*tls.Config, error) {
 	secret, err := getSecret(ctx, c, secretRef)
 	if err != nil {
 		return nil, err
 	}
-	return TLSConfigFromSecret(ctx, secret, targetURL)
+	return TLSConfigFromSecret(ctx, secret, targetURL, opts...)
 }
 
 // ProxyURLFromSecretRef creates a proxy URL from a Kubernetes secret reference.


### PR DESCRIPTION
follow-up PR for #995 .

I forgot to update the TLSConfigFromSecretRef function in #995 🙇 