### PR TITLE
ssa: fix WaitForSetWithContext waiting until timeout if set is empty

### DIFF
--- a/ssa/manager_wait.go
+++ b/ssa/manager_wait.go
@@ -86,6 +86,10 @@ func (m *ResourceManager) WaitForSet(set object.ObjMetadataSet, opts WaitOptions
 // WaitForSetWithContext checks if the given ObjMetadataSet has been fully reconciled.
 // The provided context can be used to cancel the operation.
 func (m *ResourceManager) WaitForSetWithContext(ctx context.Context, set object.ObjMetadataSet, opts WaitOptions) error {
+	if len(set) == 0 {
+		return nil
+	}
+
 	statusCollector := collector.NewResourceStatusCollector(set)
 	canceledInternally := false
 


### PR DESCRIPTION
Before this fix, if ResourceManager.WaitForSetWithContext is called with an empty set it will wait for the duration`ReconcileTimeout` is set to and return without an error.

fix: just return early if the set is empty

I judged this to be too basic of a change to be worth adding tests for, but let me know if you think otherwise.