### PR TITLE
auth/azure: use ACR-scoped token for registry authentication

### DIFF
--- a/auth/azure/provider.go
+++ b/auth/azure/provider.go
@@ -150,7 +150,14 @@ func (p Provider) GetAccessTokenOptionsForArtifactRepository(artifactRepository 
 	default:
 		conf = &cloud.AzurePublic
 	}
-	acrScope := conf.Services[cloud.ResourceManager].Endpoint + "/.default"
+
+	var acrScope string
+	if acrService, ok := conf.Services[azcontainerregistry.ServiceName]; ok {
+		acrScope = acrService.Audience + "/.default"
+	} else {
+		// Fallback for custom environments that don't define ACR service config.
+		acrScope = conf.Services[cloud.ResourceManager].Endpoint + "/.default"
+	}
 
 	return []auth.Option{auth.WithScopes(acrScope)}, nil
 }

--- a/auth/azure/provider_test.go
+++ b/auth/azure/provider_test.go
@@ -192,15 +192,15 @@ func TestProvider_NewArtifactRegistryCredentials(t *testing.T) {
 	}{
 		{
 			registry:      "foo.azurecr.io",
-			expectedScope: "https://management.azure.com/.default",
+			expectedScope: "https://containerregistry.azure.net/.default",
 		},
 		{
 			registry:      "foo.azurecr.cn",
-			expectedScope: "https://management.chinacloudapi.cn/.default",
+			expectedScope: "https://containerregistry.azure.net/.default",
 		},
 		{
 			registry:      "foo.azurecr.us",
-			expectedScope: "https://management.usgovcloudapi.net/.default",
+			expectedScope: "https://containerregistry.azure.net/.default",
 		},
 	} {
 		t.Run(tt.registry, func(t *testing.T) {
@@ -323,22 +323,22 @@ func TestProvider_GetAccessTokenOptionsForArtifactRepository(t *testing.T) {
 		{
 			name:               "Azure Public Cloud",
 			artifactRepository: "myregistry.azurecr.io",
-			expectedScope:      "https://management.azure.com/.default",
+			expectedScope:      "https://containerregistry.azure.net/.default",
 		},
 		{
 			name:               "Azure China Cloud",
 			artifactRepository: "myregistry.azurecr.cn",
-			expectedScope:      "https://management.chinacloudapi.cn/.default",
+			expectedScope:      "https://containerregistry.azure.net/.default",
 		},
 		{
 			name:               "Azure Government Cloud",
 			artifactRepository: "myregistry.azurecr.us",
-			expectedScope:      "https://management.usgovcloudapi.net/.default",
+			expectedScope:      "https://containerregistry.azure.net/.default",
 		},
 		{
 			name:               "Invalid registry",
 			artifactRepository: "myregistry.invalid.io",
-			expectedScope:      "https://management.azure.com/.default",
+			expectedScope:      "https://containerregistry.azure.net/.default",
 		},
 		{
 			name:               "Custom environment file",


### PR DESCRIPTION
## Summary
This PR fixes Azure Container Registry authentication for workload identity scenarios by requesting an ACR-scoped token instead of an ARM-scoped token.

## Problem
The token audience was derived from ARM (`https://management.azure.com/.default`), which is rejected when ACR `authentication-as-arm` is disabled (recommended by Microsoft for least-privilege security).

## Change
- Switch token scope to `https://containerregistry.azure.net/.default`.
- ~Populate ACR service config in cloud environment setup so custom environment file paths also resolve the correct ACR scope.~

## Impact
Prevents unauthorized errors against ACR when ARM audience authentication is disabled.

## Notes
First contribution from me to this repository. I used AI assistance to help construct the fix, and I manually reviewed and tested the final changes.