### PR TITLE
runtime/secrets: validate proxy URL scheme and length

### DIFF
--- a/runtime/secrets/converter_test.go
+++ b/runtime/secrets/converter_test.go
@@ -752,6 +752,36 @@ func TestProxyURLFromSecret(t *testing.T) {
 			),
 			errMsg: "secret 'default/proxy-secret': failed to parse proxy address",
 		},
+		{
+			name: "invalid scheme - ftp",
+			secret: testSecret(
+				withName("proxy-secret"),
+				withData(map[string][]byte{
+					secrets.KeyAddress: []byte("ftp://ftp.example.com:21"),
+				}),
+			),
+			errMsg: "secret 'default/proxy-secret': proxy URL must use http or https scheme, got 'ftp'",
+		},
+		{
+			name: "invalid scheme - no scheme",
+			secret: testSecret(
+				withName("proxy-secret"),
+				withData(map[string][]byte{
+					secrets.KeyAddress: []byte("proxy.example.com:8080"),
+				}),
+			),
+			errMsg: "secret 'default/proxy-secret': proxy URL must use http or https scheme",
+		},
+		{
+			name: "URL exceeds maximum length",
+			secret: testSecret(
+				withName("proxy-secret"),
+				withData(map[string][]byte{
+					secrets.KeyAddress: []byte("http://proxy.example.com/" + string(make([]byte, 2049))),
+				}),
+			),
+			errMsg: "secret 'default/proxy-secret': proxy URL exceeds maximum length of 2048 characters",
+		},
 	}
 
 	for _, tt := range tests {

--- a/tests/integration/go.mod
+++ b/tests/integration/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/fluxcd/pkg/cache v0.11.0
 	github.com/fluxcd/pkg/git v0.36.0
 	github.com/fluxcd/pkg/git/gogit v0.40.0
-	github.com/fluxcd/pkg/runtime v0.86.0
+	github.com/fluxcd/pkg/runtime v0.87.0
 	github.com/fluxcd/test-infra/tftestenv v0.0.0-20250626232827-e0ca9c3f8d7b
 	github.com/go-git/go-git/v5 v5.16.2
 	github.com/google/go-containerregistry v0.20.6


### PR DESCRIPTION
ref: https://github.com/fluxcd/notification-controller/pull/1190

While reviewing the negative diff in that PR, I noticed that the `address` key in the secret referenced by proxySecretRef is missing some validations.