### PR TITLE
kustomize: preserve existing image fields when merging spec.images

### DIFF
--- a/kustomize/kustomize_generator.go
+++ b/kustomize/kustomize_generator.go
@@ -299,16 +299,27 @@ func (g *Generator) GenerateManifest(dirPath string) ([]byte, string, Action, er
 	}
 
 	for _, image := range images {
-		newImage := kustypes.Image{
-			Name:    image.Name,
-			NewName: image.NewName,
-			NewTag:  image.NewTag,
-			Digest:  image.Digest,
-		}
 		if exists, index := checkKustomizeImageExists(kus.Images, image.Name); exists {
-			kus.Images[index] = newImage
+			// Merge the individual fields into the existing entry, so that
+			// fields set only in the kustomization.yaml (e.g. newTag) are
+			// preserved when the Kustomization overrides a subset of them,
+			// matching the behavior of a kustomize overlay.
+			if image.NewName != "" {
+				kus.Images[index].NewName = image.NewName
+			}
+			if image.NewTag != "" {
+				kus.Images[index].NewTag = image.NewTag
+			}
+			if image.Digest != "" {
+				kus.Images[index].Digest = image.Digest
+			}
 		} else {
-			kus.Images = append(kus.Images, newImage)
+			kus.Images = append(kus.Images, kustypes.Image{
+				Name:    image.Name,
+				NewName: image.NewName,
+				NewTag:  image.NewTag,
+				Digest:  image.Digest,
+			})
 		}
 	}
 

