### PR TITLE
Fix envsubst parse of empty replace pattern

### DIFF
--- a/envsubst/eval_test.go
+++ b/envsubst/eval_test.go
@@ -126,6 +126,18 @@ func TestExpand(t *testing.T) {
 			input:  "${stringZ/#abc/XYZ}",
 			output: "XYZABC123ABCabc",
 		},
+		// replace prefix with empty pattern (prepend)
+		{
+			params: map[string]string{"stringZ": "somevalue"},
+			input:  "${stringZ/#/prefix-}",
+			output: "prefix-somevalue",
+		},
+		// replace suffix with empty pattern (append)
+		{
+			params: map[string]string{"stringZ": "somevalue"},
+			input:  "${stringZ/%/-suffix}",
+			output: "somevalue-suffix",
+		},
 		// replace all
 		{
 			params: map[string]string{"stringZ": "abcABC123ABCabc"},

--- a/envsubst/parse/parse.go
+++ b/envsubst/parse/parse.go
@@ -283,11 +283,18 @@ func (t *Tree) parseReplaceFunc(name string) (Node, error) {
 
 	// scan arg[1]
 	{
-		param, err := t.parseParam(acceptNotSlash, scanIdent|scanEscape)
-		if err != nil {
-			return nil, err
+		// An empty pattern (e.g. ${param/#/string}) means the next rune is the
+		// delimiter, so there is nothing to scan. Record an empty pattern node
+		// to keep the two-argument shape the eval side expects.
+		if t.scanner.peek() == '/' {
+			node.Args = append(node.Args, newTextNode(""))
+		} else {
+			param, err := t.parseParam(acceptNotSlash, scanIdent|scanEscape)
+			if err != nil {
+				return nil, err
+			}
+			node.Args = append(node.Args, param)
 		}
-		node.Args = append(node.Args, param)
 	}
 
 	// expect delimiter

--- a/envsubst/parse/parse_test.go
+++ b/envsubst/parse/parse_test.go
@@ -219,6 +219,28 @@ var tests = []struct {
 			},
 		},
 	},
+	{
+		Text: "${string/#/replacement}",
+		Node: &FuncNode{
+			Param: "string",
+			Name:  "/#",
+			Args: []Node{
+				&TextNode{Value: ""},
+				&TextNode{Value: "replacement"},
+			},
+		},
+	},
+	{
+		Text: "${string/%/replacement}",
+		Node: &FuncNode{
+			Param: "string",
+			Name:  "/%",
+			Args: []Node{
+				&TextNode{Value: ""},
+				&TextNode{Value: "replacement"},
+			},
+		},
+	},
 
 	//
 	// default value functions


### PR DESCRIPTION
Fixes #947.

An empty pattern in a replace expansion is valid in bash: ${VAR/#/prefix-} prepends and ${VAR/%/-suffix} appends. envsubst rejects both with "unable to parse substitution within function". In parseReplaceFunc, after consuming the / and the # (or %) it scans the pattern with acceptNotSlash, but when the pattern is empty the next rune is already the delimiter, so it accepts zero chars and returns an illegal token.

The fix peeks for the delimiter first and records an empty pattern node instead of scanning, keeping the two-arg shape the eval side expects (replacePrefix/replaceSuffix already handle an empty pattern, since HasPrefix/HasSuffix with "" are true). This mirrors the existing empty-replacement handling a few lines below. Added eval and parse test cases that fail on current code with the same error from the issue and pass with the fix; go test -race, go vet and gofmt are clean for the envsubst packages.

This only covers #947 and its empty-suffix sibling. It doesn't touch #948 (${VAR/#""/prefix-}, an explicitly quoted empty pattern), which goes through a different scanning path and currently produces a silent no-op rather than a parse error - leaving that for a separate change.
