### PR TITLE
auth: introduce JWT signing with JWK for CI systems

### DIFF
--- a/auth/go.mod
+++ b/auth/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/fluxcd/pkg/apis/meta v1.27.0
 	github.com/fluxcd/pkg/cache v0.14.0
 	github.com/fluxcd/pkg/ssh v0.25.0
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-containerregistry v0.21.5
@@ -65,7 +66,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/auth/jwt/jwt.go
+++ b/auth/jwt/jwt.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package jwt issues self-signed JSON Web Tokens. It parses a private signing
+// key from a JSON Web Key (JWK) once and mints compact-serialized tokens on
+// demand, stamping the key's id into the token header so verifiers can locate the
+// matching public key.
+//
+// The signing algorithm is derived from the key type, never chosen by the caller
+// or read from the JWK's "alg" field, so it can never disagree with the key. Only
+// key types that map to a single unambiguous algorithm are supported:
+//
+//	ed25519.PrivateKey  -> EdDSA
+//	*ecdsa.PrivateKey   -> ES256 / ES384 / ES512 (by curve: P-256 / P-384 / P-521)
+//
+// RSA is intentionally unsupported: an RSA key does not determine a single
+// algorithm (RS256/384/512, PS256/384/512), so signing one would require the
+// library to pick on the caller's behalf.
+package jwt
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+	gojwt "github.com/golang-jwt/jwt/v5"
+)
+
+// SigningKey is a private signing key, parsed from a JWK, that mints signed JWTs
+// using the algorithm determined by the key type.
+type SigningKey struct {
+	key    any
+	method gojwt.SigningMethod
+	kid    string
+}
+
+// ParseJWK parses jwk, a single JSON Web Key, and returns its private signing
+// key. The key must be of a type that maps to a single signing algorithm: an
+// Ed25519 private key (kty "OKP", crv "Ed25519") or an ECDSA private key (kty
+// "EC", crv "P-256", "P-384", or "P-521"), both carrying the private "d"
+// component. RSA keys are rejected because their algorithm is ambiguous.
+func ParseJWK(jwk string) (*SigningKey, error) {
+	var k jose.JSONWebKey
+	if err := json.Unmarshal([]byte(jwk), &k); err != nil {
+		return nil, fmt.Errorf("failed to parse JWK: %w", err)
+	}
+
+	method, err := signingMethodForKey(k.Key)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SigningKey{key: k.Key, method: method, kid: k.KeyID}, nil
+}
+
+// signingMethodForKey returns the signing method uniquely determined by the
+// private key's type. It errors for key types whose algorithm is not unambiguous
+// (RSA) or that are not private signing keys.
+func signingMethodForKey(key any) (gojwt.SigningMethod, error) {
+	switch k := key.(type) {
+	case ed25519.PrivateKey:
+		return gojwt.SigningMethodEdDSA, nil
+	case *ecdsa.PrivateKey:
+		switch k.Curve {
+		case elliptic.P256():
+			return gojwt.SigningMethodES256, nil
+		case elliptic.P384():
+			return gojwt.SigningMethodES384, nil
+		case elliptic.P521():
+			return gojwt.SigningMethodES512, nil
+		default:
+			return nil, fmt.Errorf("unsupported ECDSA curve %q", k.Curve.Params().Name)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported JWK key type %T: "+
+			"want an Ed25519 or ECDSA (P-256/P-384/P-521) private key", key)
+	}
+}
+
+// clockSkewLeeway backdates the "nbf" claim so a verifier whose clock runs
+// slightly behind the issuer's does not reject a freshly minted token as not yet
+// valid. It does not extend "exp": the token still expires ttl after issuance.
+const clockSkewLeeway = 30 * time.Second
+
+// Issue mints a compact-serialized JWT signed with the key, using the algorithm
+// determined by the key type. The signing key's id is set in the "kid" header
+// field. The token carries all seven registered claims (RFC 7519): iss, sub, and
+// aud as given, iat at the current time, nbf backdated by a small clock-skew
+// leeway, exp ttl after issuance, and a random jti.
+func (k *SigningKey) Issue(iss, sub, aud string, ttl time.Duration) (string, error) {
+	jti, err := newJTI()
+	if err != nil {
+		return "", err
+	}
+
+	now := time.Now()
+	claims := gojwt.RegisteredClaims{
+		Issuer:    iss,
+		Subject:   sub,
+		Audience:  gojwt.ClaimStrings{aud},
+		IssuedAt:  gojwt.NewNumericDate(now),
+		NotBefore: gojwt.NewNumericDate(now.Add(-clockSkewLeeway)),
+		ExpiresAt: gojwt.NewNumericDate(now.Add(ttl)),
+		ID:        jti,
+	}
+
+	tok := gojwt.NewWithClaims(k.method, claims)
+	tok.Header["kid"] = k.kid
+
+	signed, err := tok.SignedString(k.key)
+	if err != nil {
+		return "", fmt.Errorf("failed to sign JWT: %w", err)
+	}
+	return signed, nil
+}
+
+// newJTI returns a random 128-bit token identifier as a hex string.
+func newJTI() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("failed to generate JWT ID: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
+}

