### PR TITLE
version: introduce functions for computing distribution versions

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -2,8 +2,11 @@ module github.com/fluxcd/pkg/cmd
 
 go 1.25.0
 
+replace github.com/fluxcd/pkg/version => ../version
+
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
+	github.com/fluxcd/pkg/version v0.12.0
 	github.com/go-git/go-git/v5 v5.16.5
 	github.com/spf13/cobra v1.10.2
 )
@@ -21,7 +24,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
-	github.com/onsi/gomega v1.39.0 // indirect
 	github.com/pjbgf/sha1cd v0.4.0 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect

--- a/version/version.go
+++ b/version/version.go
@@ -17,6 +17,7 @@ limitations under the License.
 package version
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -51,4 +52,68 @@ func Sort(c *semver.Constraints, vs []string) []string {
 		sorted = append(sorted, v.Original())
 	}
 	return sorted
+}
+
+// controllerVersion holds a major and minor version for a controller.
+type controllerVersion struct {
+	major int
+	minor int
+}
+
+// BaselineFlux2Minor is the baseline minor version of the flux2
+// distribution used for computing the minor versions of the
+// controllers in that version. This is Flux v2.7 at the moment.
+// When a new controller is added to the distribution, this
+// baseline MUST be updated, as our release workflows depend
+// on it. Flux v2.7 is, at the moment, the latest version where
+// a controller was added to the distribution: source-watcher.
+const BaselineFlux2Minor = 7
+
+// baselineControllerMinors are the minor versions for
+// the controllers in the baseline version of the flux2
+// distribution, i.e. Flux v2.{baselineFlux2Minor}.
+var baselineControllerMinors = map[string]controllerVersion{
+	// The distribution itself.
+	"flux2": {2, BaselineFlux2Minor},
+
+	// Controllers.
+	"source-controller":           {1, 7},
+	"kustomize-controller":        {1, 7},
+	"helm-controller":             {1, 4},
+	"notification-controller":     {1, 7},
+	"image-reflector-controller":  {1, 0},
+	"image-automation-controller": {1, 0},
+	"source-watcher":              {2, 0},
+}
+
+// ControllerMajor returns the major version for the given controller name.
+func ControllerMajor(controllerName string) (int, error) {
+	cv, ok := baselineControllerMinors[controllerName]
+	if !ok {
+		return 0, fmt.Errorf("unknown controller %q: not in baseline mapping", controllerName)
+	}
+	return cv.major, nil
+}
+
+// ControllerMinorForFluxMinor computes the controller minor
+// version for the given flux2 distribution minor version.
+// This function also supports controllerName="flux2".
+func ControllerMinorForFluxMinor(controllerName string, flux2Minor int) (int, error) {
+	baselineControllerMinor, ok := baselineControllerMinors[controllerName]
+	if !ok {
+		return 0, fmt.Errorf("unknown controller %q: not in baseline mapping", controllerName)
+	}
+	return flux2Minor - BaselineFlux2Minor + baselineControllerMinor.minor, nil
+}
+
+// FluxMinorForControllerMinor computes the flux2 distribution
+// minor version for the given controller minor version.
+// This function also supports controllerName="flux2" and
+// controllerMinor=<any minor version of flux2>.
+func FluxMinorForControllerMinor(controllerName string, controllerMinor int) (int, error) {
+	baselineControllerMinor, ok := baselineControllerMinors[controllerName]
+	if !ok {
+		return 0, fmt.Errorf("unknown controller %q: not in baseline mapping", controllerName)
+	}
+	return controllerMinor - baselineControllerMinor.minor + BaselineFlux2Minor, nil
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -81,3 +81,201 @@ func TestSort(t *testing.T) {
 		"v1.2.0",
 	}))
 }
