### PR TITLE
Add `--oci-skip-registry-validation` flag for custom registry proxies

### DIFF
--- a/auth/azure/provider.go
+++ b/auth/azure/provider.go
@@ -183,8 +183,17 @@ func (Provider) ParseArtifactRepository(artifactRepository string) (string, erro
 		if strings.HasSuffix(registry, registrySuffix) {
 			return registry, nil
 		}
+		// Skip validation if configured (allows custom registry proxies)
+		if auth.GetOCISkipRegistryValidation() {
+			return registry, nil
+		}
 		return "", fmt.Errorf("invalid Azure registry: '%s'. must end with %s",
 			registry, registrySuffix)
+	}
+
+	// Skip validation if configured (allows custom registry proxies)
+	if auth.GetOCISkipRegistryValidation() {
+		return registry, nil
 	}
 
 	return "", fmt.Errorf("invalid Azure registry: '%s'. must match %s",

--- a/auth/controller_flags.go
+++ b/auth/controller_flags.go
@@ -34,6 +34,11 @@ const (
 	// service account name to be used when .spec.decryption.serviceAccountName is
 	// not specified in the object.
 	ControllerFlagDefaultDecryptionServiceAccount = "default-decryption-service-account"
+
+	// ControllerFlagOCISkipRegistryValidation defines the flag for skipping OCI registry
+	// domain validation for cloud provider authentication. This allows using custom
+	// registry proxies/gateways with workload identity authentication.
+	ControllerFlagOCISkipRegistryValidation = "oci-skip-registry-validation"
 )
 
 var (
@@ -48,6 +53,10 @@ var (
 	// defaultDecryptionServiceAccount stores the default decryption
 	// service account name.
 	defaultDecryptionServiceAccount string
+
+	// ociSkipRegistryValidation stores whether to skip OCI registry
+	// domain validation for cloud provider authentication.
+	ociSkipRegistryValidation bool
 )
 
 // ErrDefaultServiceAccountNotFound is returned when a default service account
@@ -82,6 +91,16 @@ func GetDefaultKubeConfigServiceAccount() string {
 // GetDefaultDecryptionServiceAccount returns the default decryption service account name.
 func GetDefaultDecryptionServiceAccount() string {
 	return defaultDecryptionServiceAccount
+}
+
+// SetOCISkipRegistryValidation sets whether to skip OCI registry domain validation.
+func SetOCISkipRegistryValidation(skip bool) {
+	ociSkipRegistryValidation = skip
+}
+
+// GetOCISkipRegistryValidation returns whether to skip OCI registry domain validation.
+func GetOCISkipRegistryValidation() bool {
+	return ociSkipRegistryValidation
 }
 
 func getDefaultServiceAccount() string {

--- a/auth/controller_flags_test.go
+++ b/auth/controller_flags_test.go
@@ -101,3 +101,29 @@ func TestGetDefaultDecryptionServiceAccount(t *testing.T) {
 		g.Expect(auth.GetDefaultDecryptionServiceAccount()).To(Equal(""))
 	})
 }
+
+func TestSetOCISkipRegistryValidation(t *testing.T) {
+	g := NewWithT(t)
+
+	auth.SetOCISkipRegistryValidation(true)
+	t.Cleanup(func() { auth.SetOCISkipRegistryValidation(false) })
+
+	g.Expect(auth.GetOCISkipRegistryValidation()).To(BeTrue())
+}
+
+func TestGetOCISkipRegistryValidation(t *testing.T) {
+	t.Run("returns true when set", func(t *testing.T) {
+		g := NewWithT(t)
+
+		auth.SetOCISkipRegistryValidation(true)
+		t.Cleanup(func() { auth.SetOCISkipRegistryValidation(false) })
+
+		g.Expect(auth.GetOCISkipRegistryValidation()).To(BeTrue())
+	})
+
+	t.Run("returns false when not set", func(t *testing.T) {
+		g := NewWithT(t)
+
+		g.Expect(auth.GetOCISkipRegistryValidation()).To(BeFalse())
+	})
+}

--- a/auth/gcp/provider.go
+++ b/auth/gcp/provider.go
@@ -174,6 +174,11 @@ func (Provider) ParseArtifactRepository(artifactRepository string) (string, erro
 		return "", err
 	}
 
+	// Skip registry validation if configured (allows custom registry proxies)
+	if auth.GetOCISkipRegistryValidation() {
+		return ProviderName, nil
+	}
+
 	if !registryRegex.MatchString(registry) {
 		return "", fmt.Errorf("invalid GCP registry: '%s'. must match %s",
 			registry, registryPattern)


### PR DESCRIPTION
### Summary

This PR adds support for using custom OCI registry proxies/gateways with cloud provider workload identity authentication by introducing a new controller flag that bypasses registry domain validation.

### Problem

Organizations using custom OCI registry proxies (for security, caching, or compliance reasons) cannot use cloud provider authentication because the auth package validates that registry domains match official patterns (e.g., `*.gcr.io`, `*.dkr.ecr.*.amazonaws.com`, `*.azurecr.io`).

### Solution

Add a new controller flag `--oci-skip-registry-validation` that, when enabled, skips domain validation in `ParseArtifactRepository` for all cloud providers (GCP, AWS, Azure).

### Changes

#### `auth/controller_flags.go`
- Added constant `ControllerFlagOCISkipRegistryValidation`
- Added `ociSkipRegistryValidation` variable
- Added `SetOCISkipRegistryValidation()` and `GetOCISkipRegistryValidation()` functions

#### `auth/gcp/provider.go`
- Modified `ParseArtifactRepository` to skip validation when flag is enabled
- Returns provider name when validation is skipped

#### `auth/aws/provider.go`
- Modified `ParseArtifactRepository` to skip validation when flag is enabled
- Returns provider name when validation is skipped
- Modified `getECRRegionFromRegistryInput` to fall back to `AWS_REGION` env var when provider name is returned

#### `auth/azure/provider.go`
- Modified `ParseArtifactRepository` to skip validation when flag is enabled
- Returns extracted registry host when validation is skipped

### Tests

Added tests for:
- `TestSetOCISkipRegistryValidation`
- `TestGetOCISkipRegistryValidation`
- `TestProvider_ParseArtifactRegistry_SkipValidation` (GCP)
- `TestProvider_ParseArtifactRepository_SkipValidation` (AWS)
- `TestProvider_ParseArtifactRegistry_SkipValidation` (Azure)

### Usage

Controllers using this package can bind the flag:
```go
flag.BoolVar(&ociSkipRegistryValidation, auth.ControllerFlagOCISkipRegistryValidation, false,
    "Skip OCI registry domain validation for cloud provider authentication.")

// After flag.Parse()
if ociSkipRegistryValidation {
    auth.SetOCISkipRegistryValidation(true)
}
```

### Security Considerations

- This flag should only be enabled when using trusted registry proxies
- Cloud provider credentials will be sent to the configured registry endpoint

### Related

- https://github.com/fluxcd/source-controller/issues/1974
