### PR TITLE
auth/azure: Add support for custom Azure cloud configurations

### DIFF
--- a/auth/azure/options.go
+++ b/auth/azure/options.go
@@ -17,9 +17,12 @@ limitations under the License.
 package azure
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"regexp"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -65,4 +68,81 @@ func parseCluster(cluster string) (string, string, string, error) {
 	resourceGroup := m[2]
 	clusterName := m[3]
 	return subscriptionID, resourceGroup, clusterName, nil
+}
+
+// envVarAzureEnvironmentFilepath is the environment variable name used to specify the path of the configuration file with custom Azure endpoints.
+const envVarAzureEnvironmentFilepath = "AZURE_ENVIRONMENT_FILEPATH"
+
+// Environment is used to read the Azure environment configuration from a JSON file, it is a subset of the struct defined in
+// https://github.com/kubernetes-sigs/cloud-provider-azure/blob/e68bd888a7616d52f45f39238691f32821884120/pkg/azclient/cloud.go#L152-L185
+// with exact same field names and json annotations.
+// We define this struct here for two reasons:
+//  1. We are not aware of any libraries we could import this struct from.
+//  2. We don't use all the fields defined in the original struct.
+type Environment struct {
+	ContainerRegistryDNSSuffix string `json:"containerRegistryDNSSuffix,omitempty"`
+	ResourceManagerEndpoint    string `json:"resourceManagerEndpoint,omitempty"`
+	TokenAudience              string `json:"tokenAudience,omitempty"`
+}
+
+// hasEnvironmentFile checks if the environment variable AZURE_ENVIRONMENT_FILEPATH is set
+func hasEnvironmentFile() bool {
+	_, ok := os.LookupEnv(envVarAzureEnvironmentFilepath)
+	return ok
+}
+
+// getEnvironmentConfig reads the Azure environment configuration from a JSON file
+// located at the path specified by the environment variable AZURE_ENVIRONMENT_FILEPATH.
+// Call hasEnvironmentFile() before calling this function to ensure the file exists.
+func getEnvironmentConfig() (*Environment, error) {
+	envFilePath := os.Getenv(envVarAzureEnvironmentFilepath)
+	if len(envFilePath) == 0 {
+		return nil, fmt.Errorf("environment variable %s is not set", envVarAzureEnvironmentFilepath)
+	}
+	content, err := os.ReadFile(envFilePath)
+	if err != nil {
+		return nil, err
+	}
+	env := &Environment{}
+	if err = json.Unmarshal(content, env); err != nil {
+		return nil, err
+	}
+
+	return env, nil
+}
+
+// getCloudConfigFromEnvironment reads the Azure environment configuration and returns a cloud.Configuration object.
+func getCloudConfigFromEnvironment() (*cloud.Configuration, error) {
+	env, err := getEnvironmentConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	cloudConf := cloud.Configuration{
+		Services: make(map[cloud.ServiceName]cloud.ServiceConfiguration),
+	}
+	if len(env.ResourceManagerEndpoint) > 0 && len(env.TokenAudience) > 0 {
+		cloudConf.Services[cloud.ResourceManager] = cloud.ServiceConfiguration{
+			Endpoint: env.ResourceManagerEndpoint,
+			Audience: env.TokenAudience,
+		}
+	} else {
+		return nil, fmt.Errorf("resourceManagerEndpoint and tokenAudience must be set in the environment file")
+	}
+
+	return &cloudConf, nil
+}
+
+// getContainerRegistryDNSSuffix reads the Azure environment configuration and returns the container registry DNS suffix.
+func getContainerRegistryDNSSuffix() (string, error) {
+	env, err := getEnvironmentConfig()
+	if err != nil {
+		return "", err
+	}
+
+	if len(env.ContainerRegistryDNSSuffix) == 0 {
+		return "", fmt.Errorf("containerRegistryDNSSuffix must be set in the environment file")
+	}
+
+	return env.ContainerRegistryDNSSuffix, nil
 }


### PR DESCRIPTION
Fixes: https://github.com/fluxcd/pkg/issues/996

Changes include:

- Read Azure endpoint configuration from JSON file.
- JSON file path is configured via AZURE_ENVIRONMENT_FILEPATH env variable.
- Unit tests.

Test behavior:

1. Environment variable specified but file doesn't exist.

```
    - lastTransitionTime: "2025-08-06T18:25:09Z"
      message: 'failed to get credential from azure: failed to get container registry
        suffix from environment file: open /etc/cloud/cloud-config.json: no such file
        or directory'
      observedGeneration: 2
      reason: AuthenticationFailed
      status: "False"
      type: Ready
```

2. Environment variable and filepath exist but does not contain ARM endpoint/Token audience specified.

```
    - lastTransitionTime: "2025-08-06T17:56:55Z"
      message: 'failed to get credential from azure: resourceManagerEndpoint and tokenAudience
        must be set in the environment file'
      observedGeneration: 2
      reason: AuthenticationFailed
      status: "False"
      type: Ready
```

3. Environment variable and file path exist but does not contain containerRegistryDNSSuffix for OCI Repo scenarios.

```
    - lastTransitionTime: "2025-08-06T17:41:45Z"
      message: 'failed to get credential from azure: failed to get container registry
        suffix from environment file: containerRegistryDNSSuffix must be set in the
        environment file'
      observedGeneration: 1
      reason: AuthenticationFailed
      status: "False"
      type: Ready
```

4. containerRegistryDNSSuffix is present but does not match ocirepo artifact repository.

```
    - lastTransitionTime: "2025-08-06T17:40:55Z"
      message: 'failed to get credential from azure: invalid Azure registry: ''dpocitest.azurecr.private''.
        must end with azurecr.private.com'
      observedGeneration: 1
      reason: AuthenticationFailed
      status: "True"
      type: FetchFailed
```

5. Invalid JSON in configuration file

```
    - lastTransitionTime: "2025-08-06T17:46:57Z"
      message: 'failed to get credential from azure: failed to get container registry
        suffix from environment file: invalid character ''"'' after object key:value
        pair'
      observedGeneration: 1
      reason: AuthenticationFailed
      status: "False"
      type: Ready
```

6. Specifying additional fields in JSON does not lead to any errors. 