### PR TITLE
git/github: Add support for mTLS to GitHub App transport

### DIFF
--- a/git/github/client.go
+++ b/git/github/client.go
@@ -19,6 +19,7 @@ package github
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -54,6 +55,7 @@ type Client struct {
 	name           string
 	namespace      string
 	operation      string
+	tlsConfig      *tls.Config
 }
 
 // OptFunc enables specifying options for the provider.
@@ -67,6 +69,9 @@ func New(opts ...OptFunc) (*Client, error) {
 	}
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if p.tlsConfig != nil {
+		transport.TLSClientConfig = p.tlsConfig
+	}
 	if p.proxyURL != nil {
 		proxyStr := p.proxyURL.String()
 		proxyConfig := &httpproxy.Config{
@@ -109,6 +114,13 @@ func New(opts ...OptFunc) (*Client, error) {
 	}
 
 	return p, nil
+}
+
+// WithTLSConfig sets the tls config to use with the transport.
+func WithTLSConfig(tlsConfig *tls.Config) OptFunc {
+	return func(p *Client) {
+		p.tlsConfig = tlsConfig
+	}
 }
 
 // WithAppData configures the client using data from a map

--- a/git/gogit/go.mod
+++ b/git/gogit/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/elazarl/goproxy v1.7.2
 	github.com/fluxcd/gitkit v0.6.0
-	github.com/fluxcd/pkg/git v0.34.0
+	github.com/fluxcd/pkg/git v0.35.0
 	github.com/fluxcd/pkg/gittestserver v0.18.0
 	github.com/fluxcd/pkg/ssh v0.20.0
 	github.com/fluxcd/pkg/version v0.9.0

--- a/git/internal/e2e/go.mod
+++ b/git/internal/e2e/go.mod
@@ -13,8 +13,8 @@ replace (
 
 require (
 	github.com/fluxcd/go-git-providers v0.22.0
-	github.com/fluxcd/pkg/git v0.34.0
-	github.com/fluxcd/pkg/git/gogit v0.37.0
+	github.com/fluxcd/pkg/git v0.35.0
+	github.com/fluxcd/pkg/git/gogit v0.38.0
 	github.com/fluxcd/pkg/gittestserver v0.18.0
 	github.com/fluxcd/pkg/ssh v0.20.0
 	github.com/go-git/go-git/v5 v5.16.2

--- a/oci/tests/integration/go.mod
+++ b/oci/tests/integration/go.mod
@@ -20,8 +20,8 @@ require (
 	github.com/fluxcd/pkg/apis/meta v1.18.0
 	github.com/fluxcd/pkg/auth v0.23.0
 	github.com/fluxcd/pkg/cache v0.10.0
-	github.com/fluxcd/pkg/git v0.34.0
-	github.com/fluxcd/pkg/git/gogit v0.37.0
+	github.com/fluxcd/pkg/git v0.35.0
+	github.com/fluxcd/pkg/git/gogit v0.38.0
 	github.com/fluxcd/pkg/runtime v0.78.0
 	github.com/fluxcd/test-infra/tftestenv v0.0.0-20250626232827-e0ca9c3f8d7b
 	github.com/go-git/go-git/v5 v5.16.2


### PR DESCRIPTION
This commit ensures if available, a custom ca.crt is appended to system cert pool and set to the github app transport tls configuration.

closes #998 