--- a/kustomize/kustomize_generator.go
+++ b/kustomize/kustomize_generator.go
@@ -307,10 +307,8 @@ func (g *Generator) GenerateManifest(dirPath string) ([]byte, string, Action, er
 			if image.NewName != "" {
 				kus.Images[index].NewName = image.NewName
 			}
-			if image.NewTag != "" {
+			if image.NewTag != "" || image.Digest != "" {
 				kus.Images[index].NewTag = image.NewTag
-			}
-			if image.Digest != "" {
 				kus.Images[index].Digest = image.Digest
 			}
 		} else {

--- a/kustomize/kustomize_generator.go
+++ b/kustomize/kustomize_generator.go
@@ -307,6 +307,15 @@ func (g *Generator) GenerateManifest(dirPath string) ([]byte, string, Action, er
 			if image.NewName != "" {
 				kus.Images[index].NewName = image.NewName
 			}
+			// NewTag and Digest both select the image version, so they are
+			// updated as a single unit: setting one clears the other. This
+			// mirrors the kustomize image transformer, which replaces both
+			// original values whenever either is overridden (see
+			// sigs.k8s.io/kustomize api/filters/imagetag/updater.go), and
+			// the API contract that Digest takes precedence over NewTag.
+			// Keeping a stale digest next to a fresh tag would render
+			// "name:tag@digest", where the old digest silently wins at
+			// pull time.
 			if image.NewTag != "" || image.Digest != "" {
 				kus.Images[index].NewTag = image.NewTag
 				kus.Images[index].Digest = image.Digest

--- a/kustomize/kustomize_generator_test.go
+++ b/kustomize/kustomize_generator_test.go
@@ -316,6 +316,71 @@ spec:
 			expectedImage: "registry.example.com/app@" + digest,
 		},
 		{
+			name: "existing digest is cleared when only newTag is set",
+			existingImages: []kustypes.Image{
+				{Name: containerImage, Digest: digest},
+			},
+			fluxImages: []kustypes.Image{
+				{Name: containerImage, NewTag: "v2.0.0"},
+			},
+			expectedImages: []kustypes.Image{
+				{Name: containerImage, NewTag: "v2.0.0"},
+			},
+			expectedImage: containerImage + ":v2.0.0",
+		},
+		{
+			name: "existing newTag is cleared when only digest is set",
+			existingImages: []kustypes.Image{
+				{Name: containerImage, NewTag: "v1.2.3"},
+			},
+			fluxImages: []kustypes.Image{
+				{Name: containerImage, Digest: digest},
+			},
+			expectedImages: []kustypes.Image{
+				{Name: containerImage, Digest: digest},
+			},
+			expectedImage: containerImage + "@" + digest,
+		},
+		{
+			name: "existing newName is preserved when newTag replaces digest",
+			existingImages: []kustypes.Image{
+				{Name: containerImage, NewName: "registry.example.com/app", Digest: digest},
+			},
+			fluxImages: []kustypes.Image{
+				{Name: containerImage, NewTag: "v2.0.0"},
+			},
+			expectedImages: []kustypes.Image{
+				{Name: containerImage, NewName: "registry.example.com/app", NewTag: "v2.0.0"},
+			},
+			expectedImage: "registry.example.com/app:v2.0.0",
+		},
+		{
+			name: "newTag and digest set together are both applied",
+			existingImages: []kustypes.Image{
+				{Name: containerImage, NewTag: "v1.2.3"},
+			},
+			fluxImages: []kustypes.Image{
+				{Name: containerImage, NewTag: "v2.0.0", Digest: digest},
+			},
+			expectedImages: []kustypes.Image{
+				{Name: containerImage, NewTag: "v2.0.0", Digest: digest},
+			},
+			expectedImage: containerImage + ":v2.0.0@" + digest,
+		},
+		{
+			name: "entry with only a name leaves the existing entry unchanged",
+			existingImages: []kustypes.Image{
+				{Name: containerImage, NewName: "registry.example.com/app", NewTag: "v1.2.3"},
+			},
+			fluxImages: []kustypes.Image{
+				{Name: containerImage},
+			},
+			expectedImages: []kustypes.Image{
+				{Name: containerImage, NewName: "registry.example.com/app", NewTag: "v1.2.3"},
+			},
+			expectedImage: "registry.example.com/app:v1.2.3",
+		},
+		{
 			name: "existing fields are overridden when set",
 			existingImages: []kustypes.Image{
 				{Name: containerImage, NewName: "old.example.com/app", NewTag: "v1.2.3"},

--- a/kustomize/kustomize_generator_test.go
+++ b/kustomize/kustomize_generator_test.go
@@ -247,6 +247,163 @@ func Test_Components(t *testing.T) {
 	}
 }
 
+func Test_Images(t *testing.T) {
+	const containerImage = "ghcr.io/example/app"
+	const digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	deployment := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+        - name: app
+          image: ` + containerImage + `
+`
+
+	tests := []struct {
+		name           string
+		existingImages []kustypes.Image
+		fluxImages     []kustypes.Image
+		expectedImages []kustypes.Image
+		expectedImage  string
+	}{
+		{
+			name: "existing newTag is preserved when only newName is set",
+			existingImages: []kustypes.Image{
+				{Name: containerImage, NewTag: "v1.2.3"},
+			},
+			fluxImages: []kustypes.Image{
+				{Name: containerImage, NewName: "registry.example.com/app"},
+			},
+			expectedImages: []kustypes.Image{
+				{Name: containerImage, NewName: "registry.example.com/app", NewTag: "v1.2.3"},
+			},
+			expectedImage: "registry.example.com/app:v1.2.3",
+		},
+		{
+			name: "existing newName is preserved when only newTag is set",
+			existingImages: []kustypes.Image{
+				{Name: containerImage, NewName: "registry.example.com/app"},
+			},
+			fluxImages: []kustypes.Image{
+				{Name: containerImage, NewTag: "v2.0.0"},
+			},
+			expectedImages: []kustypes.Image{
+				{Name: containerImage, NewName: "registry.example.com/app", NewTag: "v2.0.0"},
+			},
+			expectedImage: "registry.example.com/app:v2.0.0",
+		},
+		{
+			name: "existing digest is preserved when only newName is set",
+			existingImages: []kustypes.Image{
+				{Name: containerImage, Digest: digest},
+			},
+			fluxImages: []kustypes.Image{
+				{Name: containerImage, NewName: "registry.example.com/app"},
+			},
+			expectedImages: []kustypes.Image{
+				{Name: containerImage, NewName: "registry.example.com/app", Digest: digest},
+			},
+			expectedImage: "registry.example.com/app@" + digest,
+		},
+		{
+			name: "existing fields are overridden when set",
+			existingImages: []kustypes.Image{
+				{Name: containerImage, NewName: "old.example.com/app", NewTag: "v1.2.3"},
+			},
+			fluxImages: []kustypes.Image{
+				{Name: containerImage, NewName: "registry.example.com/app", NewTag: "v2.0.0"},
+			},
+			expectedImages: []kustypes.Image{
+				{Name: containerImage, NewName: "registry.example.com/app", NewTag: "v2.0.0"},
+			},
+			expectedImage: "registry.example.com/app:v2.0.0",
+		},
+		{
+			name: "image without existing entry is appended",
+			fluxImages: []kustypes.Image{
+				{Name: containerImage, NewName: "registry.example.com/app", NewTag: "v2.0.0"},
+			},
+			expectedImages: []kustypes.Image{
+				{Name: containerImage, NewName: "registry.example.com/app", NewTag: "v2.0.0"},
+			},
+			expectedImage: "registry.example.com/app:v2.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			tmpDir, err := testTempDir(t)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(os.WriteFile(filepath.Join(tmpDir, "deployment.yaml"), []byte(deployment), 0o644)).To(Succeed())
+			kusYAML, err := yaml.Marshal(kustypes.Kustomization{
+				TypeMeta: kustypes.TypeMeta{
+					APIVersion: kustypes.KustomizationVersion,
+					Kind:       kustypes.KustomizationKind,
+				},
+				Resources: []string{"deployment.yaml"},
+				Images:    tt.existingImages,
+			})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(os.WriteFile(filepath.Join(tmpDir, "kustomization.yaml"), kusYAML, 0o644)).To(Succeed())
+
+			fluxImages := make([]any, 0, len(tt.fluxImages))
+			for _, im := range tt.fluxImages {
+				m := map[string]any{"name": im.Name}
+				if im.NewName != "" {
+					m["newName"] = im.NewName
+				}
+				if im.NewTag != "" {
+					m["newTag"] = im.NewTag
+				}
+				if im.Digest != "" {
+					m["digest"] = im.Digest
+				}
+				fluxImages = append(fluxImages, m)
+			}
+			ks := unstructured.Unstructured{Object: map[string]any{}}
+			g.Expect(unstructured.SetNestedSlice(ks.Object, fluxImages, "spec", "images")).To(Succeed())
+
+			_, err = kustomize.NewGenerator(tmpDir, ks).WriteFile(tmpDir)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			kfileYAML, err := os.ReadFile(filepath.Join(tmpDir, "kustomization.yaml"))
+			g.Expect(err).ToNot(HaveOccurred())
+			var kus kustypes.Kustomization
+			g.Expect(yaml.Unmarshal(kfileYAML, &kus)).To(Succeed())
+			g.Expect(kus.Images).To(Equal(tt.expectedImages))
+
+			resMap, err := kustomize.SecureBuild(tmpDir, tmpDir, false)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(resMap.Resources()).To(HaveLen(1))
+
+			out, err := resMap.AsYaml()
+			g.Expect(err).ToNot(HaveOccurred())
+			var obj map[string]interface{}
+			g.Expect(yaml.Unmarshal(out, &obj)).To(Succeed())
+			containers, found, err := unstructured.NestedSlice(obj, "spec", "template", "spec", "containers")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(containers).To(HaveLen(1))
+			image, found, err := unstructured.NestedString(containers[0].(map[string]interface{}), "image")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(image).To(Equal(tt.expectedImage))
+		})
+	}
+}
+
 func TestGenerator_BuildMetadata(t *testing.T) {
 	g := NewWithT(t)
 	dataKS, err := os.ReadFile("./testdata/buildMetadata/ks.yaml")


### PR DESCRIPTION
Fixes the image tag loss reported in fluxcd/flux2#5787.

When the `kustomization.yaml` at the Kustomization's `spec.path` already contains an `images` entry for the same image name, the generator replaced the whole entry with the one from `spec.images`, silently dropping any field set only in the existing entry. With `spec.images` setting only `newName`, the `newTag` applied by the `kustomization.yaml` was lost and the build produced an untagged image reference — diverging from how a kustomize overlay handles a partial image override (root cause analysis in https://github.com/fluxcd/flux2/issues/5787#issuecomment-4965566628).

This changes the generator to merge the fields into the existing entry instead. `newName` is merged independently, while `newTag` and `digest` are updated as a single unit: setting one clears the other. The pairing mirrors the kustomize image transformer, which replaces both original values whenever either of them is overridden ([`api/filters/imagetag/updater.go#L39-L53`](https://github.com/kubernetes-sigs/kustomize/blob/api/v0.21.1/api/filters/imagetag/updater.go#L39-L53)), and the `Image.Digest` API contract ("If digest is present NewTag value is ignored"). Without the pairing, an existing `digest` merged with an incoming `newTag` would produce `name:tag@digest`, where the stale digest silently wins at pull time while the manifest reads as updated.

| # | existing entry | `spec.images` | before (replace) | after (merge) |
|---|---|---|---|---|
| 1 | `newTag: v1.2.3` | `newName: reg/app` | `reg/app` — tag lost | `reg/app:v1.2.3` |
| 2 | `newName: reg/app` | `newTag: v2.0.0` | `app:v2.0.0` — newName lost | `reg/app:v2.0.0` |
| 3 | `digest: sha256:d1` | `newName: reg/app` | `reg/app` — digest lost | `reg/app@sha256:d1` |
| 4 | `digest: sha256:d1` | `newTag: v2.0.0` | `app:v2.0.0` | `app:v2.0.0` — digest cleared, not kept |
| 5 | `newTag: v1.2.3` | `digest: sha256:d2` | `app@sha256:d2` | `app@sha256:d2` — tag cleared, not kept |
| 6 | `newName: reg/app`, `digest: sha256:d1` | `newTag: v2.0.0` | `app:v2.0.0` — newName lost | `reg/app:v2.0.0` — newName kept, digest cleared |
| 7 | `newTag: v1.2.3` | `newTag: v2.0.0`, `digest: sha256:d2` | `app:v2.0.0@sha256:d2` | `app:v2.0.0@sha256:d2` — both set explicitly, both applied |
| 8 | `newName: reg/app`, `newTag: v1.2.3` | *(only `name`)* | `app` — all overrides lost | `reg/app:v1.2.3` — no-op |

The cross-axis rows (1–3, 6) are the actual bug fix: `newName` selects *where* the image lives, `newTag`/`digest` select *which version*, and a partial override of one axis no longer clobbers the other. On the version axis (rows 4–5) the merge intentionally behaves like the old replace, so switching between tag and digest pinning never leaves a stale value of the other field behind.

`Test_Images` covers every row above — asserting both the merged `kustomization.yaml` entry and the final image reference rendered through a real kustomize build — plus a full override of all fields and appending an entry with no existing match. The behavior was also reproduced end-to-end against kustomize-controller v1.8.5 and v1.9.3 (https://github.com/gecube/flux2-5787-repro).
