### PR TITLE
Add backport label for Flux 2.9

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -34,3 +34,6 @@
 - name: backport:flux/v2.8.x
   description: To be backported to flux/v2.8.x
   color: '#ffd700'
+- name: backport:flux/v2.9.x
+  description: To be backported to flux/v2.9.x
+  color: '#ffd700'


### PR DESCRIPTION
Part of https://github.com/fluxcd/flux2/issues/5942