### PR TITLE
git: Preserve sparse checkout directories when switching branches

### DIFF
--- a/git/gogit/client.go
+++ b/git/gogit/client.go
@@ -69,15 +69,16 @@ const ClientName = "go-git"
 // Client implements repository.Client.
 type Client struct {
 	*repository.DiscardCloser
-	path                 string
-	repository           *extgogit.Repository
-	authOpts             *git.AuthOptions
-	storer               storage.Storer
-	worktreeFS           billy.Filesystem
-	credentialsOverHTTP  bool
-	useDefaultKnownHosts bool
-	singleBranch         bool
-	proxy                transport.ProxyOptions
+	path                      string
+	repository                *extgogit.Repository
+	authOpts                  *git.AuthOptions
+	storer                    storage.Storer
+	worktreeFS                billy.Filesystem
+	credentialsOverHTTP       bool
+	useDefaultKnownHosts      bool
+	singleBranch              bool
+	proxy                     transport.ProxyOptions
+	sparseCheckoutDirectories []string
 }
 
 var _ repository.Client = &Client{}
@@ -503,8 +504,9 @@ func (g *Client) SwitchBranch(ctx context.Context, branchName string) error {
 	}
 
 	err = wt.Checkout(&extgogit.CheckoutOptions{
-		Branch: refName,
-		Create: create,
+		Branch:                    refName,
+		Create:                    create,
+		SparseCheckoutDirectories: g.sparseCheckoutDirectories,
 	})
 	if err != nil {
 		return fmt.Errorf("could not checkout to branch '%s': %w", branchName, err)

--- a/git/gogit/clone.go
+++ b/git/gogit/clone.go
@@ -135,6 +135,7 @@ func (g *Client) cloneBranch(ctx context.Context, url, branch string, opts repos
 		return nil, fmt.Errorf("unable to resolve commit object for HEAD '%s': %w", head.Hash(), err)
 	}
 	g.repository = repo
+	g.sparseCheckoutDirectories = opts.SparseCheckoutDirectories
 	return buildCommitWithRef(cc, nil, ref)
 }
 
@@ -234,6 +235,7 @@ func (g *Client) cloneTag(ctx context.Context, url, tag string, opts repository.
 	}
 
 	g.repository = repo
+	g.sparseCheckoutDirectories = opts.SparseCheckoutDirectories
 	return buildCommitWithRef(cc, tagObj, ref)
 }
 
@@ -302,6 +304,7 @@ func (g *Client) cloneCommit(ctx context.Context, url, commit string, opts repos
 	}
 
 	g.repository = repo
+	g.sparseCheckoutDirectories = opts.SparseCheckoutDirectories
 	return buildCommitWithRef(cc, nil, cloneOpts.ReferenceName)
 }
 
@@ -435,6 +438,7 @@ func (g *Client) cloneSemVer(ctx context.Context, url, semverTag string, opts re
 	}
 
 	g.repository = repo
+	g.sparseCheckoutDirectories = opts.SparseCheckoutDirectories
 	return buildCommitWithRef(cc, tagObj, tagRef.Name())
 }
 


### PR DESCRIPTION
# Description
## Problem
When cloning a repository with SparseCheckoutDirectories option, the sparse checkout setting was not preserved when calling SwitchBranch(). This caused a full checkout of all files instead of only the specified directories.

## Root Cause
The SwitchBranch() method in client.go did not pass SparseCheckoutDirectories to wt.Checkout(), unlike the clone functions in clone.go which correctly handle this option.

## Solution
- Added sparseCheckoutDirectories field to the Client struct to store the sparse checkout configuration
- Store the sparse checkout directories during clone operations (cloneBranch, cloneTag, cloneCommit, cloneSemVer)
- Pass the stored sparseCheckoutDirectories to wt.Checkout() in SwitchBranch()

## Changes
- git/gogit/client.go: Added sparseCheckoutDirectories field to Client struct and updated SwitchBranch() to use it
- git/gogit/clone.go: Store SparseCheckoutDirectories from clone options into the client
- git/gogit/client_test.go: Added test case to verify sparse checkout is preserved after branch switch