### PR TITLE
auth/actionsoidc: fetch OIDC tokens from actions-based CI systems

### DIFF
--- a/auth/actionsoidc/actionsoidc.go
+++ b/auth/actionsoidc/actionsoidc.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package actionsoidc fetches OIDC ID tokens from the GitHub/Forgejo Actions
+// token endpoint. Both providers expose the same contract: a job granted the
+// 'id-token: write' permission gets the ACTIONS_ID_TOKEN_REQUEST_URL and
+// ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variables, and a GET request to
+// that URL with the request token as a bearer credential returns a JSON object
+// with the ID token in its "value" field.
+package actionsoidc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	// EnvRequestURL is the environment variable holding the URL of the
+	// GitHub/Forgejo Actions OIDC token request endpoint.
+	EnvRequestURL = "ACTIONS_ID_TOKEN_REQUEST_URL"
+
+	// EnvRequestToken is the environment variable holding the bearer token used
+	// to authenticate the request to the endpoint in EnvRequestURL.
+	EnvRequestToken = "ACTIONS_ID_TOKEN_REQUEST_TOKEN"
+)
+
+// FetchToken requests an OIDC ID token for the given audience from the
+// GitHub/Forgejo Actions token endpoint. The endpoint URL and the request
+// bearer token are read from the EnvRequestURL and EnvRequestToken environment
+// variables, which Actions injects into a job that has the 'id-token: write'
+// permission.
+//
+// It returns the ID token and its expiration time. The expiration is read from
+// the token's 'exp' claim without verifying the signature: the token was issued
+// by the trusted endpoint one HTTP call ago, and the expiry is only used by
+// callers to schedule re-minting.
+func FetchToken(ctx context.Context, audience string) (string, time.Time, error) {
+	requestURL := os.Getenv(EnvRequestURL)
+	requestToken := os.Getenv(EnvRequestToken)
+	if requestURL == "" || requestToken == "" {
+		return "", time.Time{}, fmt.Errorf("%s and %s must be set in the environment; "+
+			"ensure the Actions job has the 'id-token: write' permission", EnvRequestURL, EnvRequestToken)
+	}
+
+	u, err := url.Parse(requestURL)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("invalid %s: %w", EnvRequestURL, err)
+	}
+	q := u.Query()
+	q.Set("audience", audience)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to create OIDC token request: %w", err)
+	}
+	req.Header.Set("Authorization", "bearer "+requestToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("OIDC token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", time.Time{}, fmt.Errorf("OIDC token request failed with status %s: %s",
+			resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	var result struct {
+		Value string `json:"value"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to decode OIDC token response: %w", err)
+	}
+	if result.Value == "" {
+		return "", time.Time{}, errors.New("the OIDC token response did not contain a token")
+	}
+
+	exp, err := tokenExpiry(result.Value)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	return result.Value, exp, nil
+}
+
+// tokenExpiry extracts the 'exp' claim from a compact-serialized JWT without
+// verifying its signature, matching how auth/generic reads service account
+// token expirations.
+func tokenExpiry(token string) (time.Time, error) {
+	tok, _, err := jwt.NewParser().ParseUnverified(token, jwt.MapClaims{})
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse OIDC token: %w", err)
+	}
+	exp, err := tok.Claims.GetExpirationTime()
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to get expiration time from OIDC token: %w", err)
+	}
+	if exp == nil {
+		return time.Time{}, errors.New("OIDC token has no exp claim")
+	}
+	return exp.Time, nil
+}

--- a/auth/actionsoidc/actionsoidc_test.go
+++ b/auth/actionsoidc/actionsoidc_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actionsoidc_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/fluxcd/pkg/auth/actionsoidc"
+)
+
+// makeJWT mints an unsigned-but-parseable JWT carrying the given exp claim.
+func makeJWT(t *testing.T, exp time.Time) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"exp": exp.Unix()})
+	signed, err := tok.SignedString([]byte("test-secret"))
+	if err != nil {
+		t.Fatalf("failed to mint test JWT: %v", err)
+	}
+	return signed
+}
+
+func TestFetchToken(t *testing.T) {
+	t.Run("fetches token and exp", func(t *testing.T) {
+		exp := time.Now().Add(time.Hour).Truncate(time.Second)
+		idToken := makeJWT(t, exp)
+
+		var gotAudience, gotAuth, gotPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAudience = r.URL.Query().Get("audience")
+			gotAuth = r.Header.Get("Authorization")
+			gotPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":"` + idToken + `"}`))
+		}))
+		defer srv.Close()
+
+		t.Setenv(actionsoidc.EnvRequestURL, srv.URL+"/token?api-version=2.0")
+		t.Setenv(actionsoidc.EnvRequestToken, "request-token")
+
+		token, gotExp, err := actionsoidc.FetchToken(context.Background(), "my-audience")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if token != idToken {
+			t.Errorf("token = %q, want %q", token, idToken)
+		}
+		if !gotExp.Equal(exp) {
+			t.Errorf("exp = %v, want %v", gotExp, exp)
+		}
+		if gotAudience != "my-audience" {
+			t.Errorf("audience query = %q, want my-audience", gotAudience)
+		}
+		if gotAuth != "bearer request-token" {
+			t.Errorf("Authorization = %q, want bearer request-token", gotAuth)
+		}
+		if gotPath != "/token" {
+			t.Errorf("path = %q, want /token (base path preserved)", gotPath)
+		}
+	})
+
+	t.Run("errors when env vars are unset", func(t *testing.T) {
+		t.Setenv(actionsoidc.EnvRequestURL, "")
+		t.Setenv(actionsoidc.EnvRequestToken, "")
+		_, _, err := actionsoidc.FetchToken(context.Background(), "aud")
+		if err == nil || !strings.Contains(err.Error(), actionsoidc.EnvRequestURL) {
+			t.Fatalf("expected error mentioning %s, got: %v", actionsoidc.EnvRequestURL, err)
+		}
+	})
+
+	t.Run("errors on non-200 response", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte("denied"))
+		}))
+		defer srv.Close()
+		t.Setenv(actionsoidc.EnvRequestURL, srv.URL)
+		t.Setenv(actionsoidc.EnvRequestToken, "request-token")
+
+		_, _, err := actionsoidc.FetchToken(context.Background(), "aud")
+		if err == nil || !strings.Contains(err.Error(), "denied") {
+			t.Fatalf("expected error containing response body, got: %v", err)
+		}
+	})
+
+	t.Run("errors on empty value", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"value":""}`))
+		}))
+		defer srv.Close()
+		t.Setenv(actionsoidc.EnvRequestURL, srv.URL)
+		t.Setenv(actionsoidc.EnvRequestToken, "request-token")
+
+		_, _, err := actionsoidc.FetchToken(context.Background(), "aud")
+		if err == nil || !strings.Contains(err.Error(), "did not contain a token") {
+			t.Fatalf("expected empty-token error, got: %v", err)
+		}
+	})
+
+	t.Run("errors on token without exp", func(t *testing.T) {
+		tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{})
+		noExp, err := tok.SignedString([]byte("test-secret"))
+		if err != nil {
+			t.Fatalf("failed to mint test JWT: %v", err)
+		}
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"value":"` + noExp + `"}`))
+		}))
+		defer srv.Close()
+		t.Setenv(actionsoidc.EnvRequestURL, srv.URL)
+		t.Setenv(actionsoidc.EnvRequestToken, "request-token")
+
+		_, _, err = actionsoidc.FetchToken(context.Background(), "aud")
+		if err == nil || !strings.Contains(err.Error(), "exp claim") {
+			t.Fatalf("expected missing-exp error, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Introduce `actionsoidc.FetchToken()` API for fetching OIDC tokens in GitHub and Forgejo Actions. This will be useful for:

* `flux trigger receiver`
* `flux push artifact` and friends
* `flux-mirror sync`