### PR TITLE
ssa: Add strict field validation option for dry-run

### DIFF
--- a/ssa/manager_diff.go
+++ b/ssa/manager_diff.go
@@ -38,6 +38,12 @@ type DiffOptions struct {
 	// IfNotPresentSelector determines which in-cluster objects are skipped from dry-run apply
 	// based on the matching labels or annotations.
 	IfNotPresentSelector map[string]string `json:"ifNotPresentSelector"`
+
+	// Strict enables strict field validation, making the server reject
+	// requests that contain unknown or duplicate fields.
+	// This requires Kubernetes v1.27+.
+	// https://kubernetes.io/blog/2023/04/24/openapi-v3-field-validation-ga/#server-side-field-validation
+	Strict bool `json:"strict"`
 }
 
 // DefaultDiffOptions returns the default dry-run apply options.
@@ -65,7 +71,7 @@ func (m *ResourceManager) Diff(ctx context.Context, object *unstructured.Unstruc
 	}
 
 	dryRunObject := object.DeepCopy()
-	if err := m.dryRunApply(ctx, dryRunObject); err != nil {
+	if err := m.dryRunApply(ctx, dryRunObject, opts.Strict); err != nil {
 		return nil, nil, nil, errors.NewDryRunErr(err, dryRunObject)
 	}
 


### PR DESCRIPTION
⚠️ The `FieldValidation` option is only available for `client.Patch()`. Given that `client.Apply()` is suppose to replace `client.Patch()`, and the `FieldValidation` is not an option of `client.Apply()`, merging this could put us in a tough situation where we'll not be able to upgrade controller-runtime once they remove the deprecated `client.Patch(ctx, obj, client.Apply, opts)`.