### PR TITLE
auth: refactor git credentials

### DIFF
--- a/auth/aws/provider.go
+++ b/auth/aws/provider.go
@@ -45,8 +45,20 @@ import (
 
 // ProviderName is the name of the AWS authentication provider.
 const (
-	ProviderName                       = "aws"
+	ProviderName = "aws"
+
+	// codeCommitCanonicalTimestampFormat is the SigV4 canonical timestamp
+	// format (ISO 8601 basic, no separators, no fractional seconds) embedded
+	// in the CodeCommit Git password and used as the canonical request time
+	// during signing. The trailing 'Z' is appended separately by the caller.
 	codeCommitCanonicalTimestampFormat = "20060102T150405"
+
+	// codeCommitSignatureValidity is the server-side replay window for
+	// SigV4-signed CodeCommit Git requests. AWS documents that the password
+	// generated for HTTPS access to a CodeCommit repository stops working
+	// after about 15 minutes:
+	// https://docs.aws.amazon.com/codecommit/latest/userguide/troubleshooting-ch.html
+	codeCommitSignatureValidity = 15 * time.Minute
 )
 
 // Provider implements the auth.Provider interface for AWS authentication.
@@ -398,24 +410,11 @@ func (p Provider) NewRESTConfig(ctx context.Context, accessTokens []auth.Token,
 	}, nil
 }
 
-func (p Provider) impl() Implementation {
-	if p.Implementation == nil {
-		return implementation{}
-	}
-	return p.Implementation
-}
-
-type signerHeaderHostOnly struct{}
-
-func (signerHeaderHostOnly) IsSigned(h string) bool {
-	return h == "host"
-}
-
-// GetRegionFromCodeCommitURL extracts the AWS region from a CodeCommit HTTPS
+// getRegionFromCodeCommitURL extracts the AWS region from a CodeCommit HTTPS
 // git URL (e.g. https://git-codecommit.us-east-1.amazonaws.com/...).
 // Returns an error if the URL is nil, not HTTPS, or not a valid CodeCommit URL.
 // https://docs.aws.amazon.com/codecommit/latest/userguide/regions.html#regions-git
