### PR TITLE
Support force delete propagation policy

### DIFF
--- a/ssa/manager_apply.go
+++ b/ssa/manager_apply.go
@@ -42,6 +42,8 @@ import (
 	"github.com/fluxcd/pkg/ssa/utils"
 )
 
+const forceApplyPropagationPolicyAnnotation = "kustomize.toolkit.fluxcd.io/propagationPolicy"
+
 // ApplyOptions contains options for server-side apply requests.
 type ApplyOptions struct {
 	// Force configures the engine to recreate objects that contain immutable field changes.
@@ -141,7 +143,12 @@ func (m *ResourceManager) Apply(ctx context.Context, object *unstructured.Unstru
 	dryRunObject := object.DeepCopy()
 	if err := m.dryRunApply(ctx, dryRunObject); err != nil {
 		if !errors.IsNotFound(getError) && m.shouldForceApply(object, existingObject, opts, err) {
-			if err := m.client.Delete(ctx, existingObject, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !errors.IsNotFound(err) {
+			deleteOpts, err := forceApplyDeleteOptions(object)
+			if err != nil {
+				return nil, fmt.Errorf("%s immutable field detected, %w",
+					utils.FmtUnstructured(dryRunObject), err)
+			}
+			if err := m.client.Delete(ctx, existingObject, deleteOpts...); err != nil && !errors.IsNotFound(err) {
 				return nil, fmt.Errorf("%s immutable field detected, failed to delete object: %w",
 					utils.FmtUnstructured(dryRunObject), err)
 			}
@@ -256,7 +263,12 @@ func (m *ResourceManager) ApplyAll(ctx context.Context, objects []*unstructured.
 					// as immutable and deleted it when ApplyAll was called the last time (the check for ImmutableError
 					// returns false positives)
 					if !errors.IsNotFound(getError) && m.shouldForceApply(object, existingObject, opts, err) {
-						if err := m.client.Delete(ctx, existingObject, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !errors.IsNotFound(err) {
+						deleteOpts, err := forceApplyDeleteOptions(object)
+						if err != nil {
+							return fmt.Errorf("%s immutable field detected, %w",
+								utils.FmtUnstructured(dryRunObject), err)
+						}
+						if err := m.client.Delete(ctx, existingObject, deleteOpts...); err != nil && !errors.IsNotFound(err) {
 							return fmt.Errorf("%s immutable field detected, failed to delete object: %w",
 								utils.FmtUnstructured(dryRunObject), err)
 						}
@@ -579,6 +591,23 @@ func removeIgnoredFields(matchObj, obj *unstructured.Unstructured, rules jsondif
 	}
 
 	return nil
+}
+
+func forceApplyDeleteOptions(object *unstructured.Unstructured) ([]client.DeleteOption, error) {
+	value, ok := object.GetAnnotations()[forceApplyPropagationPolicyAnnotation]
+	if !ok {
+		// Keep PropagationPolicy unset so the API server owns the default.
+		return nil, nil
+	}
+
+	switch {
+	case strings.EqualFold(value, string(metav1.DeletePropagationBackground)):
+		return []client.DeleteOption{client.PropagationPolicy(metav1.DeletePropagationBackground)}, nil
+	case strings.EqualFold(value, string(metav1.DeletePropagationOrphan)):
+		return []client.DeleteOption{client.PropagationPolicy(metav1.DeletePropagationOrphan)}, nil
+	default:
+		return nil, fmt.Errorf("unsupported propagation policy %q, must be background or orphan", value)
+	}
 }
 
 // lookupJSONPointer resolves an RFC 6901 JSON pointer against the unstructured

--- a/ssa/manager_apply.go
+++ b/ssa/manager_apply.go
@@ -42,15 +42,17 @@ import (
 	"github.com/fluxcd/pkg/ssa/utils"
 )
 
-const forceApplyPropagationPolicyAnnotation = "kustomize.toolkit.fluxcd.io/propagationPolicy"
-
 // ApplyOptions contains options for server-side apply requests.
 type ApplyOptions struct {
 	// Force configures the engine to recreate objects that contain immutable field changes.
+	// The propagation policy used for deleting the existing object can be configured
+	// with the kustomize.toolkit.fluxcd.io/propagationPolicy annotation.
 	Force bool `json:"force"`
 
 	// ForceSelector determines which in-cluster objects are Force applied
 	// based on the matching labels or annotations.
+	// The propagation policy used for deleting the existing object can be configured
+	// with the kustomize.toolkit.fluxcd.io/propagationPolicy annotation.
 	ForceSelector map[string]string `json:"forceSelector"`
 
 	// ExclusionSelector determines which in-cluster objects are skipped from apply
@@ -593,10 +595,15 @@ func removeIgnoredFields(matchObj, obj *unstructured.Unstructured, rules jsondif
 	return nil
 }
 
+const forceApplyPropagationPolicyAnnotation = "kustomize.toolkit.fluxcd.io/propagationPolicy"
+
+// forceApplyDeleteOptions returns delete options for forced immutable object replacement.
+// The kustomize.toolkit.fluxcd.io/propagationPolicy annotation accepts 'background'
+// and 'orphan'. When the annotation is absent, PropagationPolicy remains unset so
+// the API server owns the default.
 func forceApplyDeleteOptions(object *unstructured.Unstructured) ([]client.DeleteOption, error) {
 	value, ok := object.GetAnnotations()[forceApplyPropagationPolicyAnnotation]
 	if !ok {
-		// Keep PropagationPolicy unset so the API server owns the default.
 		return nil, nil
 	}
 

--- a/ssa/manager_apply_test.go
+++ b/ssa/manager_apply_test.go
@@ -532,6 +532,71 @@ func TestApply_Force(t *testing.T) {
 	})
 }
 
+func TestForceApplyDeleteOptions(t *testing.T) {
+	background := metav1.DeletePropagationBackground
+	orphan := metav1.DeletePropagationOrphan
+
+	tests := []struct {
+		name       string
+		annotation string
+		want       *metav1.DeletionPropagation
+		wantErr    string
+	}{
+		{
+			name: "no annotation uses API server default",
+		},
+		{
+			name:       "background annotation sets background policy",
+			annotation: "background",
+			want:       &background,
+		},
+		{
+			name:       "orphan annotation sets orphan policy",
+			annotation: "orphan",
+			want:       &orphan,
+		},
+		{
+			name:       "invalid annotation errors",
+			annotation: "foreground",
+			wantErr:    `unsupported propagation policy "foreground", must be background or orphan`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			object := &unstructured.Unstructured{}
+			if tt.annotation != "" {
+				object.SetAnnotations(map[string]string{
+					forceApplyPropagationPolicyAnnotation: tt.annotation,
+				})
+			}
+
+			opts, err := forceApplyDeleteOptions(object)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				if diff := cmp.Diff(tt.wantErr, err.Error()); diff != "" {
+					t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			deleteOpts := &client.DeleteOptions{}
+			for _, opt := range opts {
+				opt.ApplyToDelete(deleteOpts)
+			}
+
+			if diff := cmp.Diff(tt.want, deleteOpts.PropagationPolicy); diff != "" {
+				t.Errorf("Mismatch from expected value (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestApply_SetNativeKindsDefaults(t *testing.T) {
 	timeout := 10 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)


### PR DESCRIPTION
## What changed

Adds support for `kustomize.toolkit.fluxcd.io/propagationPolicy` when force-applying immutable resource changes. The annotation accepts `background` and `orphan`; when it is absent, the delete request leaves `PropagationPolicy` unset so the Kubernetes API server default applies.

## Why

Force apply previously hardcoded background deletion. This prevented users from orphaning dependents during forced replacement and also meant Flux carried its own default instead of relying on Kubernetes when no annotation was set.

## Validation

- `KUBEBUILDER_ASSETS=... go test -run TestForceApplyDeleteOptions -count=1`
- `go test -c`
- `git diff --check`

`make test-ssa` was attempted, but the full envtest suite failed in existing Kubernetes 1.36 force-apply and API migration cases unrelated to the focused propagation-policy coverage.