### PR TITLE
auth: Refactor usage of http client from options

### DIFF
--- a/auth/aws/credentials_provider.go
+++ b/auth/aws/credentials_provider.go
@@ -37,9 +37,10 @@ func NewCredentialsProvider(ctx context.Context, opts ...auth.Option) aws.Creden
 
 // Retrieve implements aws.CredentialsProvider.
 // The context is ignored, use the constructor to set the context.
-// This is because some callers of the library pass context.Background()
-// when calling this method (e.g. SOPS), so to ensure we have a real
-// context we pass it in the constructor.
+// This is because the GCP abstraction does not receive a context
+// in the method arguments, so we unfortunately need to standardize
+// the behavior of all providers around this so the usage of this
+// library can be consistent regardless of the provider.
 func (c *credentialsProvider) Retrieve(context.Context) (aws.Credentials, error) {
 	token, err := auth.GetAccessToken(c.ctx, Provider{}, c.opts...)
 	if err != nil {

--- a/auth/azure/token_credential.go
+++ b/auth/azure/token_credential.go
@@ -38,9 +38,10 @@ func NewTokenCredential(ctx context.Context, opts ...auth.Option) azcore.TokenCr
 
 // GetToken implements exported.TokenCredential.
 // The context is ignored, use the constructor to set the context.
-// This is because some callers of the library pass context.Background()
-// when calling this method (e.g. SOPS), so to ensure we have a real
-// context we pass it in the constructor.
+// This is because the GCP abstraction does not receive a context
+// in the method arguments, so we unfortunately need to standardize
+// the behavior of all providers around this so the usage of this
+// library can be consistent regardless of the provider.
 func (t *tokenCredential) GetToken(_ context.Context, tokenOpts policy.TokenRequestOptions) (azcore.AccessToken, error) {
 	opts := t.opts
 	if tokenOpts.Scopes != nil {

--- a/auth/gcp/provider.go
+++ b/auth/gcp/provider.go
@@ -55,9 +55,7 @@ func (p Provider) NewControllerToken(ctx context.Context, opts ...auth.Option) (
 	var o auth.Options
 	o.Apply(opts...)
 
-	if hc := o.GetHTTPClient(); hc != nil {
-		ctx = context.WithValue(ctx, oauth2.HTTPClient, hc)
-	}
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, o.GetHTTPClient())
 
 	src, err := p.impl().DefaultTokenSource(ctx, scopes...)
 	if err != nil {
@@ -145,9 +143,7 @@ func (p Provider) NewTokenForServiceAccount(ctx context.Context, oidcToken strin
 		conf.TokenInfoURL = "https://sts.googleapis.com/v1/introspect"
 	}
 
-	if hc := o.GetHTTPClient(); hc != nil {
-		ctx = context.WithValue(ctx, oauth2.HTTPClient, hc)
-	}
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, o.GetHTTPClient())
 
 	src, err := p.impl().NewTokenSource(ctx, conf)
 	if err != nil {


### PR DESCRIPTION
After #1003, `o.GetHTTPClient()` no longer returns a `nil` client, so the consuming code can rely on that and stop checking if a client is returned.

I'm also updating the comments on the token source abstractions for `aws` and `azure`. The real reason we'll keep them like this is to conform with the unforutnate `gcp` anti-pattern, and not because SOPS passes `context.Background()`. I have landed a PR in SOPS upstream to support a `ctx` as argument in all the providers, so this will stop being true at some point. The real reason is to keep the all three token source abstractions aligned, and `gcp` is unfortunately dictating how it should be. Here's an example of how these three token source abstractions are consistently used: https://github.com/fluxcd/kustomize-controller/blob/60b8f86f490b46110d95079a49544de5580807c5/internal/decryptor/decryptor.go#L335-L363