### PR TITLE
fix(tools): respect manual major version bumps in go.mod

### DIFF
--- a/cmd/internal/module_bump.go
+++ b/cmd/internal/module_bump.go
@@ -95,9 +95,22 @@ func (m *ModuleBump) apply(ctx context.Context, targetModule string, dryRun bool
 		return false, fmt.Errorf("failed to read %s: %w", gomod, err)
 	}
 	oldContent := string(b)
-	if !m.regex.MatchString(oldContent) {
+	// Extract current version from the go.mod line and compare with the computed new version.
+	matches := m.regex.FindStringSubmatch(oldContent)
+	if len(matches) == 0 {
 		return false, nil
 	}
+	if len(matches) > 1 {
+		if currentVer, err := semver.NewVersion(matches[1]); err == nil {
+			if newVer, err := semver.NewVersion(m.newVersion); err == nil {
+				if currentVer.GreaterThan(newVer) {
+					// Use the higher version already present (e.g., a manual major bump).
+					m.newVersion = currentVer.String()
+				}
+			}
+		}
+	}
+
 	bumpString := fmt.Sprintf("github.com/fluxcd/pkg/%s v%s", m.module, m.newVersion)
 	newContent := m.regex.ReplaceAllString(oldContent, bumpString)
 	if oldContent == newContent {


### PR DESCRIPTION
fix(tools): respect manual major version bumps in go.mod

Previously, the release tool computed module version bumps and blindly 
replaced existing versions in go.mod files using regex. This caused 
manual major version bumps (e.g., v1.0.0) to be incorrectly downgraded 
to computed minor bumps (e.g., v0.18.0), resulting in false-positive 
modifications that blocked the release process.

This commit updates the apply function in module_bump.go to:
- Extract the existing version string from the target go.mod file.
- Parse both the existing and computed versions using semver.
- Dynamically adopt the existing version if it is mathematically 
  greater than the internally computed version.

Fixes #1172