### PR TITLE
ssa: modernize go for variables (forvar)

### DIFF
--- a/ssa/manager_apply.go
+++ b/ssa/manager_apply.go
@@ -154,8 +154,6 @@ func (m *ResourceManager) ApplyAll(ctx context.Context, objects []*unstructured.
 		g, ctx := errgroup.WithContext(ctx)
 		g.SetLimit(m.concurrency)
 		for i, object := range objects {
-			i, object := i, object
-
 			g.Go(func() error {
 				utils.RemoveCABundleFromCRD(object)
 


### PR DESCRIPTION
Today I saw this message in my IDE:

<img width="552" height="102" alt="Screenshot from 2026-01-16 06-01-10" src="https://github.com/user-attachments/assets/17da390b-2d95-4bbf-a7b4-dd70315930ac" />

Then I found this:

https://go.dev/doc/go1.22#language

Starting with Go 1.22, for variables are recreated on every iteration, instead of being created only once in the beginning and then updated.

I have used this variable copy+shadowing many times before inside loops and understand why this was needed before Go 1.22, so I'm glad to learn about this improvement.

This language improvement also eliminates the need for this pattern (which also exists in a few places in our codebase):

```go
for i, x := range someSlice {
  go func(i int, x someType) { // these args are no longer needed
    // do something with i and x
  }(i, x)
}
```