--- a/auth/jwt/jwt_test.go
+++ b/auth/jwt/jwt_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jwt_test
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+	gojwt "github.com/golang-jwt/jwt/v5"
+
+	"github.com/fluxcd/pkg/auth/jwt"
+)
+
+func marshalJWK(t *testing.T, key jose.JSONWebKey) string {
+	t.Helper()
+	b, err := json.Marshal(key)
+	if err != nil {
+		t.Fatalf("failed to marshal JWK: %v", err)
+	}
+	return string(b)
+}
+
+func TestParseJWK_Errors(t *testing.T) {
+	_, edPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rsaPriv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		jwk     string
+		wantErr string
+	}{
+		{
+			name:    "not json",
+			jwk:     "{not json",
+			wantErr: "failed to parse JWK",
+		},
+		{
+			name:    "rsa rejected as ambiguous",
+			jwk:     marshalJWK(t, jose.JSONWebKey{Key: rsaPriv, KeyID: "a", Algorithm: "RS256"}),
+			wantErr: "unsupported JWK key type *rsa.PrivateKey",
+		},
+		{
+			name:    "public key only",
+			jwk:     marshalJWK(t, jose.JSONWebKey{Key: edPriv.Public(), KeyID: "a", Algorithm: "EdDSA"}),
+			wantErr: "unsupported JWK key type ed25519.PublicKey",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := jwt.ParseJWK(tt.jwk)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got: %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestSigningKey_Issue(t *testing.T) {
+	ed25519Pub, ed25519Priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	es256 := ecKey(t, elliptic.P256())
+	es384 := ecKey(t, elliptic.P384())
+	es521 := ecKey(t, elliptic.P521())
+
+	tests := []struct {
+		name    string
+		priv    crypto.PrivateKey
+		pub     crypto.PublicKey
+		wantAlg string
+	}{
+		{"ed25519", ed25519Priv, ed25519Pub, "EdDSA"},
+		{"ecdsa P-256", es256.priv, es256.pub, "ES256"},
+		{"ecdsa P-384", es384.priv, es384.pub, "ES384"},
+		{"ecdsa P-521", es521.priv, es521.pub, "ES512"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const kid = "my-key"
+			jwk := marshalJWK(t, jose.JSONWebKey{Key: tt.priv, KeyID: kid})
+
+			key, err := jwt.ParseJWK(jwk)
+			if err != nil {
+				t.Fatalf("ParseJWK: %v", err)
+			}
+
+			signed, err := key.Issue("https://issuer", "my-subject", "my-audience", 10*time.Second)
+			if err != nil {
+				t.Fatalf("Issue: %v", err)
+			}
+
+			claims := gojwt.MapClaims{}
+			tok, err := gojwt.NewParser().ParseWithClaims(signed, claims, func(*gojwt.Token) (any, error) {
+				return tt.pub, nil
+			})
+			if err != nil {
+				t.Fatalf("token failed to verify: %v", err)
+			}
+
+			if tok.Method.Alg() != tt.wantAlg {
+				t.Errorf("alg = %q, want %q", tok.Method.Alg(), tt.wantAlg)
+			}
+			if got := tok.Header["kid"]; got != kid {
+				t.Errorf("kid header = %v, want %q", got, kid)
+			}
+
+			if got, _ := claims.GetIssuer(); got != "https://issuer" {
+				t.Errorf("iss = %q", got)
+			}
+			if got, _ := claims.GetSubject(); got != "my-subject" {
+				t.Errorf("sub = %q", got)
+			}
+			if got, _ := claims.GetAudience(); len(got) != 1 || got[0] != "my-audience" {
+				t.Errorf("aud = %v", got)
+			}
+			iat, _ := claims.GetIssuedAt()
+			nbf, _ := claims.GetNotBefore()
+			exp, _ := claims.GetExpirationTime()
+			if iat == nil || nbf == nil || exp == nil {
+				t.Fatalf("missing time claims: iat=%v nbf=%v exp=%v", iat, nbf, exp)
+			}
+			if want := iat.Add(-30 * time.Second); !nbf.Equal(want) {
+				t.Errorf("nbf = %s, want %s (iat backdated 30s)", nbf, want)
+			}
+			if d := exp.Sub(iat.Time); d != 10*time.Second {
+				t.Errorf("lifetime = %s, want 10s", d)
+			}
+			if jti, ok := claims["jti"].(string); !ok || jti == "" {
+				t.Errorf("jti = %v, want non-empty string", claims["jti"])
+			}
+		})
+	}
+}
+
+func TestSigningKey_Issue_FreshJTIPerCall(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jwk := marshalJWK(t, jose.JSONWebKey{Key: priv, KeyID: "k"})
+	key, err := jwt.ParseJWK(jwk)
+	if err != nil {
+		t.Fatalf("ParseJWK: %v", err)
+	}
+
+	seen := make(map[string]bool)
+	for range 10 {
+		signed, err := key.Issue("iss", "sub", "aud", time.Second)
+		if err != nil {
+			t.Fatalf("Issue: %v", err)
+		}
+		claims := gojwt.MapClaims{}
+		if _, _, err := gojwt.NewParser().ParseUnverified(signed, claims); err != nil {
+			t.Fatalf("ParseUnverified: %v", err)
+		}
+		jti, _ := claims["jti"].(string)
+		if seen[jti] {
+			t.Fatalf("jti %q reused", jti)
+		}
+		seen[jti] = true
+	}
+}
+
+type ecPair struct {
+	priv *ecdsa.PrivateKey
+	pub  *ecdsa.PublicKey
+}
+
+// ecKey generates a deterministic-per-call ECDSA key pair on the given curve.
+func ecKey(t *testing.T, curve elliptic.Curve) ecPair {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate ECDSA key: %v", err)
+	}
+	return ecPair{priv: priv, pub: &priv.PublicKey}
+}

