### PR TITLE
auth/utils: ensure registry credentials are always fresh

### DIFF
--- a/auth/utils/registry.go
+++ b/auth/utils/registry.go
@@ -24,6 +24,17 @@ import (
 	"github.com/fluxcd/pkg/auth"
 )
 
+// delegatedAuthenticator is an authn.Authenticator that delegates
+// calls for Authorization to a provided function.
+type delegatedAuthenticator struct {
+	authorizationFunc func() (*authn.AuthConfig, error)
+}
+
+// Authorization implements authn.Authenticator.
+func (d *delegatedAuthenticator) Authorization() (*authn.AuthConfig, error) {
+	return d.authorizationFunc()
+}
+
 // GetArtifactRegistryCredentials retrieves the registry credentials for the
 // specified artifact repository and provider.
 func GetArtifactRegistryCredentials(ctx context.Context, providerName string,
@@ -34,5 +45,15 @@ func GetArtifactRegistryCredentials(ctx context.Context, providerName string,
 		return nil, err
 	}
 
-	return auth.GetArtifactRegistryCredentials(ctx, provider, artifactRepository, opts...)
+	// Fetch credentials lazily by wrapping the call to auth.GetArtifactRegistryCredentials
+	// in a delegatedAuthenticator. This ensures that credentials are fresh when
+	// Authorization() is called on the authn.Authenticator returned by this function.
+	authorizationFunc := func() (*authn.AuthConfig, error) {
+		authenticator, err := auth.GetArtifactRegistryCredentials(ctx, provider, artifactRepository, opts...)
+		if err != nil {
+			return nil, err
+		}
+		return authenticator.Authorization()
+	}
+	return &delegatedAuthenticator{authorizationFunc: authorizationFunc}, nil
 }

--- a/auth/utils/registry_test.go
+++ b/auth/utils/registry_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	authutils "github.com/fluxcd/pkg/auth/utils"
+)
+
+func TestGetArtifactRegistryCredentials(t *testing.T) {
+	t.Run("credentials are fetched lazily", func(t *testing.T) {
+		g := NewWithT(t)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Force the context to be canceled to verify that credentials are fetched lazily.
+
+		artifactRepository := "012345678901.dkr.ecr.us-east-1.amazonaws.com/repo"
+		authenticator, err := authutils.GetArtifactRegistryCredentials(ctx, "aws", artifactRepository)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(authenticator).NotTo(BeNil())
+
+		authConfig, err := authenticator.Authorization()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err).To(MatchError(ContainSubstring("context canceled")))
+		g.Expect(authConfig).To(BeNil())
+	})
+}


### PR DESCRIPTION
This PR fixes a bug **(not a vuln!)**, but I have never seen it happen, there are no user reports that I'm aware of.

Long-running operations using artifact registry credentials for multiple OCI/HTTP calls can hit 401, since credentials are statically resolved by `auth.GetArtifactRegistryCredentials()`. That function returns a user+pass pair immediately (due to how `auth/{aws|azure|gcp}` are implemented for ECR/ACR/GAR). In other words, the `Authorize()` method of the returned `authn.Authenticator` will return a cached user+pass pair that never changes. This fix delays the call to `auth.GetArtifactRegistryCredentials()` to happen on demand inside `authn.Authenticator.Authorize()`, which ensures that multiple calls will always return a fresh credential. This is because `auth.GetArtifactRegistryCredentials()` has a smart cache inside that keeps track of the credential lifetime. This makes it never return an expired credential, as a new one is created when the cached one is expired (the cache knows when).

This fix is super good for `flux-mirror sync`, which calls `auth/utills.GetArtifactRegistryCredentials()` (not the low-level one from `auth`) for ECR/ACR/GAR only once during the process startup and hands the `authn.Authenticator` off to `go-containerregistry`. Before this fix, `go-containerregistry` would call `Authorize()` again internally upon a 401 and get the same credentials acquired during process startup. This PR causes `Authorize()` to return valid creds on every call.

I don't think SC or IRC would ever hit this bug, since their operations are not super long. The reconcilers just perform a handful of calls, and no OCI artifact is large enough that it takes 2-digit minutes to reconcile. But this PR fixes the whole thing anyway.