### PR TITLE
runtime/cel: fix requiring int `.status.observedGeneration`

### DIFF
--- a/runtime/cel/status_evaluator.go
+++ b/runtime/cel/status_evaluator.go
@@ -88,18 +88,14 @@ func (s *StatusEvaluator) Evaluate(ctx context.Context, u *unstructured.Unstruct
 	unsObj := u.UnstructuredContent()
 
 	// Check if the object has the field status.observedGeneration
-	// and if it differs from metadata.generation, in which case we
-	// return status InProgress.
+	// as an int64 and if it differs from metadata.generation, in which
+	// case we return status InProgress. If the field is not an int64
+	// (e.g. some CRDs type it as a string), we skip this built-in check
+	// and rely solely on the user-provided CEL expressions.
 	observedGeneration, ok, err := unstructured.NestedInt64(unsObj, "status", "observedGeneration")
-	if err != nil {
-		return nil, err
-	}
-	if ok {
+	if err == nil && ok {
 		generation, ok, err := unstructured.NestedInt64(unsObj, "metadata", "generation")
-		if err != nil {
-			return nil, err
-		}
-		if ok && observedGeneration != generation {
+		if err == nil && ok && observedGeneration != generation {
 			return &status.Result{Status: status.InProgressStatus}, nil
 		}
 	}

--- a/runtime/cel/status_evaluator_test.go
+++ b/runtime/cel/status_evaluator_test.go
@@ -314,6 +314,36 @@ func TestStatusEvaluator_Evaluate(t *testing.T) {
 			},
 			result: status.Result{Status: status.InProgressStatus},
 		},
+		{
+			name: "object with non-int64 status.observedGeneration is tolerated and delegated to CEL expressions",
+			exprs: kustomize.HealthCheckExpressions{
+				Current: "status.observedGeneration == '2'",
+			},
+			obj: map[string]any{
+				"metadata": map[string]any{
+					"generation": int64(2),
+				},
+				"status": map[string]any{
+					"observedGeneration": "2",
+				},
+			},
+			result: status.Result{Status: status.CurrentStatus},
+		},
+		{
+			name: "object with non-int64 metadata.generation is tolerated and delegated to CEL expressions",
+			exprs: kustomize.HealthCheckExpressions{
+				Current: "metadata.generation == '2'",
+			},
+			obj: map[string]any{
+				"metadata": map[string]any{
+					"generation": "2",
+				},
+				"status": map[string]any{
+					"observedGeneration": int64(2),
+				},
+			},
+			result: status.Result{Status: status.CurrentStatus},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
Fixes: https://github.com/fluxcd/flux2/issues/5862