-func GetRegionFromCodeCommitURL(gitURL *url.URL) (string, error) {
+func getRegionFromCodeCommitURL(gitURL *url.URL) (string, error) {
 	if gitURL == nil {
 		return "", fmt.Errorf("Git URL must be specified for AWS CodeCommit authentication")
 	}
@@ -431,28 +430,51 @@ func GetRegionFromCodeCommitURL(gitURL *url.URL) (string, error) {
 	return urlSplit[1], nil
 }
 
-// NewCodeCommitGitToken returns HTTPS Git credentials for AWS CodeCommit.
-func (Provider) NewCodeCommitGitCredentials(_ context.Context, accessTokens []auth.Token, opts ...auth.Option) (string, string, error) {
-	var o auth.Options
-	o.Apply(opts...)
-
-	gitURL := o.GitURL
-	region, err := GetRegionFromCodeCommitURL(gitURL)
+// GetAccessTokenOptionsForGitRepository implements auth.GitCredentialsProvider.
+// AWS requires a region for obtaining access credentials. To avoid requiring
+// callers to pass a region in addition to the CodeCommit URL, we extract the
+// region from the URL and inject it as STSRegion so that object-level workload
+// identity (which requires an explicit region) works without extra config.
+func (Provider) GetAccessTokenOptionsForGitRepository(gitURL *url.URL) ([]auth.Option, error) {
+	region, err := getRegionFromCodeCommitURL(gitURL)
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
-	if len(accessTokens) == 0 {
-		return "", "", fmt.Errorf("AWS access token is required for region %q", region)
+	return []auth.Option{auth.WithSTSRegion(region)}, nil
+}
+
+// ParseGitRepository implements auth.GitCredentialsProvider.
+// It validates the URL is a CodeCommit URL and returns the URL string so that
+// it is included in the cache key: CodeCommit credentials are a SigV4 signature
+// over the request URL, so distinct URLs must map to distinct cache entries.
+func (Provider) ParseGitRepository(gitURL *url.URL) (string, error) {
+	if _, err := getRegionFromCodeCommitURL(gitURL); err != nil {
+		return "", err
+	}
+	return gitURL.String(), nil
+}
+
+// NewGitCredentials implements auth.GitCredentialsProvider.
+func (Provider) NewGitCredentials(_ context.Context, gitInput string,
+	accessToken auth.Token, _ ...auth.Option) (*auth.GitCredentials, error) {
+
+	gitURL, err := url.Parse(gitInput)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CodeCommit URL: %w", err)
+	}
+	region, err := getRegionFromCodeCommitURL(gitURL)
+	if err != nil {
+		return nil, err
 	}
 
-	creds, ok := accessTokens[0].(*Credentials)
+	creds, ok := accessToken.(*Credentials)
 	if !ok {
-		return "", "", fmt.Errorf("failed to cast token to AWS token: %T", accessTokens[0])
+		return nil, fmt.Errorf("failed to cast token to AWS token: %T", accessToken)
 	}
 
 	req, err := http.NewRequest("GIT", gitURL.String(), nil)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to build CodeCommit signing request: %w", err)
+		return nil, fmt.Errorf("failed to build CodeCommit signing request: %w", err)
 	}
 	req.Host = gitURL.Host
 
@@ -477,15 +499,39 @@ func (Provider) NewCodeCommitGitCredentials(_ context.Context, accessTokens []au
 	}
 
 	if err := signer.SignRequest(signInput); err != nil {
-		return "", "", fmt.Errorf("failed to sign request: %w", err)
+		return nil, fmt.Errorf("failed to sign request: %w", err)
 	}
 
 	authHeader := req.Header.Get("Authorization")
-	sigStart := strings.Index(authHeader, "Signature=")
-	signature := authHeader[sigStart+10:]
+	_, after, _ := strings.Cut(authHeader, "Signature=")
+	signature := after
 
 	username := strings.Join([]string{*creds.AccessKeyId, *creds.SessionToken}, "%")
 	password := signingTime.Format(codeCommitCanonicalTimestampFormat) + "Z" + signature
 
-	return username, password, nil
+	// The signed password is invalid once either the server's replay window
+	// elapses or the underlying credentials expire, whichever comes first.
+	expiresAt := signingTime.Add(codeCommitSignatureValidity)
+	if creds.Expiration.Before(expiresAt) {
+		expiresAt = *creds.Expiration
+	}
+
+	return &auth.GitCredentials{
+		Username:  username,
+		Password:  password,
+		ExpiresAt: expiresAt,
+	}, nil
+}
+
+func (p Provider) impl() Implementation {
+	if p.Implementation == nil {
+		return implementation{}
+	}
+	return p.Implementation
+}
+
+type signerHeaderHostOnly struct{}
+
+func (signerHeaderHostOnly) IsSigned(h string) bool {
+	return h == "host"
 }

--- a/auth/aws/provider_test.go
+++ b/auth/aws/provider_test.go
@@ -538,7 +538,7 @@ func TestProvider_GetAccessTokenOptionsForCluster(t *testing.T) {
 	g.Expect(o.STSRegion).To(Equal("us-west-2"))
 }
 
-func TestGetRegionFromCodeCommitURL(t *testing.T) {
+func TestProvider_GetAccessTokenOptionsForGitRepository(t *testing.T) {
 	for _, tt := range []struct {
 		name           string
 		gitURL         string
@@ -583,19 +583,80 @@ func TestGetRegionFromCodeCommitURL(t *testing.T) {
 				parsedURL, err = url.Parse(tt.gitURL)
 				g.Expect(err).NotTo(HaveOccurred())
 			}
-			region, err := aws.GetRegionFromCodeCommitURL(parsedURL)
+			atOpts, err := aws.Provider{}.GetAccessTokenOptionsForGitRepository(parsedURL)
 			if tt.err != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(Equal(tt.err))
+				g.Expect(atOpts).To(BeNil())
 			} else {
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(region).To(Equal(tt.expectedRegion))
+				var o auth.Options
+				o.Apply(atOpts...)
+				g.Expect(o.STSRegion).To(Equal(tt.expectedRegion))
 			}
 		})
 	}
 }
 
