### PR TITLE
Fix Azure e2e tests after new major version with breaking changes

### DIFF
--- a/tests/integration/terraform/azure/version.tf
+++ b/tests/integration/terraform/azure/version.tf
@@ -1,7 +1,11 @@
 terraform {
   required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.20.0, <5.0.0"
+    }
     azuredevops = {
-      source  = "microsoft/azuredevops"
+      source = "microsoft/azuredevops"
     }
   }
 }


### PR DESCRIPTION
`hashicorp/azurerm` shipped v5.0 yesterday with lots of breaking changes. This PR mitigates the breakage by pinning to below v5.0. Later we can upgrade to the new version with the required changes.