### PR TITLE
auth: sync ECR detection with upstream

### DIFF
--- a/auth/aws/provider.go
+++ b/auth/aws/provider.go
@@ -204,23 +204,33 @@ func (p Provider) GetAccessTokenOptionsForArtifactRepository(artifactRepository 
 }
 
 // This regex is sourced from the AWS ECR Credential Helper (https://github.com/awslabs/amazon-ecr-credential-helper).
-// It covers both public AWS partitions like amazonaws.com, China partitions like amazonaws.com.cn, and non-public partitions.
-const registryPattern = `([0-9+]*).dkr[.-]ecr(?:-fips)?\.([^/.]*)\.(amazonaws\.com[.cn]*|amazonaws\.eu|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov|on\.aws)`
+// It covers the public AWS partition (amazonaws.com), the China partitions (amazonaws.com.cn), the European Sovereign
+// Cloud (amazonaws.eu) and the non-public partitions, as well as the dual-stack hostnames used for IPv6 access
+// (on.aws and on.amazonwebservices.com.cn).
+// The pattern is anchored so that it matches the registry host in full rather than any substring of it, which is what
+// makes a match proof that the host belongs to ECR.
+const registryPattern = `^([0-9]{12})\.dkr[.-]ecr(?:-fips)?\.([a-zA-Z0-9][a-zA-Z0-9_-]{0,99})\.(amazonaws\.(?:com(?:\.cn)?|eu)|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`
 
-const publicECR = "public.ecr.aws"
+// The public ECR registry is reachable over an IPv4-only hostname and a dual-stack one.
+const (
+	publicECR          = "public.ecr.aws"
+	publicECRDualStack = "ecr-public.aws.com"
+)
 
 var registryRegex = regexp.MustCompile(registryPattern)
 
 // ParseArtifactRepository implements auth.Provider.
-// ParseArtifactRepository returns the ECR region, unless the registry
-// is public.ecr.aws, in which case it returns public.ecr.aws.
+// ParseArtifactRepository returns the ECR region, unless the registry is one of
+// the public ECR hostnames, in which case it returns public.ecr.aws.
 func (Provider) ParseArtifactRepository(artifactRepository string) (string, error) {
 	registry, err := auth.GetRegistryFromArtifactRepository(artifactRepository)
 	if err != nil {
 		return "", err
 	}
 
-	if registry == publicECR {
+	// Both public hostnames are normalized to publicECR, which is what selects
+	// the public authorization token API and the us-east-1 region downstream.
+	if registry == publicECR || registry == publicECRDualStack {
 		return publicECR, nil
 	}
 

--- a/auth/aws/provider_test.go
+++ b/auth/aws/provider_test.go
@@ -387,6 +387,16 @@ func TestProvider_ParseArtifactRepository(t *testing.T) {
 			expectValid:        true,
 		},
 		{
+			artifactRepository: "012345678901.dkr-ecr.cn-north-1.on.amazonwebservices.com.cn/foo",
+			expectedRegion:     "cn-north-1",
+			expectValid:        true,
+		},
+		{
+			artifactRepository: "012345678901.dkr-ecr.cn-north-1.on.amazonwebservices.com.cn",
+			expectedRegion:     "cn-north-1",
+			expectValid:        true,
+		},
+		{
 			artifactRepository: "gcr.io/foo/bar:baz",
 			expectValid:        false,
 		},
@@ -394,6 +404,62 @@ func TestProvider_ParseArtifactRepository(t *testing.T) {
 			artifactRepository: "public.ecr.aws/foo/bar",
 			expectedRegion:     "public.ecr.aws",
 			expectValid:        true,
+		},
+		{
+			artifactRepository: "ecr-public.aws.com/foo/bar",
+			expectedRegion:     "public.ecr.aws",
+			expectValid:        true,
+		},
+		{
+			artifactRepository: "ecr-public.aws.com",
+			expectedRegion:     "public.ecr.aws",
+			expectValid:        true,
+		},
+		// Hosts that merely embed an ECR hostname are not ECR hosts.
+		{
+			artifactRepository: "012345678901.dkr.ecr.us-east-1.amazonaws.com.example.org/foo",
+			expectValid:        false,
+		},
+		{
+			artifactRepository: "012345678901.dkr.ecr.us-east-1.amazonaws.com.example.org",
+			expectValid:        false,
+		},
+		{
+			artifactRepository: "prefix-012345678901.dkr.ecr.us-east-1.amazonaws.com/foo",
+			expectValid:        false,
+		},
+		{
+			artifactRepository: "xdkr.ecr.us-east-1.amazonaws.com.example.org/foo",
+			expectValid:        false,
+		},
+		{
+			artifactRepository: "012345678901.dkr.ecr.us-east-1.amazonaws.comcn/foo",
+			expectValid:        false,
+		},
+		{
+			artifactRepository: "012345678901.dkr.ecr.us-east-1.amazonaws.com.nc/foo",
+			expectValid:        false,
+		},
+		{
+			artifactRepository: "012345678901Xdkr.ecr.us-east-1.amazonaws.com/foo",
+			expectValid:        false,
+		},
+		{
+			artifactRepository: "public.ecr.aws.example.org/foo/bar",
+			expectValid:        false,
+		},
+		{
+			artifactRepository: "ecr-public.aws.com.example.org/foo/bar",
+			expectValid:        false,
+		},
+		// The registry ID is an AWS account ID, which is always 12 digits.
+		{
+			artifactRepository: "01234567890.dkr.ecr.us-east-1.amazonaws.com/foo",
+			expectValid:        false,
+		},
+		{
+			artifactRepository: "0123456789012.dkr.ecr.us-east-1.amazonaws.com/foo",
+			expectValid:        false,
 		},
 	}
 


### PR DESCRIPTION
Our ECR detection logic was lagging behind upstream and missed dual-stack support for Public ECR and China region. 

This PR brings Flux ECR detection on par with [amazon-ecr-credential-helper `ecrPattern` (v0.12.0)](https://github.com/awslabs/amazon-ecr-credential-helper/blob/v0.12.0/ecr-login/api/client.go#L35-L42).