-func TestProvider_NewCodeCommitGitCredentials(t *testing.T) {
+func TestProvider_ParseGitRepository(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		gitURL         string
+		expectedRegion string
+		err            string
+	}{
+		{
+			name:           "valid CodeCommit URL",
+			gitURL:         "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/test-repo",
+			expectedRegion: "us-east-1",
+		},
+		{
+			name:           "valid CodeCommit FIPS URL",
+			gitURL:         "https://git-codecommit-fips.us-west-2.amazonaws.com/v1/repos/test-repo",
+			expectedRegion: "us-west-2",
+		},
+		{
+			name:           "valid CodeCommit China URL",
+			gitURL:         "https://git-codecommit.cn-north-1.amazonaws.com.cn/v1/repos/test-repo",
+			expectedRegion: "cn-north-1",
+		},
+		{
+			name: "nil URL",
+			err:  "Git URL must be specified for AWS CodeCommit authentication",
+		},
+		{
+			name:   "non-HTTPS URL",
+			gitURL: "http://git-codecommit.us-east-1.amazonaws.com/v1/repos/test-repo",
+			err:    "AWS CodeCommit authentication requires an HTTPS Git URL",
+		},
+		{
+			name:   "invalid CodeCommit URL",
+			gitURL: "https://github.com/org/repo",
+			err:    "invalid AWS CodeCommit Git URL: github.com",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			var parsedURL *url.URL
+			if tt.gitURL != "" {
+				var err error
+				parsedURL, err = url.Parse(tt.gitURL)
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			gitInput, err := aws.Provider{}.ParseGitRepository(parsedURL)
+			if tt.err != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(Equal(tt.err))
+				g.Expect(gitInput).To(BeEmpty())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(gitInput).To(Equal(tt.gitURL))
+			}
+		})
+	}
+}
+
+func TestProvider_NewGitCredentials(t *testing.T) {
 	invalidToken := &generic.Token{Token: "invalid", ExpiresAt: time.Now().Add(time.Hour)}
 	proxyUrl := url.URL{Scheme: "http", Host: "proxy.example.com"}
 	awsRegion := "us-east-1"
@@ -603,7 +664,7 @@ func TestProvider_NewCodeCommitGitCredentials(t *testing.T) {
 		name             string
 		gitURL           string
 		getAccessToken   bool
-		accessTokens     []auth.Token
+		accessToken      auth.Token
 		expectedUsername string
 		err              string
 	}{
@@ -626,34 +687,10 @@ func TestProvider_NewCodeCommitGitCredentials(t *testing.T) {
 			expectedUsername: "access-key-id%session-token",
 		},
 		{
-			name:           "missing Git URL",
-			getAccessToken: true,
-			err:            "Git URL must be specified for AWS CodeCommit authentication",
-		},
-		{
-			name:           "non HTTPS URL",
-			gitURL:         "http://git-codecommit.us-east-1.amazonaws.com/v1/repos/test-repo",
-			getAccessToken: true,
-			err:            "AWS CodeCommit authentication requires an HTTPS Git URL",
-		},
-		{
-			name:           "invalid CodeCommit URL",
-			gitURL:         "https://github.com/org/repo",
-			getAccessToken: true,
-			err:            "invalid AWS CodeCommit Git URL: github.com",
-		},
-		{
-			name:           "missing access token",
-			gitURL:         "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/test-repo",
-			getAccessToken: false,
-			accessTokens:   []auth.Token{},
-			err:            `AWS access token is required for region "us-east-1"`,
-		},
-		{
 			name:           "invalid access token type",
 			gitURL:         "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/test-repo",
 			getAccessToken: false,
-			accessTokens:   []auth.Token{invalidToken},
+			accessToken:    invalidToken,
 			err:            "failed to cast token to AWS token: *generic.Token",
 		},
 	} {
@@ -667,35 +704,27 @@ func TestProvider_NewCodeCommitGitCredentials(t *testing.T) {
 				returnCreds: awssdk.Credentials{AccessKeyID: "access-key-id", SecretAccessKey: "secret-access-key", SessionToken: "session-token"},
 			}
 
-			opts := []auth.Option{}
-			if tt.gitURL != "" {
-				gitURL, err := url.Parse(tt.gitURL)
-				g.Expect(err).NotTo(HaveOccurred())
-				opts = append(opts, auth.WithGitURL(*gitURL))
-			}
-
 			provider := aws.Provider{Implementation: impl}
-			accessTokens := tt.accessTokens
+			accessToken := tt.accessToken
 			if tt.getAccessToken {
-				accessToken, err := auth.GetAccessToken(t.Context(), provider,
+				var err error
+				accessToken, err = auth.GetAccessToken(t.Context(), provider,
 					auth.WithSTSRegion(awsRegion),
 					auth.WithProxyURL(proxyUrl),
 				)
 				g.Expect(err).NotTo(HaveOccurred())
-				accessTokens = []auth.Token{accessToken}
 			}
 
-			username, password, err := provider.NewCodeCommitGitCredentials(t.Context(), accessTokens, opts...)
+			creds, err := provider.NewGitCredentials(t.Context(), tt.gitURL, accessToken)
 
 			if tt.err == "" {
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(username).To(Equal(tt.expectedUsername))
-				g.Expect(password).To(MatchRegexp(`^[0-9]{8}T[0-9]{6}Z[0-9a-f]{64}$`))
+				g.Expect(creds.Username).To(Equal(tt.expectedUsername))
+				g.Expect(creds.Password).To(MatchRegexp(`^[0-9]{8}T[0-9]{6}Z[0-9a-f]{64}$`))
 			} else {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(Equal(tt.err))
-				g.Expect(username).To(BeEmpty())
-				g.Expect(password).To(BeEmpty())
+				g.Expect(creds).To(BeNil())
 			}
 		})
 	}

--- a/auth/azure/provider.go
+++ b/auth/azure/provider.go
@@ -19,6 +19,7 @@ package azure
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -391,6 +392,34 @@ func (p Provider) NewRESTConfig(ctx context.Context, accessTokens []auth.Token,
 		BearerToken: aksToken.Token,
 		CAData:      caData,
 		ExpiresAt:   aksToken.ExpiresOn,
+	}, nil
+}
+
+// GetAccessTokenOptionsForGitRepository implements auth.GitCredentialsProvider.
+// Azure DevOps requires the DevOps scope for obtaining an access token that
+// can be used as a bearer token against Azure Repos.
+func (Provider) GetAccessTokenOptionsForGitRepository(*url.URL) ([]auth.Option, error) {
+	return []auth.Option{auth.WithScopes(ScopeDevOps)}, nil
+}
+
+// ParseGitRepository implements auth.GitCredentialsProvider.
+// Azure DevOps access tokens are not bound to the Git repository URL,
+// so this returns a constant input that does not affect the cache key.
+func (Provider) ParseGitRepository(*url.URL) (string, error) {
+	return "azure-devops", nil
+}
+
+// NewGitCredentials implements auth.GitCredentialsProvider.
+func (Provider) NewGitCredentials(_ context.Context, _ string,
+	accessToken auth.Token, _ ...auth.Option) (*auth.GitCredentials, error) {
+
+	token, ok := accessToken.(*Token)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast token to Azure token: %T", accessToken)
+	}
+	return &auth.GitCredentials{
+		BearerToken: token.Token,
+		ExpiresAt:   token.ExpiresOn,
 	}, nil
 }
 

