### PR TITLE
auth: add 10-second timeout to HTTP client for token acquisition

### DIFF
--- a/auth/options_test.go
+++ b/auth/options_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2025 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestOptions_GetHTTPClient(t *testing.T) {
+	tests := []struct {
+		name        string
+		options     Options
+		expectProxy bool
+	}{
+		{
+			name:        "no proxy configured",
+			options:     Options{},
+			expectProxy: false,
+		},
+		{
+			name: "proxy configured",
+			options: Options{
+				ProxyURL: &url.URL{Scheme: "http", Host: "proxy.example.com:8080"},
+			},
+			expectProxy: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := tt.options.GetHTTPClient()
+
+			if client == nil {
+				t.Error("GetHTTPClient() returned nil, expected non-nil client")
+			}
+
+			expectedTimeout := 10 * time.Second
+			if client.Timeout != expectedTimeout {
+				t.Errorf("GetHTTPClient() timeout = %v, want %v", client.Timeout, expectedTimeout)
+			}
+
+			if client.Transport == nil {
+				t.Error("GetHTTPClient() transport is nil")
+				return
+			}
+
+			if tt.expectProxy && tt.options.ProxyURL == nil {
+				t.Error("Expected proxy but ProxyURL is nil")
+			}
+		})
+	}
+}

--- a/oci/tests/integration/go.mod
+++ b/oci/tests/integration/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/elazarl/goproxy v1.7.2
 	github.com/fluxcd/cli-utils v0.36.0-flux.14
 	github.com/fluxcd/pkg/apis/meta v1.18.0
-	github.com/fluxcd/pkg/auth v0.23.0
+	github.com/fluxcd/pkg/auth v0.24.0
 	github.com/fluxcd/pkg/cache v0.10.0
 	github.com/fluxcd/pkg/git v0.35.0
 	github.com/fluxcd/pkg/git/gogit v0.38.0


### PR DESCRIPTION
Following https://github.com/fluxcd/pkg/pull/1000#issuecomment-3160477432, add timeout setting only.

The `GetHTTPClient()` method now always returns an HTTP client with a 10-second timeout to prevent indefinite hangs during token acquisition from cloud provider STS services.