+
+func TestControllerMajor(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(ControllerMajor("flux2")).To(Equal(2))
+	g.Expect(ControllerMajor("source-controller")).To(Equal(1))
+	g.Expect(ControllerMajor("kustomize-controller")).To(Equal(1))
+	g.Expect(ControllerMajor("helm-controller")).To(Equal(1))
+	g.Expect(ControllerMajor("notification-controller")).To(Equal(1))
+	g.Expect(ControllerMajor("image-reflector-controller")).To(Equal(1))
+	g.Expect(ControllerMajor("image-automation-controller")).To(Equal(1))
+	g.Expect(ControllerMajor("source-watcher")).To(Equal(2))
+
+	_, err := ControllerMajor("unknown-controller")
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestControllerMinorForFluxMinor(t *testing.T) {
+	tests := []struct {
+		name           string
+		controllerName string
+		flux2Minor     int
+		expected       int
+		expectErr      bool
+	}{
+		{
+			name:           "flux2 identity",
+			controllerName: "flux2",
+			flux2Minor:     7,
+			expected:       7,
+		},
+		{
+			name:           "flux2 higher minor",
+			controllerName: "flux2",
+			flux2Minor:     10,
+			expected:       10,
+		},
+		{
+			name:           "source-controller at baseline",
+			controllerName: "source-controller",
+			flux2Minor:     7,
+			expected:       7,
+		},
+		{
+			name:           "source-controller above baseline",
+			controllerName: "source-controller",
+			flux2Minor:     9,
+			expected:       9,
+		},
+		{
+			name:           "helm-controller at baseline",
+			controllerName: "helm-controller",
+			flux2Minor:     7,
+			expected:       4,
+		},
+		{
+			name:           "helm-controller above baseline",
+			controllerName: "helm-controller",
+			flux2Minor:     10,
+			expected:       7,
+		},
+		{
+			name:           "image-reflector-controller at baseline",
+			controllerName: "image-reflector-controller",
+			flux2Minor:     7,
+			expected:       0,
+		},
+		{
+			name:           "image-reflector-controller above baseline",
+			controllerName: "image-reflector-controller",
+			flux2Minor:     8,
+			expected:       1,
+		},
+		{
+			name:           "source-watcher at baseline",
+			controllerName: "source-watcher",
+			flux2Minor:     7,
+			expected:       0,
+		},
+		{
+			name:           "unknown controller",
+			controllerName: "unknown-controller",
+			flux2Minor:     7,
+			expectErr:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result, err := ControllerMinorForFluxMinor(tc.controllerName, tc.flux2Minor)
+			if tc.expectErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(result).To(Equal(tc.expected))
+			}
+		})
+	}
+}
+
+func TestFluxMinorForControllerMinor(t *testing.T) {
+	tests := []struct {
+		name            string
+		controllerName  string
+		controllerMinor int
+		expected        int
+		expectErr       bool
+	}{
+		{
+			name:            "flux2 identity",
+			controllerName:  "flux2",
+			controllerMinor: 7,
+			expected:        7,
+		},
+		{
+			name:            "flux2 higher minor",
+			controllerName:  "flux2",
+			controllerMinor: 10,
+			expected:        10,
+		},
+		{
+			name:            "source-controller at baseline",
+			controllerName:  "source-controller",
+			controllerMinor: 7,
+			expected:        7,
+		},
+		{
+			name:            "source-controller above baseline",
+			controllerName:  "source-controller",
+			controllerMinor: 9,
+			expected:        9,
+		},
+		{
+			name:            "helm-controller at baseline",
+			controllerName:  "helm-controller",
+			controllerMinor: 4,
+			expected:        7,
+		},
+		{
+			name:            "helm-controller above baseline",
+			controllerName:  "helm-controller",
+			controllerMinor: 7,
+			expected:        10,
+		},
+		{
+			name:            "image-reflector-controller at baseline",
+			controllerName:  "image-reflector-controller",
+			controllerMinor: 0,
+			expected:        7,
+		},
+		{
+			name:            "image-reflector-controller above baseline",
+			controllerName:  "image-reflector-controller",
+			controllerMinor: 1,
+			expected:        8,
+		},
+		{
+			name:            "source-watcher at baseline",
+			controllerName:  "source-watcher",
+			controllerMinor: 0,
+			expected:        7,
+		},
+		{
+			name:            "unknown controller",
+			controllerName:  "unknown-controller",
+			controllerMinor: 7,
+			expectErr:       true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result, err := FluxMinorForControllerMinor(tc.controllerName, tc.controllerMinor)
+			if tc.expectErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(result).To(Equal(tc.expected))
+			}
+		})
+	}
+}
+
+func TestControllerMinorFluxMinorRoundTrip(t *testing.T) {
+	g := NewWithT(t)
+
+	for controllerName := range baselineControllerMinors {
+		for flux2Minor := BaselineFlux2Minor; flux2Minor <= BaselineFlux2Minor+5; flux2Minor++ {
+			controllerMinor, err := ControllerMinorForFluxMinor(controllerName, flux2Minor)
+			g.Expect(err).NotTo(HaveOccurred(), "controller: %s, flux2Minor: %d", controllerName, flux2Minor)
+
+			roundTripped, err := FluxMinorForControllerMinor(controllerName, controllerMinor)
+			g.Expect(err).NotTo(HaveOccurred(), "controller: %s, controllerMinor: %d", controllerName, controllerMinor)
+			g.Expect(roundTripped).To(Equal(flux2Minor), "round-trip failed for controller: %s, flux2Minor: %d", controllerName, flux2Minor)
+		}
+	}
+}


### PR DESCRIPTION
Introducing `version.ControllerMinorForFluxMinor()` and `version.FluxMinorForControllerMinor()`.