### PR TITLE
auth/aws: support ECR dualstack endpoints

### DIFF
--- a/auth/aws/provider.go
+++ b/auth/aws/provider.go
@@ -185,7 +185,7 @@ func (p Provider) GetAccessTokenOptionsForArtifactRepository(artifactRepository 
 
 // This regex is sourced from the AWS ECR Credential Helper (https://github.com/awslabs/amazon-ecr-credential-helper).
 // It covers both public AWS partitions like amazonaws.com, China partitions like amazonaws.com.cn, and non-public partitions.
-const registryPattern = `([0-9+]*).dkr.ecr(?:-fips)?\.([^/.]*)\.(amazonaws\.com[.cn]*|amazonaws\.eu|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)`
+const registryPattern = `([0-9+]*).dkr[.-]ecr(?:-fips)?\.([^/.]*)\.(amazonaws\.com[.cn]*|amazonaws\.eu|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov|on\.aws)`
 
 const publicECR = "public.ecr.aws"
 

--- a/auth/aws/provider_test.go
+++ b/auth/aws/provider_test.go
@@ -366,6 +366,26 @@ func TestProvider_ParseArtifactRepository(t *testing.T) {
 			expectValid:        true,
 		},
 		{
+			artifactRepository: "557238627320.dkr-ecr.us-west-2.on.aws/foo:v1",
+			expectedRegion:     "us-west-2",
+			expectValid:        true,
+		},
+		{
+			artifactRepository: "557238627320.dkr-ecr.us-west-2.on.aws/foo",
+			expectedRegion:     "us-west-2",
+			expectValid:        true,
+		},
+		{
+			artifactRepository: "557238627320.dkr-ecr.us-west-2.on.aws",
+			expectedRegion:     "us-west-2",
+			expectValid:        true,
+		},
+		{
+			artifactRepository: "557238627320.dkr-ecr.eu-central-1.on.aws/v2/part/part",
+			expectedRegion:     "eu-central-1",
+			expectValid:        true,
+		},
+		{
 			artifactRepository: "gcr.io/foo/bar:baz",
 			expectValid:        false,
 		},


### PR DESCRIPTION
Closes: https://github.com/fluxcd/flux2/issues/5712

Two changes:

1. `.dkr.ecr` -> `.dkr[.-]ecr`: the character class `[.-]` matches either a dot or a hyphen between `dkr` and `ecr`,  supporting both `dkr.ecr` (existing) and `dkr-ecr` (new `on.aws` format)
2. Added `|on\.aws` at the end of the domain group: matches the new `on.aws` TLD