### PR TITLE
envsubst: support a negative substring length instead of panicking

### DIFF
--- a/envsubst/funcs.go
+++ b/envsubst/funcs.go
@@ -121,6 +121,18 @@ func toSubstr(s string, args ...string) string {
 		return s
 	}
 
+	if length < 0 {
+		// a negative length counts back from the end of the string, so
+		// ${var:1:-1} drops the first and the last character.
+		end := len(s) + length
+		if end < pos {
+			// bash rejects this as a negative substring expression.
+			return ""
+		}
+
+		return s[pos:end]
+	}
+
 	if pos+length >= len(s) {
 		if pos < len(s) {
 			// if the position exceeds the length of the

--- a/envsubst/funcs_test.go
+++ b/envsubst/funcs_test.go
@@ -121,4 +121,24 @@ func Test_substr(t *testing.T) {
 	if got != want {
 		t.Errorf("Expect substr function to cut entire string if pos is itself out of bound")
 	}
+
+	got, want = toSubstr("hello world", "2", "-1"), "llo worl"
+	if got != want {
+		t.Errorf("Expect substr function to count a negative length back from the end, got %q want %q", got, want)
+	}
+
+	got, want = toSubstr("hello world", "0", "-3"), "hello wo"
+	if got != want {
+		t.Errorf("Expect substr function to count a negative length back from the end at offset 0, got %q want %q", got, want)
+	}
+
+	got, want = toSubstr("hello world", "8", "-8"), ""
+	if got != want {
+		t.Errorf("Expect substr function to return empty when a negative length ends before the offset, got %q want %q", got, want)
+	}
+
+	got, want = toSubstr("hello world", "-4", "-1"), "orl"
+	if got != want {
+		t.Errorf("Expect substr function to combine a negative offset with a negative length, got %q want %q", got, want)
+	}
 }


### PR DESCRIPTION
`toSubstr` parses the length argument and then slices with it directly:

```go
length, err := strconv.Atoi(args[1])
...
return s[pos : pos+length]
```

A negative length is never considered, so `${VAR:2:-1}` builds a backwards slice and panics:

```
panic: runtime error: slice bounds out of range [2:1]
```

That is reachable straight through the public API, not just the helper:

```go
Eval("${VAR:2:-1}", func(string) (string, bool) { return "hello world", true })
```

which matters because with post-build substitution the template is the manifest text, so the expression that crashes the process can come from a Kustomization rather than from the operator's own environment.

The rest of this file goes out of its way to match bash ("bash returns the string if the position cannot be parsed"), and bash has had negative lengths since 4.2: they count back from the end of the string, and the expression is rejected when the end lands before the offset. I checked the cases against bash 5 rather than going from the manual:

```
$ VAR="hello world"; echo "[${VAR:2:-1}]"; echo "[${VAR:0:-3}]"; echo "[${VAR: -4:-1}]"; echo "[${VAR:8:-8}]"
[llo worl]
[hello wo]
[orl]
bash: line 1: -8: substring expression < 0
```

So this handles the negative length the same way, returning an empty string for the case bash errors on, since these helpers have no error channel. Positive lengths take exactly the same path as before.

Four cases added to `Test_substr`. On the unmodified tree the first of them panics and takes the test binary down; with the change `go test ./...` passes across the envsubst module.
