### PR TITLE
runtime/client: disable kubeconfig client-side rate limiting if flowcontrol is supported

### DIFF
--- a/runtime/client/client.go
+++ b/runtime/client/client.go
@@ -75,7 +75,7 @@ func GetConfigOrDie(opts Options) *rest.Config {
 	config := ctrl.GetConfigOrDie()
 	enabled, err := flowcontrol.IsEnabled(context.Background(), config)
 	if err == nil && enabled {
-		// A negative QPS and Burst indicates that the client should not have a rate limiter.
+		// A negative QPS indicates that the client should not have a rate limiter.
 		// Ref: https://github.com/kubernetes/kubernetes/blob/v1.24.0/staging/src/k8s.io/client-go/rest/config.go#L354-L364
 		config.QPS = -1
 		config.Burst = -1

--- a/runtime/client/impersonator.go
+++ b/runtime/client/impersonator.go
@@ -169,7 +169,7 @@ func (i *Impersonator) clientForKubeConfig(ctx context.Context) (rc.Client, *pol
 		return nil, nil, err
 	}
 
-	restConfig = KubeConfig(restConfig, i.kubeConfigOpts)
+	restConfig = KubeConfig(ctx, restConfig, i.kubeConfigOpts)
 	i.setImpersonationConfig(restConfig)
 
 	restMapper, err := NewDynamicRESTMapper(restConfig)


### PR DESCRIPTION
I noticed client-side ratelimiting messages from the kustomization controller for my kustomization that has a kubeconfig configured.

Looking at the code, I saw that this already gets disabled in `GetConfigOrDie` if the server supports APF but not in the codepath where we construct a rest config from a custom kubeconfig, this change fixes that.