### PR TITLE
HelmRelease drift detection generates JSON patch that replaces entire `metadata` instead of `annotations` and `labels`

### DIFF
--- a/ssa/jsondiff/testdata/annotated-configmap.yaml
+++ b/ssa/jsondiff/testdata/annotated-configmap.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "configmap-data"
+  annotations:
+    prev: some-previous-value

--- a/ssa/jsondiff/unstructured.go
+++ b/ssa/jsondiff/unstructured.go
@@ -246,6 +246,14 @@ func copyAnnotationsAndLabels(obj *unstructured.Unstructured) *unstructured.Unst
 		Object: make(map[string]interface{}),
 	}
 
+	// When annotations and labels were missing on the cluster object but present on the desired object, drift
+	//	detection produced an "add /metadata" patch. JSON Patch interprets this as replacing the entire metadata block,
+	//	dropping fields like metadata.name. By copying name, we preserve at least one field in metadata to avoid this.
+	name, ok, _ := unstructured.NestedFieldCopy(obj.Object, "metadata", "name")
+	if ok {
+		_ = unstructured.SetNestedField(c.Object, name, "metadata", "name")
+	}
+
 	annotations, ok, _ := unstructured.NestedFieldCopy(obj.Object, "metadata", "annotations")
 	if ok {
 		_ = unstructured.SetNestedField(c.Object, annotations, "metadata", "annotations")

--- a/ssa/jsondiff/unstructured_test.go
+++ b/ssa/jsondiff/unstructured_test.go
@@ -94,10 +94,8 @@ func TestUnstructuredList(t *testing.T) {
 						DesiredObject: desired[1],
 						ClusterObject: cluster[1],
 						Patch: jsondiff.Patch{
-							{Type: jsondiff.OperationAdd, Path: "/metadata", Value: map[string]interface{}{
-								"annotations": map[string]interface{}{
-									"annotated": "yes",
-								},
+							{Type: jsondiff.OperationAdd, Path: "/metadata/annotations", Value: map[string]interface{}{
+								"annotated": "yes",
 							}},
 						},
 					},
@@ -250,10 +248,8 @@ func TestUnstructuredList(t *testing.T) {
 						DesiredObject: desired[1],
 						ClusterObject: cluster[1],
 						Patch: jsondiff.Patch{
-							{Type: jsondiff.OperationAdd, Path: "/metadata", Value: map[string]interface{}{
-								"labels": map[string]interface{}{
-									"labeled": "change",
-								},
+							{Type: jsondiff.OperationAdd, Path: "/metadata/labels", Value: map[string]interface{}{
+								"labeled": "change",
 							}},
 						},
 					},
@@ -294,10 +290,8 @@ func TestUnstructuredList(t *testing.T) {
 						DesiredObject: desired[1],
 						ClusterObject: cluster[1],
 						Patch: jsondiff.Patch{
-							{Type: jsondiff.OperationAdd, Path: "/metadata", Value: map[string]interface{}{
-								"labels": map[string]interface{}{
-									"labeled": "change",
-								},
+							{Type: jsondiff.OperationAdd, Path: "/metadata/labels", Value: map[string]interface{}{
+								"labeled": "change",
 							}},
 						},
 					},
@@ -503,6 +497,44 @@ func TestUnstructured(t *testing.T) {
 					Patch: jsondiff.Patch{
 						{Type: jsondiff.OperationAdd, Path: "/metadata/annotations/annotated", Value: "yes"},
 						{Type: jsondiff.OperationAdd, Path: "/metadata/labels/labeled", Value: "yes"},
+					},
+				}
+			},
+		},
+		{
+			name: "ConfigMap with added label and annotation",
+			path: "testdata/empty-configmap.yaml",
+			mutateDesired: func(obj *unstructured.Unstructured) {
+				_ = unstructured.SetNestedField(obj.Object, "yes", "metadata", "annotations", "annotated")
+				_ = unstructured.SetNestedField(obj.Object, "yes", "metadata", "labels", "labeled")
+			},
+			want: func(desired, cluster client.Object) *Diff {
+				return &Diff{
+					Type:          DiffTypeUpdate,
+					DesiredObject: desired,
+					ClusterObject: cluster,
+					Patch: jsondiff.Patch{
+						{Type: jsondiff.OperationAdd, Path: "/metadata/annotations", Value: map[string]interface{}{"annotated": "yes"}},
+						{Type: jsondiff.OperationAdd, Path: "/metadata/labels", Value: map[string]interface{}{"labeled": "yes"}},
+					},
+				}
+			},
+		},
+		{
+			name: "Annotated ConfigMap with added label and annotation",
+			path: "testdata/annotated-configmap.yaml",
+			mutateDesired: func(obj *unstructured.Unstructured) {
+				_ = unstructured.SetNestedField(obj.Object, "yes", "metadata", "annotations", "annotated")
+				_ = unstructured.SetNestedField(obj.Object, "yes", "metadata", "labels", "labeled")
+			},
+			want: func(desired, cluster client.Object) *Diff {
+				return &Diff{
+					Type:          DiffTypeUpdate,
+					DesiredObject: desired,
+					ClusterObject: cluster,
+					Patch: jsondiff.Patch{
+						{Type: jsondiff.OperationAdd, Path: "/metadata/annotations/annotated", Value: "yes"},
+						{Type: jsondiff.OperationAdd, Path: "/metadata/labels", Value: map[string]interface{}{"labeled": "yes"}},
 					},
 				}
 			},


### PR DESCRIPTION
### Describe the bug

When drift detection computes a JSON patch for changes limited to `metadata.annotations` and `metadata.labels`, the generated patch targets `/metadata` and replaces the entire `metadata` object, instead of adding only `annotations` and `labels`.

This leads to an incorrect patch that would drop required metadata fields such as `name`, `namespace`, `uid`, etc.

### To Reproduce

Given the following current object in the cluster:

```yaml
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: configmap-data
  namespace: default
```

And the desired object rendered by Helm is:

```yaml
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: configmap-data
  namespace: default
  annotations:
    foo: bar
  labels:
    baz: qux
```

Drift detection produces the following JSON patch:

```json
[
  {
    "value": {
      "annotations": {
        "foo": "bar"
      },
      "labels": {
        "baz": "qux"
      }
    },
    "op": "add",
    "path": "/metadata"
  }
]
```

In JSON Patch semantics, `op: "add"` with `path: "/metadata"` on an existing key replaces the entire `metadata` object. This means every existing field under `metadata` that is not part of this value is effectively removed.

### Expected behavior

The generated JSON patch should target only the changed subtrees under `metadata`, for example:

```json
[
  {
    "value": {
      "foo": "bar"
    },
    "op": "add",
    "path": "/metadata/annotations"
  },
  {
    "value": {
      "baz": "qux"
    },
    "op": "add",
    "path": "/metadata/labels"
  }
]
```

This way, existing fields under `metadata` such as `name`, `namespace`, `uid`, `resourceVersion`, and any other keys are preserved.

### Fix

This PR preserves metadata.name in copyAnnotationsAndLabels and that prevents the resulting metadata to be empty, which solves the issue with wrong JSON patch