### PR TITLE
auth/gcp: add support for sovereign cloud artifact registry

### DIFF
--- a/auth/gcp/provider.go
+++ b/auth/gcp/provider.go
@@ -163,7 +163,7 @@ func (Provider) GetAccessTokenOptionsForArtifactRepository(string) ([]auth.Optio
 	return nil, nil
 }
 
-const registryPattern = `^(((.+\.)?gcr\.io)|(.+-docker\.pkg\.dev))$`
+const registryPattern = `^(((.+\.)?gcr\.io)|(.+-docker\.pkg\.dev)|(.+-docker\.s3nsregistry\.fr))$`
 
 var registryRegex = regexp.MustCompile(registryPattern)
 

--- a/auth/gcp/provider_test.go
+++ b/auth/gcp/provider_test.go
@@ -314,6 +314,26 @@ func TestProvider_ParseArtifactRegistry(t *testing.T) {
 			artifactRepository: "012345678901.dkr.ecr.us-east-1.amazonaws.com",
 			expectValid:        false,
 		},
+		{
+			artifactRepository: "u-france-east1-docker.s3nsregistry.fr/s3ns/dsna-shared-registry-0/shared-registry",
+			expectValid:        true,
+		},
+		{
+			artifactRepository: "u-france-east1-docker.s3nsregistry.fr",
+			expectValid:        true,
+		},
+		{
+			artifactRepository: "docker.s3nsregistry.fr",
+			expectValid:        false,
+		},
+		{
+			artifactRepository: "-docker.s3nsregistry.fr",
+			expectValid:        false,
+		},
+		{
+			artifactRepository: "a.docker.s3nsregistry.fr",
+			expectValid:        false,
+		},
 	} {
 		t.Run(tt.artifactRepository, func(t *testing.T) {
 			g := NewWithT(t)


### PR DESCRIPTION
Closes: https://github.com/fluxcd/flux2/issues/5874

This will unblock support only for controller-level workload identity. The Google libraries will read the environment variables internally when using controller-level workload identity.  For object-level we will need new API surface, to be covered in a new RFC I'm working on.