### PR TITLE
Fix nil Reason panic in chartutil

### DIFF
--- a/chartutil/values.go
+++ b/chartutil/values.go
@@ -95,9 +95,9 @@ func (e *ErrValuesReference) Error() string {
 	if key := e.Key; key != "" {
 		b.WriteString(fmt.Sprintf(" with key '%s'", key))
 	}
-	reason := e.Reason.Error()
-	if reason == "" && e.Err == nil {
-		reason = ErrUnknown.Error()
+	reason := ErrUnknown.Error()
+	if e.Reason != nil && e.Reason.Error() != "" {
+		reason = e.Reason.Error()
 	}
 	if e.Err != nil {
 		reason = e.Err.Error()

--- a/chartutil/values_test.go
+++ b/chartutil/values_test.go
@@ -18,6 +18,7 @@ package chartutil
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -26,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/fluxcd/pkg/apis/meta"
@@ -402,6 +404,38 @@ func TestReplacePathValue(t *testing.T) {
 			}
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(values).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestErrValuesReferenceErrorNilReason(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *ErrValuesReference
+		want string
+	}{
+		{
+			name: "without wrapped error",
+			err: &ErrValuesReference{
+				Name: types.NamespacedName{Namespace: "default", Name: "values"},
+			},
+			want: "could not resolve chart values reference 'default/values': unknown error",
+		},
+		{
+			name: "with wrapped error",
+			err: &ErrValuesReference{
+				Name: types.NamespacedName{Namespace: "default", Name: "values"},
+				Err:  errors.New("boom"),
+			},
+			want: "could not resolve chart values reference 'default/values': boom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(func() { _ = tt.err.Error() }).ToNot(Panic())
+			g.Expect(tt.err.Error()).To(Equal(tt.want))
 		})
 	}
 }


### PR DESCRIPTION
`ErrValuesReference.Error()` dereferences `Reason` even though type docs say a nil `Reason` should behave like `ErrUnknown`. 
So `(&chartutil.ErrValuesReference{}).Error()` blows up

This patch falls back to `ErrUnknown` when `Reason` is nil and adds a regression test for zero-value and wrapped-error cases.

Repro
`go test ./... -run TestErrValuesReferenceErrorNilReason`

Checks
`make test-chartutil`
