### PR TITLE
build: target host arch for local builds/envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,9 @@ GO_TEST_ARGS ?= -race
 # API generation utilities
 CONTROLLER_GEN_VERSION ?= v0.21.0
 
-# Architecture to use envtest with
-ENVTEST_ARCH ?= amd64
+# Architecture to use envtest with; defaults to the host architecture.
+LOCALARCH ?= $(shell go env GOARCH)
+ENVTEST_ARCH ?= $(LOCALARCH)
 
 # Kubernetes versions to use envtest with
 ENVTEST_KUBERNETES_VERSION?=1.36


### PR DESCRIPTION
build fix. `ENVTEST_ARCH` was hardcoded to `amd64`, so anyone on arm64 (apple silicon, arm CI runners, etc) ends up pulling amd64 envtest binaries and running the test suite under emulation.

envtest publishes native arm64 binaries now (including darwin/arm64), so the pin and Darwin override is no longer needed.

I ran all tests and docker-builds across the 9 repos via apple silicon

tracking: https://github.com/fluxcd/flux2/issues/5931