--- a/auth/azure/provider_test.go
+++ b/auth/azure/provider_test.go
@@ -685,6 +685,101 @@ func TestProvider_GetAccessTokenOptionsForCluster(t *testing.T) {
 	})
 }
 
+func TestProvider_GetAccessTokenOptionsForGitRepository(t *testing.T) {
+	g := NewWithT(t)
+
+	gitURL, err := url.Parse("https://dev.azure.com/myorg/myproject/_git/myrepo")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	opts, err := azure.Provider{}.GetAccessTokenOptionsForGitRepository(gitURL)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(opts).To(HaveLen(1))
+
+	var o auth.Options
+	o.Apply(opts...)
+	g.Expect(o.Scopes).To(Equal([]string{azure.ScopeDevOps}))
+
+	// The URL is not used to compute the scope, so a nil URL must also work.
+	opts, err = azure.Provider{}.GetAccessTokenOptionsForGitRepository(nil)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(opts).To(HaveLen(1))
+	o = auth.Options{}
+	o.Apply(opts...)
+	g.Expect(o.Scopes).To(Equal([]string{azure.ScopeDevOps}))
+}
+
+func TestProvider_ParseGitRepository(t *testing.T) {
+	g := NewWithT(t)
+
+	// Azure DevOps access tokens are not bound to the repository URL, so
+	// ParseGitRepository must return a stable input regardless of the URL.
+	for _, raw := range []string{
+		"https://dev.azure.com/myorg/myproject/_git/myrepo",
+		"https://myorg.visualstudio.com/myproject/_git/myrepo",
+		"https://other.example.com/whatever",
+	} {
+		u, err := url.Parse(raw)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		gitInput, err := azure.Provider{}.ParseGitRepository(u)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(gitInput).To(Equal("azure-devops"))
+	}
+
+	// nil URL must also be accepted: the URL is not parsed/validated.
+	gitInput, err := azure.Provider{}.ParseGitRepository(nil)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(gitInput).To(Equal("azure-devops"))
+}
+
+func TestProvider_NewGitCredentials(t *testing.T) {
+	expiresOn := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+
+	for _, tt := range []struct {
+		name        string
+		accessToken auth.Token
+		expected    *auth.GitCredentials
+		err         string
+	}{
+		{
+			name: "valid Azure access token is returned as bearer token",
+			accessToken: &azure.Token{AccessToken: azcore.AccessToken{
+				Token:     "aad-token",
+				ExpiresOn: expiresOn,
+			}},
+			expected: &auth.GitCredentials{
+				BearerToken: "aad-token",
+				ExpiresAt:   expiresOn,
+			},
+		},
+		{
+			name:        "wrong token type is rejected",
+			accessToken: &mockNonAzureToken{},
+			err:         "failed to cast token to Azure token: *azure_test.mockNonAzureToken",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			creds, err := azure.Provider{}.NewGitCredentials(
+				context.Background(), "azure-devops", tt.accessToken)
+
+			if tt.err != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(Equal(tt.err))
+				g.Expect(creds).To(BeNil())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(creds).To(Equal(tt.expected))
+			}
+		})
+	}
+}
+
+type mockNonAzureToken struct{}
+
+func (*mockNonAzureToken) GetDuration() time.Duration { return 0 }
+
 func createKubeconfig(clusterName, serverURL string) []byte {
 	return []byte(fmt.Sprintf(`apiVersion: v1
 clusters:

--- a/auth/git.go
+++ b/auth/git.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"slices"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/fluxcd/pkg/cache"
+)
+
+// GitCredentialsProvider is an interface that defines methods for
+// retrieving credentials for Git repositories from cloud providers.
+type GitCredentialsProvider interface {
+	Provider
+
+	// GetAccessTokenOptionsForGitRepository returns the options that must be
+	// passed to the provider to retrieve access tokens for the given Git
+	// repository URL.
+	GetAccessTokenOptionsForGitRepository(gitURL *url.URL) ([]Option, error)
+
+	// ParseGitRepository parses the given Git repository URL to verify
+	// it's a valid repository URL for the provider. As a result it returns
+	// an opaque per-repository input required for issuing Git credentials.
+	// This input is included in the cache key for the issued credentials,
+	// which is critical for providers whose credentials depend on the URL
+	// (e.g. AWS CodeCommit, whose credentials are a SigV4 signature over
+	// the request URL).
+	ParseGitRepository(gitURL *url.URL) (string, error)
+
+	// NewGitCredentials takes the input extracted by ParseGitRepository()
+	// and an access token and returns credentials that can be used to
+	// authenticate against the Git repository.
+	NewGitCredentials(ctx context.Context, gitInput string,
+		accessToken Token, opts ...Option) (*GitCredentials, error)
+}
+
+// GitCredentials contains authentication data needed in order to access a Git
+// repository.
+type GitCredentials struct {
+	BearerToken string
+	Username    string
+	Password    string
+	ExpiresAt   time.Time
+}
+
+// GetDuration implements Token.
+func (g *GitCredentials) GetDuration() time.Duration {
+	return time.Until(g.ExpiresAt)
+}
+
+// GetGitCredentials retrieves the Git credentials for the Git repository URL
+// set via WithGitURL and the specified provider.
+func GetGitCredentials(ctx context.Context, provider GitCredentialsProvider,
+	opts ...Option) (*GitCredentials, error) {
+
+	var o Options
+	o.Apply(opts...)
+
+	gitURL := o.GitURL
+	if gitURL == nil {
+		return nil, errors.New("a Git repository URL is required for issuing Git credentials")
+	}
+
+	gitInput, err := provider.ParseGitRepository(gitURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// First, we need an access token. This cannot be retrieved inside the
+	// cache lock, otherwise we reach a deadlock.
+	accessTokenOpts, err := provider.GetAccessTokenOptionsForGitRepository(gitURL)
+	if err != nil {
+		return nil, err
+	}
+	accessTokenOpts = append(slices.Clone(opts), accessTokenOpts...)
+	accessToken, err := GetAccessToken(ctx, provider, accessTokenOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get access token for Git repository: %w", err)
+	}
+
+	// Prepare a function to create new credentials.
+	newGitCredentials := func() (*GitCredentials, error) {
+		creds, err := provider.NewGitCredentials(ctx, gitInput, accessToken, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Git credentials: %w", err)
+		}
+		return creds, nil
+	}
+
+	// Bail out early if cache is disabled.
+	if o.Cache == nil {
+		return newGitCredentials()
+	}
+
+	// Build cache key.
+	var serviceAccount *corev1.ServiceAccount
+	var providerIdentity string
+	var audiences []string
+	if o.ShouldGetServiceAccountToken() {
+		var err error
+		saRef := client.ObjectKey{
+			Name:      o.ServiceAccountName,
+			Namespace: o.ServiceAccountNamespace,
+		}
+		serviceAccount, audiences, providerIdentity, err =
+			getServiceAccountAndProviderInfo(ctx, provider, o.Client, saRef, opts...)
+		if err != nil {
+			return nil, err
+		}
+	}
+	accessTokenCacheKey := buildAccessTokenCacheKey(provider, audiences,
+		providerIdentity, serviceAccount, accessTokenOpts...)
+	cacheKey := buildCacheKey(
+		fmt.Sprintf("accessTokenCacheKey=%s", accessTokenCacheKey),
+		fmt.Sprintf("gitRepositoryCacheKey=%s", gitInput))
+
+	// Build involved object details.
+	kind := o.InvolvedObject.Kind
+	name := o.InvolvedObject.Name
+	namespace := o.InvolvedObject.Namespace
+	operation := o.InvolvedObject.Operation
+
+	// Get credentials from cache.
+	creds, _, err := o.Cache.GetOrSet(ctx, cacheKey, func(ctx context.Context) (cache.Token, error) {
+		return newGitCredentials()
+	}, cache.WithInvolvedObject(kind, name, namespace, operation))
+	if err != nil {
+		return nil, err
+	}
+
+	return creds.(*GitCredentials), nil
+}

--- a/auth/git_test.go
+++ b/auth/git_test.go
@@ -1,0 +1,322 @@
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth_test
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/fluxcd/pkg/auth"
+	"github.com/fluxcd/pkg/cache"
+)
+
+func TestGetGitCredentials(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	kubeClient, oidcClient := newTestEnv(t, ctx)
+
+	// Create a default service account.
+	defaultServiceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "default",
+		},
+	}
+	err := kubeClient.Create(ctx, defaultServiceAccount)
+	g.Expect(err).NotTo(HaveOccurred())
+	saRef := client.ObjectKey{
+		Name:      defaultServiceAccount.Name,
+		Namespace: defaultServiceAccount.Namespace,
+	}
+
+	gitURL, err := url.Parse("https://git.example.com/org/repo.git")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	now := time.Now()
+
+	for _, tt := range []struct {
+		name               string
+		provider           *mockProvider
+		gitURL             *url.URL
+		opts               []auth.Option
+		disableObjectLevel bool
+		defaultSA          string
+		expectedCreds      *auth.GitCredentials
+		expectedErr        string
+	}{
+		{
+			name: "git credentials from controller access token",
+			provider: &mockProvider{
+				returnGitInput:        "git-cache-key",
+				returnControllerToken: &mockToken{token: "mock-default-token"},
+				returnGitCredentials: &auth.GitCredentials{
+					BearerToken: "mock-bearer-token",
+				},
+				paramGitURL:      gitURL,
+				paramAccessToken: &mockToken{token: "mock-default-token"},
+			},
+			gitURL: gitURL,
+			opts: []auth.Option{
+				auth.WithAudiences("audience1", "audience2"),
+				auth.WithScopes("scope1", "scope2"),
+				auth.WithSTSRegion("us-east-1"),
+				auth.WithSTSEndpoint("https://sts.some-cloud.io"),
+				auth.WithProxyURL(url.URL{Scheme: "http", Host: "proxy.io:8080"}),
+				auth.WithCAData("ca-data"),
+			},
+			expectedCreds: &auth.GitCredentials{
+				BearerToken: "mock-bearer-token",
+			},
+		},
+		{
+			name: "git credentials from access token from service account",
+			provider: &mockProvider{
+				returnName:        "mock-provider",
+				returnGitInput:    "git-cache-key",
+				returnAccessToken: &mockToken{token: "mock-access-token"},
+				returnGitCredentials: &auth.GitCredentials{
+					Username: "user",
+					Password: "pass",
+				},
+				paramAudiences:       []string{"audience1", "audience2"},
+				paramServiceAccount:  *defaultServiceAccount,
+				paramOIDCTokenClient: oidcClient,
+				paramGitURL:          gitURL,
+				paramAccessToken:     &mockToken{token: "mock-access-token"},
+			},
+			gitURL: gitURL,
+			opts: []auth.Option{
+				auth.WithClient(kubeClient),
+				auth.WithServiceAccountName(saRef.Name),
+				auth.WithServiceAccountNamespace(saRef.Namespace),
+				auth.WithAudiences("audience1", "audience2"),
+				auth.WithScopes("scope1", "scope2"),
+				auth.WithSTSRegion("us-east-1"),
+				auth.WithSTSEndpoint("https://sts.some-cloud.io"),
+				auth.WithProxyURL(url.URL{Scheme: "http", Host: "proxy.io:8080"}),
+				auth.WithCAData("ca-data"),
+			},
+			expectedCreds: &auth.GitCredentials{
+				Username: "user",
+				Password: "pass",
+			},
+		},
+		{
+			name: "git credentials from access token from service account, works with lockdown",
+			provider: &mockProvider{
+				returnName:        "mock-provider",
+				returnGitInput:    "git-cache-key",
+				returnAccessToken: &mockToken{token: "mock-access-token"},
+				returnGitCredentials: &auth.GitCredentials{
+					Username: "user",
+					Password: "pass",
+				},
+				paramAudiences:       []string{"audience1", "audience2"},
+				paramServiceAccount:  *defaultServiceAccount,
+				paramOIDCTokenClient: oidcClient,
+				paramGitURL:          gitURL,
+				paramAccessToken:     &mockToken{token: "mock-access-token"},
+			},
+			gitURL: gitURL,
+			opts: []auth.Option{
+				auth.WithClient(kubeClient),
+				auth.WithServiceAccountNamespace(saRef.Namespace),
+				auth.WithAudiences("audience1", "audience2"),
+				auth.WithScopes("scope1", "scope2"),
+				auth.WithSTSRegion("us-east-1"),
+				auth.WithSTSEndpoint("https://sts.some-cloud.io"),
+				auth.WithProxyURL(url.URL{Scheme: "http", Host: "proxy.io:8080"}),
+				auth.WithCAData("ca-data"),
+			},
+			defaultSA: saRef.Name,
+			expectedCreds: &auth.GitCredentials{
+				Username: "user",
+				Password: "pass",
+			},
+		},
+		{
+			name: "git credentials from access token from service account, works with lockdown and feature gate",
+			provider: &mockProvider{
+				returnName:        "mock-provider",
+				returnGitInput:    "git-cache-key",
+				returnAccessToken: &mockToken{token: "mock-access-token"},
+				returnGitCredentials: &auth.GitCredentials{
+					Username: "user",
+					Password: "pass",
+				},
+				paramAudiences:       []string{"audience1", "audience2"},
+				paramServiceAccount:  *defaultServiceAccount,
+				paramOIDCTokenClient: oidcClient,
+				paramGitURL:          gitURL,
+				paramAccessToken:     &mockToken{token: "mock-access-token"},
+			},
+			gitURL: gitURL,
+			opts: []auth.Option{
+				auth.WithClient(kubeClient),
+				auth.WithServiceAccountNamespace(saRef.Namespace),
+				auth.WithAudiences("audience1", "audience2"),
+				auth.WithScopes("scope1", "scope2"),
+				auth.WithSTSRegion("us-east-1"),
+				auth.WithSTSEndpoint("https://sts.some-cloud.io"),
+				auth.WithProxyURL(url.URL{Scheme: "http", Host: "proxy.io:8080"}),
+				auth.WithCAData("ca-data"),
+			},
+			defaultSA:          saRef.Name,
+			disableObjectLevel: true,
+			expectedCreds: &auth.GitCredentials{
+				Username: "user",
+				Password: "pass",
+			},
+			expectedErr: "ObjectLevelWorkloadIdentity feature gate is not enabled",
+		},
+		{
+			name: "all the options are taken into account in the cache key",
+			provider: &mockProvider{
+				returnName:          "mock-provider",
+				returnIdentity:      "mock-identity",
+				returnGitInput:      "git-cache-key",
+				paramServiceAccount: *defaultServiceAccount,
+				paramGitURL:         gitURL,
+			},
+			gitURL: gitURL,
+			opts: []auth.Option{
+				auth.WithClient(kubeClient),
+				auth.WithServiceAccountName(saRef.Name),
+				auth.WithServiceAccountNamespace(saRef.Namespace),
+				auth.WithAudiences("audience1", "audience2"),
+				auth.WithScopes("scope1", "scope2"),
+				auth.WithSTSRegion("us-east-1"),
+				auth.WithSTSEndpoint("https://sts.some-cloud.io"),
+				auth.WithProxyURL(url.URL{Scheme: "http", Host: "proxy.io:8080"}),
+				auth.WithCAData("ca-data"),
+				func(o *auth.Options) {
+					tokenCache, err := cache.NewTokenCache(2)
+					g.Expect(err).NotTo(HaveOccurred())
+
+					const accessTokenKey = "db625bd5a96dc48fcc100659c6db98857d1e0ceec930bbded0fdece14af4307c"
+					var token auth.Token = &mockToken{token: "cached-token"}
+					cachedToken, ok, err := tokenCache.GetOrSet(ctx, accessTokenKey, func(ctx context.Context) (cache.Token, error) {
+						return token, nil
+					})
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(ok).To(BeFalse())
+					g.Expect(cachedToken).To(Equal(token))
+
+					const gitCredentialsKey = "e357f59fa20ef36d03cebec28a4b5edcadab91f5b878fb24c6e97379375e3443"
+					token = &auth.GitCredentials{
+						Username:  "cached-user",
+						Password:  "cached-pass",
+						ExpiresAt: now.Add(time.Hour),
+					}
+					cachedToken, ok, err = tokenCache.GetOrSet(ctx, gitCredentialsKey, func(ctx context.Context) (cache.Token, error) {
+						return token, nil
+					})
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(ok).To(BeFalse())
+					g.Expect(cachedToken).To(Equal(token))
+
+					o.Cache = tokenCache
+				},
+			},
+			expectedCreds: &auth.GitCredentials{
+				Username:  "cached-user",
+				Password:  "cached-pass",
+				ExpiresAt: now.Add(time.Hour),
+			},
+		},
+		{
+			name: "missing Git URL",
+			provider: &mockProvider{
+				paramGitURL: gitURL,
+			},
+			expectedErr: "a Git repository URL is required",
+		},
+		{
+			name: "error parsing Git repository",
+			provider: &mockProvider{
+				paramGitURL:  gitURL,
+				returnGitErr: "mock error",
+			},
+			gitURL:      gitURL,
+			expectedErr: "mock error",
+		},
+		{
+			name: "disable object level workload identity",
+			provider: &mockProvider{
+				paramServiceAccount: *defaultServiceAccount,
+				paramGitURL:         gitURL,
+				returnGitInput:      "git-cache-key",
+			},
+			gitURL: gitURL,
+			opts: []auth.Option{
+				auth.WithClient(kubeClient),
+				auth.WithServiceAccountName(saRef.Name),
+				auth.WithServiceAccountNamespace(saRef.Namespace),
+				auth.WithAudiences("audience1", "audience2"),
+				auth.WithScopes("scope1", "scope2"),
+				auth.WithSTSRegion("us-east-1"),
+				auth.WithSTSEndpoint("https://sts.some-cloud.io"),
+				auth.WithProxyURL(url.URL{Scheme: "http", Host: "proxy.io:8080"}),
+				auth.WithCAData("ca-data"),
+			},
+			disableObjectLevel: true,
+			expectedErr:        "ObjectLevelWorkloadIdentity feature gate is not enabled",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			tt.provider.t = t
+
+			if !tt.disableObjectLevel {
+				auth.EnableObjectLevelWorkloadIdentity()
+				t.Cleanup(auth.DisableObjectLevelWorkloadIdentity)
+			}
+
+			if tt.defaultSA != "" {
+				auth.SetDefaultServiceAccount(tt.defaultSA)
+				t.Cleanup(func() { auth.SetDefaultServiceAccount("") })
+			}
+
+			opts := tt.opts
+			if tt.gitURL != nil {
+				opts = append(opts, auth.WithGitURL(*tt.gitURL))
+			}
+
+			creds, err := auth.GetGitCredentials(ctx, tt.provider, opts...)
+
+			if tt.expectedErr != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectedErr))
+				g.Expect(creds).To(BeNil())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(creds).To(Equal(tt.expectedCreds))
+			}
+		})
+	}
+}

--- a/auth/provider_test.go
+++ b/auth/provider_test.go
@@ -39,6 +39,10 @@ type mockProvider struct {
 	returnIdentityErr       string
 	returnRegistryErr       string
 	returnRegistryInput     string
+	returnGitErr            string
+	returnGitInput          string
+	returnGitOptions        []auth.Option
+	returnGitCredentials    *auth.GitCredentials
 	returnRESTConfig        *auth.RESTConfig
 	returnRESTConfigOptsErr string
 	returnControllerToken   auth.Token
@@ -49,6 +53,7 @@ type mockProvider struct {
 	paramServiceAccount     corev1.ServiceAccount
 	paramOIDCTokenClient    *http.Client
 	paramArtifactRepository string
+	paramGitURL             *url.URL
 	paramCluster            string
 	paramClusterAddress     string
 	paramAccessToken        auth.Token
@@ -145,6 +150,33 @@ func (m *mockProvider) NewArtifactRegistryCredentials(ctx context.Context, regis
 	g.Expect(accessToken).To(Equal(m.paramAccessToken))
 	m.checkOptions(opts...)
 	return m.returnRegistryToken, nil
+}
+
+func (m *mockProvider) ParseGitRepository(gitURL *url.URL) (string, error) {
+	m.t.Helper()
+	g := NewWithT(m.t)
+	g.Expect(gitURL).To(Equal(m.paramGitURL))
+	if m.returnGitErr != "" {
+		return "", errors.New(m.returnGitErr)
+	}
+	return m.returnGitInput, nil
+}
+
+func (m *mockProvider) GetAccessTokenOptionsForGitRepository(gitURL *url.URL) ([]auth.Option, error) {
+	m.t.Helper()
+	g := NewWithT(m.t)
+	g.Expect(gitURL).To(Equal(m.paramGitURL))
+	return m.returnGitOptions, nil
+}
+
+func (m *mockProvider) NewGitCredentials(ctx context.Context, gitInput string,
+	accessToken auth.Token, opts ...auth.Option) (*auth.GitCredentials, error) {
+	m.t.Helper()
+	g := NewWithT(m.t)
+	g.Expect(gitInput).To(Equal(m.returnGitInput))
+	g.Expect(accessToken).To(Equal(m.paramAccessToken))
+	m.checkOptions(opts...)
+	return m.returnGitCredentials, nil
 }
 
 func (m *mockProvider) GetAccessTokenOptionsForCluster(opts ...auth.Option) ([][]auth.Option, error) {

--- a/auth/utils/git.go
+++ b/auth/utils/git.go
@@ -19,63 +19,19 @@ package utils
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	"github.com/fluxcd/pkg/auth"
-	"github.com/fluxcd/pkg/auth/aws"
-	"github.com/fluxcd/pkg/auth/azure"
 )
 
-// GitCredentials contains authentication data needed in order to access a Git
-// repository.
-type GitCredentials struct {
-	BearerToken string
-	Username    string
-	Password    string
-}
+// GetGitCredentials looks up the implemented providers that support Git
+// and returns the credentials for the specified provider.
+func GetGitCredentials(ctx context.Context, providerName string,
+	opts ...auth.Option) (*auth.GitCredentials, error) {
 
-// GetGitCredentials looks up by the implemented providers that support Git
-// and returns the credentials for the provider.
-func GetGitCredentials(ctx context.Context, providerName string, opts ...auth.Option) (*GitCredentials, error) {
-	switch providerName {
-	case azure.ProviderName:
-		opts = append(slices.Clone(opts), auth.WithScopes(azure.ScopeDevOps))
-		token, err := auth.GetAccessToken(ctx, azure.Provider{}, opts...)
-		if err != nil {
-			return nil, err
-		}
-		return &GitCredentials{
-			BearerToken: token.(*azure.Token).Token,
-		}, nil
-	case aws.ProviderName:
-		provider := aws.Provider{}
-		awsOpts := slices.Clone(opts)
-
-		// Extract the region from the CodeCommit URL and inject it as STSRegion
-		// before calling GetAccessToken. This will ensure that it's possible to call AWS SDK
-		// even without AWS_REGION environment variable.
-		var o auth.Options
-		o.Apply(awsOpts...)
-		if o.STSRegion == "" && o.GitURL != nil {
-			if region, err := aws.GetRegionFromCodeCommitURL(o.GitURL); err == nil {
-				awsOpts = append(awsOpts, auth.WithSTSRegion(region))
-			}
-		}
-
-		token, err := auth.GetAccessToken(ctx, provider, awsOpts...)
-		if err != nil {
-			return nil, err
-		}
-
-		username, password, err := provider.NewCodeCommitGitCredentials(ctx, []auth.Token{token}, awsOpts...)
-		if err != nil {
-			return nil, err
-		}
-		return &GitCredentials{
-			Username: username,
-			Password: password,
-		}, nil
-	default:
+	provider, err := ProviderByName[auth.GitCredentialsProvider](providerName)
+	if err != nil {
 		return nil, fmt.Errorf("provider '%s' does not support Git credentials", providerName)
 	}
+
+	return auth.GetGitCredentials(ctx, provider, opts...)
 }

--- a/auth/utils/provider_test.go
+++ b/auth/utils/provider_test.go
@@ -96,6 +96,39 @@ func TestProviderByName(t *testing.T) {
 		})
 	})
 
+	t.Run("git providers", func(t *testing.T) {
+		for _, tt := range []struct {
+			name     string
+			provider any
+		}{
+			{
+				name:     azure.ProviderName,
+				provider: azure.Provider{},
+			},
+			{
+				name:     aws.ProviderName,
+				provider: aws.Provider{},
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				g := NewWithT(t)
+				p, err := authutils.ProviderByName[auth.GitCredentialsProvider](tt.name)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(p).To(Equal(tt.provider))
+			})
+		}
+
+		for _, name := range []string{gcp.ProviderName, generic.ProviderName} {
+			t.Run(name, func(t *testing.T) {
+				g := NewWithT(t)
+				p, err := authutils.ProviderByName[auth.GitCredentialsProvider](name)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("does not implement the expected interface"))
+				g.Expect(p).To(BeNil())
+			})
+		}
+	})
+
 	t.Run("restconfig providers", func(t *testing.T) {
 		for _, tt := range []struct {
 			name     string


### PR DESCRIPTION
Make Git repository credentials (Azure DevOps and AWS CodeCommit) follow the abstract pattern of OCI registry and Kubernetes credentials.