### PR TITLE
envsubst: enforce strict mode for transformation operators

### DIFF
--- a/envsubst/eval_test.go
+++ b/envsubst/eval_test.go
@@ -292,6 +292,28 @@ func TestExpandStrict(t *testing.T) {
 			output:  "default",
 			wantErr: nil,
 		},
+		// missing with a transformation operator should still error.
+		// Regression coverage for fluxcd/flux2#5836.
+		{params: map[string]string{}, input: "${#missing}", wantErr: errVarNotSet},
+		{params: map[string]string{}, input: "${missing^}", wantErr: errVarNotSet},
+		{params: map[string]string{}, input: "${missing^^}", wantErr: errVarNotSet},
+		{params: map[string]string{}, input: "${missing,}", wantErr: errVarNotSet},
+		{params: map[string]string{}, input: "${missing,,}", wantErr: errVarNotSet},
+		{params: map[string]string{}, input: "${missing:0}", wantErr: errVarNotSet},
+		{params: map[string]string{}, input: "${missing:0:10}", wantErr: errVarNotSet},
+		{params: map[string]string{}, input: "${missing/pattern/replacement}", wantErr: errVarNotSet},
+		{params: map[string]string{}, input: "${missing//pattern/replacement}", wantErr: errVarNotSet},
+		{params: map[string]string{}, input: "${missing/#pattern/replacement}", wantErr: errVarNotSet},
+		{params: map[string]string{}, input: "${missing/%pattern/replacement}", wantErr: errVarNotSet},
+		{params: map[string]string{}, input: "${missing#pattern}", wantErr: errVarNotSet},
+		{params: map[string]string{}, input: "${missing##pattern}", wantErr: errVarNotSet},
+		{params: map[string]string{}, input: "${missing%pattern}", wantErr: errVarNotSet},
+		{params: map[string]string{}, input: "${missing%%pattern}", wantErr: errVarNotSet},
+		// Default-providing operators must still succeed when the var is
+		// missing — exclusion must not regress these cases.
+		{params: map[string]string{}, input: "${missing:-fallback}", output: "fallback"},
+		{params: map[string]string{}, input: "${missing:=assigned}", output: "assigned"},
+		{params: map[string]string{}, input: "${missing=assigned}", output: "assigned"},
 	}
 
 	for _, expr := range expressions {

--- a/envsubst/template.go
+++ b/envsubst/template.go
@@ -131,13 +131,32 @@ func (t *Template) evalFunc(s *state, node *parse.FuncNode) error {
 
 	v, exists := s.mapper(node.Param)
 
-	if node.Name == "" && !exists {
+	// A variable is missing in strict mode (mapper returns exists=false) when
+	// it is referenced bare (${var}) or with a transformation operator that
+	// reads the value (e.g. ${#var}, ${var^^}, ${var/foo/bar}). Default-
+	// providing operators (-, :-, +, :+, =, :=, ?, :?) intentionally handle
+	// the unset case, so leave them alone.
+	if !exists && !isDefaultOp(node.Name) {
 		return fmt.Errorf("%w: %q", errVarNotSet, node.Param)
 	}
 	fn := lookupFunc(node.Name, len(args))
 
 	_, err := io.WriteString(s.writer, fn(v, args...))
 	return err
+}
+
+// isDefaultOp reports whether name is a POSIX-style parameter expansion
+// operator that tolerates an unset variable and supplies its own fallback
+// value (e.g. ${var:-default}, ${var:+set}, ${var:=assign}, ${var:?err}).
+// These operators are excluded from the strict-mode "variable not set"
+// check because the unset case is part of their contract.
+func isDefaultOp(name string) bool {
+	switch name {
+	case "-", "+", "=", "?",
+		":-", ":+", ":=", ":?":
+		return true
+	}
+	return false
 }
 
 // lookupFunc returns the parameters substitution function by name. If the


### PR DESCRIPTION
## Summary

The strict-mode check in `envsubst.evalFunc` only fired for bare `\${var}` references:

```go
if node.Name == "" && !exists {
    return fmt.Errorf("%w: %q", errVarNotSet, node.Param)
}
```

Any transformation operator (`\${#var}`, `\${var^^}`, `\${var/foo/bar}`, etc.) short-circuited that guard — `node.Name` is non-empty — and fell through to the default substitution, silently treating the variable as an empty string. That defeats the point of `--strict` for any template that uses bash-style substitutions, as reported in fluxcd/flux2#5836.

Split the unset-variable check: error when the variable is missing *unless* the operator is one of the default-providing family (`-`, `:-`, `+`, `:+`, `=`, `:=`, `?`, `:?`) whose contract is to handle the unset case. Extracted into `isDefaultOp` so the set is explicit.

Fixes fluxcd/flux2#5836

## Test plan

- [x] `go test ./...`
- [x] `gofmt` clean
- [x] Added strict-mode regression cases for `\${#missing}`, `\${missing^}`, `\${missing^^}`, `\${missing,}`, `\${missing,,}`, `\${missing:0}`, `\${missing:0:10}`, `\${missing/pattern/replacement}` and the `//`, `/#`, `/%` variants — all must now return `errVarNotSet`.
- [x] Verified `\${missing:-fallback}` still expands to `fallback` without error.

Signed-off-by: Ali <alliasgher123@gmail.com>