--- a/auth/utils/cijwt/cijwt.go
+++ b/auth/utils/cijwt/cijwt.go
@@ -14,21 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package cioidc provides an http.RoundTripper that authenticates outbound
-// requests on a per-host basis with a JWT obtained from a CI/CD platform's OIDC
-// integration.
+// Package cijwt provides an http.RoundTripper that authenticates outbound
+// requests on a per-host basis with a JWT, sourcing the token from a CI/CD
+// platform's OIDC integration or signing it locally.
 //
-// Each configured host gets its token one of two ways:
+// Each configured host gets its token one of three ways:
 //   - WithHostAudience mints an OIDC ID token for the given audience from the
 //     GitHub/Forgejo Actions token endpoint (see the actionsoidc package),
 //     caching it for the first 50% of its lifetime and reminting on demand.
 //   - WithHostToken sends a static JWT as-is, e.g. a GitLab CI id_token injected
 //     into the job environment.
+//   - WithHostJWK signs a fresh, short-lived JWT with a private key from a JWK,
+//     issuing a new token for every request rather than caching it.
 //
 // Requests to hosts that were not configured are forwarded unchanged, so a
 // request to a registry the JWT is not meant for keeps its existing
 // authentication.
-package cioidc
+package cijwt
 
 import (
 	"context"
@@ -38,17 +40,32 @@ import (
 	"time"
 
 	"github.com/fluxcd/pkg/auth/actionsoidc"
+	"github.com/fluxcd/pkg/auth/jwt"
 )
+
+// jwkTokenTTL is the lifetime of the JWTs signed for WithHostJWK hosts. They are
+// minted fresh for every request, so the window only needs to cover a single
+// request's round trip plus clock skew between the issuer and the verifier.
+const jwkTokenTTL = 60 * time.Second
 
 type hostValue struct {
 	host  string
 	value string
 }
 
+type hostJWK struct {
+	host string
+	jwk  string
+	iss  string
+	aud  string
+	sub  string
+}
+
 type options struct {
 	inner     http.RoundTripper
 	tokens    []hostValue
 	audiences []hostValue
+	jwks      []hostJWK
 }
 
 // Option configures a Transport.
@@ -73,6 +90,16 @@ func WithHostAudience(host, audience string) Option {
 	return func(o *options) { o.audiences = append(o.audiences, hostValue{host, audience}) }
 }
 
+// WithHostJWK configures host to be authenticated with a JWT signed locally
+// using a private key parsed from jwk (a single JSON Web Key holding an Ed25519
+// or ECDSA private key; the signing algorithm is derived from the key type, see
+// the jwt package). Each request gets a freshly signed, 60-second-lived token
+// carrying iss, aud, and sub as given and the signing key's id in the "kid"
+// header. Unlike WithHostAudience, the token is never cached.
+func WithHostJWK(host, jwk, iss, aud, sub string) Option {
+	return func(o *options) { o.jwks = append(o.jwks, hostJWK{host, jwk, iss, aud, sub}) }
+}
+
 type cacheEntry struct {
 	token string
 	// exp is when the cached token must be reminted. A zero value means it
@@ -80,15 +107,25 @@ type cacheEntry struct {
 	exp time.Time
 }
 
+type jwkConfig struct {
+	key *jwt.SigningKey
+	iss string
+	aud string
+	sub string
+}
+
 // Transport is an http.RoundTripper that stamps Authorization: Bearer <jwt> on
-// requests whose URL host was configured with WithHostToken or WithHostAudience.
-// Any existing Authorization header on a configured host is overwritten;
-// requests to other hosts pass through untouched.
+// requests whose URL host was configured with WithHostToken, WithHostAudience,
+// or WithHostJWK. Any existing Authorization header on a configured host is
+// overwritten; requests to other hosts pass through untouched.
 type Transport struct {
 	inner http.RoundTripper
 	// audiences maps a host to the audience minted for it; the factory used on
 	// a cache miss.
 	audiences map[string]string
+	// jwk maps a host to the signing config used to mint a fresh token for
+	// every request. It is read-only after construction.
+	jwk map[string]jwkConfig
 
 	mu    sync.Mutex
 	cache map[string]cacheEntry
@@ -96,7 +133,8 @@ type Transport struct {
 
 // NewTransport returns a Transport configured by opts. At least one host must be
 // configured. It returns an error if the same host is configured more than once,
-// whether via WithHostToken, WithHostAudience, or a mix of the two.
+// whether via WithHostToken, WithHostAudience, WithHostJWK, or a mix of them, or
+// if a WithHostJWK key fails to parse.
 func NewTransport(opts ...Option) (*Transport, error) {
 	o := &options{inner: http.DefaultTransport}
 	for _, opt := range opts {
@@ -106,10 +144,11 @@ func NewTransport(opts ...Option) (*Transport, error) {
 	t := &Transport{
 		inner:     o.inner,
 		audiences: make(map[string]string, len(o.audiences)),
+		jwk:       make(map[string]jwkConfig, len(o.jwks)),
 		cache:     make(map[string]cacheEntry, len(o.tokens)),
 	}
 
-	seen := make(map[string]bool, len(o.tokens)+len(o.audiences))
+	seen := make(map[string]bool, len(o.tokens)+len(o.audiences)+len(o.jwks))
 	claim := func(host string) error {
 		if seen[host] {
 			return fmt.Errorf("host %q is configured more than once", host)
@@ -131,9 +170,19 @@ func NewTransport(opts ...Option) (*Transport, error) {
 		}
 		t.audiences[hv.host] = hv.value
 	}
+	for _, hj := range o.jwks {
+		if err := claim(hj.host); err != nil {
+			return nil, err
+		}
+		key, err := jwt.ParseJWK(hj.jwk)
+		if err != nil {
+			return nil, fmt.Errorf("host %q: %w", hj.host, err)
+		}
+		t.jwk[hj.host] = jwkConfig{key: key, iss: hj.iss, aud: hj.aud, sub: hj.sub}
+	}
 
 	if len(seen) == 0 {
-		return nil, fmt.Errorf("at least one host must be configured with WithHostToken or WithHostAudience")
+		return nil, fmt.Errorf("at least one host must be configured with WithHostToken, WithHostAudience, or WithHostJWK")
 	}
 
 	return t, nil
@@ -143,7 +192,7 @@ func NewTransport(opts ...Option) (*Transport, error) {
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	token, ok, err := t.tokenForHost(req.Context(), req.URL.Host)
 	if err != nil {
-		return nil, fmt.Errorf("failed to obtain CI OIDC token for host %q: %w", req.URL.Host, err)
+		return nil, fmt.Errorf("failed to obtain CI JWT for host %q: %w", req.URL.Host, err)
 	}
 	if !ok {
 		// Host not configured: forward unchanged, preserving existing auth.
@@ -156,9 +205,20 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.inner.RoundTrip(cloned)
 }
 
-// tokenForHost returns the bearer token for host, minting and caching it on a
-// miss. The boolean is false when host was not configured.
+// tokenForHost returns the bearer token for host. WithHostJWK hosts get a
+// freshly signed token on every call; WithHostAudience hosts are minted and
+// cached on a miss. The boolean is false when host was not configured.
 func (t *Transport) tokenForHost(ctx context.Context, host string) (string, bool, error) {
+	// JWK hosts sign a new token per request and never touch the cache, so they
+	// need no locking (t.jwk is read-only after construction).
+	if cfg, ok := t.jwk[host]; ok {
+		token, err := cfg.key.Issue(cfg.iss, cfg.sub, cfg.aud, jwkTokenTTL)
+		if err != nil {
+			return "", false, err
+		}
+		return token, true, nil
+	}
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 

--- a/auth/utils/cijwt/cijwt_test.go
+++ b/auth/utils/cijwt/cijwt_test.go
@@ -14,9 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cioidc_test
+package cijwt_test
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -25,10 +28,11 @@ import (
 	"testing"
 	"time"
 
+	jose "github.com/go-jose/go-jose/v4"
 	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/fluxcd/pkg/auth/actionsoidc"
-	"github.com/fluxcd/pkg/auth/utils/cioidc"
+	"github.com/fluxcd/pkg/auth/utils/cijwt"
 )
 
 // makeJWT mints an unsigned-but-parseable JWT carrying the given exp claim.
@@ -40,6 +44,25 @@ func makeJWT(t *testing.T, exp time.Time) string {
 		t.Fatalf("failed to mint test JWT: %v", err)
 	}
 	return signed
+}
+
+// makeEdDSAJWK generates a fresh Ed25519 key pair and returns it as a private
+// JWK (JSON) alongside the public key and key id for verifying issued tokens.
+func makeEdDSAJWK(t *testing.T, kid string) (jwk string, pub ed25519.PublicKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate Ed25519 key: %v", err)
+	}
+	b, err := json.Marshal(jose.JSONWebKey{
+		Key:       priv,
+		KeyID:     kid,
+		Algorithm: "EdDSA",
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal JWK: %v", err)
+	}
+	return string(b), pub
 }
 
 // tokenServer mints a fresh JWT with the configured TTL on each call, counting
@@ -76,9 +99,9 @@ func (r *recordingRT) RoundTrip(req *http.Request) (*http.Response, error) {
 	return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
 }
 
-func mustNewTransport(t *testing.T, inner http.RoundTripper, opts ...cioidc.Option) *cioidc.Transport {
+func mustNewTransport(t *testing.T, inner http.RoundTripper, opts ...cijwt.Option) *cijwt.Transport {
 	t.Helper()
-	tr, err := cioidc.NewTransport(append([]cioidc.Option{cioidc.WithInner(inner)}, opts...)...)
+	tr, err := cijwt.NewTransport(append([]cijwt.Option{cijwt.WithInner(inner)}, opts...)...)
 	if err != nil {
 		t.Fatalf("NewTransport: %v", err)
 	}
@@ -95,9 +118,10 @@ func get(t *testing.T, tr http.RoundTripper, host string) {
 }
 
 func TestNewTransport_Validation(t *testing.T) {
+	jwk, _ := makeEdDSAJWK(t, "key-1")
 	tests := []struct {
 		name    string
-		opts    []cioidc.Option
+		opts    []cijwt.Option
 		wantErr string
 	}{
 		{
@@ -107,39 +131,55 @@ func TestNewTransport_Validation(t *testing.T) {
 		},
 		{
 			name: "duplicate within tokens",
-			opts: []cioidc.Option{
-				cioidc.WithHostToken("a.example", "t1"),
-				cioidc.WithHostToken("a.example", "t2"),
+			opts: []cijwt.Option{
+				cijwt.WithHostToken("a.example", "t1"),
+				cijwt.WithHostToken("a.example", "t2"),
 			},
 			wantErr: `host "a.example" is configured more than once`,
 		},
 		{
 			name: "duplicate within audiences",
-			opts: []cioidc.Option{
-				cioidc.WithHostAudience("a.example", "aud1"),
-				cioidc.WithHostAudience("a.example", "aud2"),
+			opts: []cijwt.Option{
+				cijwt.WithHostAudience("a.example", "aud1"),
+				cijwt.WithHostAudience("a.example", "aud2"),
 			},
 			wantErr: `host "a.example" is configured more than once`,
 		},
 		{
 			name: "duplicate across token and audience",
-			opts: []cioidc.Option{
-				cioidc.WithHostToken("a.example", "t"),
-				cioidc.WithHostAudience("a.example", "aud"),
+			opts: []cijwt.Option{
+				cijwt.WithHostToken("a.example", "t"),
+				cijwt.WithHostAudience("a.example", "aud"),
 			},
 			wantErr: `host "a.example" is configured more than once`,
 		},
 		{
+			name: "duplicate across token and jwk",
+			opts: []cijwt.Option{
+				cijwt.WithHostToken("a.example", "t"),
+				cijwt.WithHostJWK("a.example", jwk, "iss", "aud", "sub"),
+			},
+			wantErr: `host "a.example" is configured more than once`,
+		},
+		{
+			name: "invalid jwk",
+			opts: []cijwt.Option{
+				cijwt.WithHostJWK("a.example", "not-json", "iss", "aud", "sub"),
+			},
+			wantErr: `host "a.example": failed to parse JWK`,
+		},
+		{
 			name: "valid mix of distinct hosts",
-			opts: []cioidc.Option{
-				cioidc.WithHostToken("static.example", "t"),
-				cioidc.WithHostAudience("mint.example", "aud"),
+			opts: []cijwt.Option{
+				cijwt.WithHostToken("static.example", "t"),
+				cijwt.WithHostAudience("mint.example", "aud"),
+				cijwt.WithHostJWK("jwk.example", jwk, "iss", "aud", "sub"),
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := cioidc.NewTransport(tt.opts...)
+			_, err := cijwt.NewTransport(tt.opts...)
 			if tt.wantErr == "" {
 				if err != nil {
 					t.Fatalf("expected no error, got: %v", err)
@@ -155,7 +195,7 @@ func TestNewTransport_Validation(t *testing.T) {
 
 func TestTransport_PassesThroughUnconfiguredHosts(t *testing.T) {
 	rec := &recordingRT{}
-	tr := mustNewTransport(t, rec, cioidc.WithHostToken("configured.example", "tok"))
+	tr := mustNewTransport(t, rec, cijwt.WithHostToken("configured.example", "tok"))
 
 	get(t, tr, "other.example")
 
@@ -166,7 +206,7 @@ func TestTransport_PassesThroughUnconfiguredHosts(t *testing.T) {
 
 func TestTransport_StaticTokenStampedAsIs(t *testing.T) {
 	rec := &recordingRT{}
-	tr := mustNewTransport(t, rec, cioidc.WithHostToken("static.example", "static.jwt.value"))
+	tr := mustNewTransport(t, rec, cijwt.WithHostToken("static.example", "static.jwt.value"))
 
 	get(t, tr, "static.example")
 	get(t, tr, "static.example")
@@ -180,7 +220,7 @@ func TestTransport_StaticTokenStampedAsIs(t *testing.T) {
 func TestTransport_MintsAndCachesPerHost(t *testing.T) {
 	ts := newTokenServer(t, time.Hour)
 	rec := &recordingRT{}
-	tr := mustNewTransport(t, rec, cioidc.WithHostAudience("mint.example", "aud"))
+	tr := mustNewTransport(t, rec, cijwt.WithHostAudience("mint.example", "aud"))
 
 	for range 5 {
 		get(t, tr, "mint.example")
@@ -202,7 +242,7 @@ func TestTransport_RemintsAfterHalfLife(t *testing.T) {
 	// next call must remint.
 	ts := newTokenServer(t, 4*time.Second)
 	rec := &recordingRT{}
-	tr := mustNewTransport(t, rec, cioidc.WithHostAudience("mint.example", "aud"))
+	tr := mustNewTransport(t, rec, cijwt.WithHostAudience("mint.example", "aud"))
 
 	get(t, tr, "mint.example")
 	if ts.calls.Load() != 1 {
@@ -220,7 +260,7 @@ func TestTransport_RemintsAfterHalfLife(t *testing.T) {
 func TestTransport_NearExpiredMintErrors(t *testing.T) {
 	newTokenServer(t, 500*time.Millisecond) // half-life 250ms < 1s guard
 	rec := &recordingRT{}
-	tr := mustNewTransport(t, rec, cioidc.WithHostAudience("mint.example", "aud"))
+	tr := mustNewTransport(t, rec, cijwt.WithHostAudience("mint.example", "aud"))
 
 	req, _ := http.NewRequest(http.MethodGet, "https://mint.example/v2/", nil)
 	_, err := tr.RoundTrip(req)
@@ -231,7 +271,7 @@ func TestTransport_NearExpiredMintErrors(t *testing.T) {
 
 func TestTransport_DoesNotMutateCallerRequest(t *testing.T) {
 	rec := &recordingRT{}
-	tr := mustNewTransport(t, rec, cioidc.WithHostToken("static.example", "static.jwt"))
+	tr := mustNewTransport(t, rec, cijwt.WithHostToken("static.example", "static.jwt"))
 
 	req, _ := http.NewRequest(http.MethodGet, "https://static.example/v2/", nil)
 	req.Header.Set("Authorization", "Basic original")
@@ -245,14 +285,17 @@ func TestTransport_DoesNotMutateCallerRequest(t *testing.T) {
 
 func TestTransport_RoutesPerHost(t *testing.T) {
 	newTokenServer(t, time.Hour)
+	jwk, _ := makeEdDSAJWK(t, "key-1")
 	rec := &recordingRT{}
 	tr := mustNewTransport(t, rec,
-		cioidc.WithHostToken("static.example", "static-token"),
-		cioidc.WithHostAudience("mint.example", "aud"),
+		cijwt.WithHostToken("static.example", "static-token"),
+		cijwt.WithHostAudience("mint.example", "aud"),
+		cijwt.WithHostJWK("jwk.example", jwk, "https://issuer.example", "registry", "subject"),
 	)
 
 	get(t, tr, "static.example")
 	get(t, tr, "mint.example")
+	get(t, tr, "jwk.example")
 	get(t, tr, "other.example")
 
 	if rec.auths[0] != "Bearer static-token" {
@@ -261,7 +304,76 @@ func TestTransport_RoutesPerHost(t *testing.T) {
 	if !strings.HasPrefix(rec.auths[1], "Bearer ") || rec.auths[1] == "Bearer static-token" {
 		t.Errorf("mint host auth = %q, want a distinct minted Bearer token", rec.auths[1])
 	}
-	if rec.auths[2] != "Basic should-be-overwritten" {
-		t.Errorf("unconfigured host auth = %q, want untouched", rec.auths[2])
+	if !strings.HasPrefix(rec.auths[2], "Bearer ") {
+		t.Errorf("jwk host auth = %q, want a signed Bearer token", rec.auths[2])
+	}
+	if rec.auths[3] != "Basic should-be-overwritten" {
+		t.Errorf("unconfigured host auth = %q, want untouched", rec.auths[3])
+	}
+}
+
+func TestTransport_JWKSignsFreshTokenPerRequest(t *testing.T) {
+	const kid = "signing-key"
+	jwk, pub := makeEdDSAJWK(t, kid)
+	rec := &recordingRT{}
+	tr := mustNewTransport(t, rec,
+		cijwt.WithHostJWK("jwk.example", jwk, "https://issuer.example", "registry", "the-subject"))
+
+	get(t, tr, "jwk.example")
+	get(t, tr, "jwk.example")
+
+	if len(rec.auths) != 2 {
+		t.Fatalf("got %d requests, want 2", len(rec.auths))
+	}
+
+	var jtis []string
+	for i, auth := range rec.auths {
+		raw, ok := strings.CutPrefix(auth, "Bearer ")
+		if !ok {
+			t.Fatalf("request %d Authorization = %q, want Bearer prefix", i, auth)
+		}
+
+		claims := jwt.MapClaims{}
+		tok, err := jwt.NewParser().ParseWithClaims(raw, claims, func(*jwt.Token) (any, error) {
+			return pub, nil
+		})
+		if err != nil {
+			t.Fatalf("request %d: token failed to verify: %v", i, err)
+		}
+		if tok.Method.Alg() != "EdDSA" {
+			t.Errorf("request %d alg = %q, want EdDSA", i, tok.Method.Alg())
+		}
+		if got := tok.Header["kid"]; got != kid {
+			t.Errorf("request %d kid header = %v, want %q", i, got, kid)
+		}
+
+		// All seven registered claims must be present and well-formed.
+		if got, _ := claims.GetIssuer(); got != "https://issuer.example" {
+			t.Errorf("request %d iss = %q", i, got)
+		}
+		if got, _ := claims.GetSubject(); got != "the-subject" {
+			t.Errorf("request %d sub = %q", i, got)
+		}
+		if got, _ := claims.GetAudience(); len(got) != 1 || got[0] != "registry" {
+			t.Errorf("request %d aud = %v", i, got)
+		}
+		iat, _ := claims.GetIssuedAt()
+		nbf, _ := claims.GetNotBefore()
+		exp, _ := claims.GetExpirationTime()
+		if iat == nil || nbf == nil || exp == nil {
+			t.Fatalf("request %d missing time claims: iat=%v nbf=%v exp=%v", i, iat, nbf, exp)
+		}
+		if d := exp.Sub(iat.Time); d != 60*time.Second {
+			t.Errorf("request %d lifetime = %s, want 60s", i, d)
+		}
+		jti, ok := claims["jti"].(string)
+		if !ok || jti == "" {
+			t.Errorf("request %d jti = %v, want non-empty string", i, claims["jti"])
+		}
+		jtis = append(jtis, jti)
+	}
+
+	if jtis[0] == jtis[1] {
+		t.Errorf("jti reused across requests (%q); each request must get a fresh token", jtis[0])
 	}
 }


### PR DESCRIPTION
Also move `auth/utils/cioidc` to `auth/utils/cijwt`.

This will be useful for `flux-mirror sync` and `flux push artifact`.

Similar to how the transport injects OIDC tokens retrieved from CI platforms like GitHub, GitLab and Forgejo (which are JWT tokens by the definition of OIDC), this PR introduces support for "bring your own key" JWT authentication in the `auth/jwt` package.

`WithHostJWK()` accepts a target host, a private JWK, and the `iss`, `aud` and `sub` claims. The transport will issue one JWT per request. This adds minimal overhead per request since the parameters are all in memory and no network calls are made for issuing a token (as opposed for example to `actionsoidc`). Because it's much cheaper to issue tokens like this, we make them 60sec-lived, which is awesome!

I have specific plans to use `flux-mirror sync` with this feature in my company.