### PR TITLE
runtime/client: Reject file references in kubeconfigs

### DIFF
--- a/runtime/client/impersonator.go
+++ b/runtime/client/impersonator.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	rc "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
@@ -218,7 +217,11 @@ func (i *Impersonator) getRESTConfigFromSecret(ctx context.Context) (*rest.Confi
 		return nil, fmt.Errorf("KubeConfig secret '%s' does not contain a 'value' key with a kubeconfig", secretName)
 	}
 
-	return clientcmd.RESTConfigFromKubeConfig(kubeConfig)
+	restConfig, err := KubeConfigFromBytes(kubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("invalid KubeConfig in secret '%s': %w", secretName, err)
+	}
+	return restConfig, nil
 }
 
 func (i *Impersonator) setImpersonationConfig(restConfig *rest.Config) {

--- a/runtime/client/impersonator_test.go
+++ b/runtime/client/impersonator_test.go
@@ -247,6 +247,36 @@ func TestGetRESTConfigFromSecret(t *testing.T) {
 			},
 			wantErrContains: "does not contain a 'value' key",
 		},
+		{
+			name: "error when kubeconfig references a token file",
+			secretRef: &meta.KubeConfigReference{
+				SecretRef: &meta.SecretKeyReference{Name: "kc-tokenfile"},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kc-tokenfile",
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{"value": []byte(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://1.2.3.4
+  name: development
+contexts:
+- context:
+    cluster: development
+    user: developer
+  name: dev
+current-context: dev
+users:
+- name: developer
+  user:
+    tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token`)},
+			},
+			wantErrContains: "invalid KubeConfig in secret",
+		},
 	}
 
 	for _, tt := range tests {

--- a/runtime/client/kubeconfig.go
+++ b/runtime/client/kubeconfig.go
@@ -18,11 +18,14 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/fluxcd/cli-utils/pkg/flowcontrol"
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 const (
@@ -65,6 +68,57 @@ func (o *KubeConfigOptions) BindFlags(fs *pflag.FlagSet) {
 		"Allow use of the user.exec section in kubeconfigs provided for remote apply.")
 	fs.BoolVar(&o.InsecureTLS, flagInsecureKubeConfigTLS, false,
 		"Allow that kubeconfigs provided for remote apply can disable TLS verification.")
+}
+
+// KubeConfigFromBytes builds a *rest.Config from the given serialized
+// kubeconfig. The kubeconfig must be self-contained: credentials and
+// certificates have to be embedded inline (`token`, `client-certificate-data`,
+// `client-key-data`, `certificate-authority-data`). References to files on the
+// local filesystem (`tokenFile`, `client-certificate`, `client-key`,
+// `certificate-authority`) are rejected.
+//
+// The returned config is not sanitized; callers are expected to pass it
+// through KubeConfig.
+func KubeConfigFromBytes(kubeConfig []byte) (*rest.Config, error) {
+	cfg, err := clientcmd.Load(kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+	if err := ValidateKubeConfig(cfg); err != nil {
+		return nil, err
+	}
+	return clientcmd.NewDefaultClientConfig(*cfg, &clientcmd.ConfigOverrides{}).ClientConfig()
+}
+
+// ValidateKubeConfig returns an error if any cluster or user entry in the
+// given kubeconfig references a file on the local filesystem instead of
+// embedding the data inline.
+func ValidateKubeConfig(cfg *clientcmdapi.Config) error {
+	if cfg == nil {
+		return fmt.Errorf("kubeconfig is nil")
+	}
+	for name, cluster := range cfg.Clusters {
+		if cluster == nil {
+			return fmt.Errorf("cluster '%s' is nil", name)
+		}
+		if cluster.CertificateAuthority != "" {
+			return fmt.Errorf("cluster '%s' references a certificate-authority file, only certificate-authority-data is supported", name)
+		}
+	}
+	for name, user := range cfg.AuthInfos {
+		if user == nil {
+			return fmt.Errorf("user '%s' is nil", name)
+		}
+		switch {
+		case user.TokenFile != "":
+			return fmt.Errorf("user '%s' references a tokenFile, only an inline token is supported", name)
+		case user.ClientCertificate != "":
+			return fmt.Errorf("user '%s' references a client-certificate file, only client-certificate-data is supported", name)
+		case user.ClientKey != "":
+			return fmt.Errorf("user '%s' references a client-key file, only client-key-data is supported", name)
+		}
+	}
+	return nil
 }
 
 // KubeConfig sanitises a kubeconfig represented as *rest.Config using

--- a/runtime/client/kubeconfig_test.go
+++ b/runtime/client/kubeconfig_test.go
@@ -166,3 +166,152 @@ func TestKubeConfig(t *testing.T) {
 func duration(d time.Duration) *time.Duration {
 	return &d
 }
+
+const testKubeConfigInline = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://1.2.3.4
+  name: development
+contexts:
+- context:
+    cluster: development
+    user: developer
+  name: dev
+current-context: dev
+users:
+- name: developer
+  user:
+    token: some-token`
+
+func TestKubeConfigFromBytes(t *testing.T) {
+	tests := []struct {
+		name       string
+		kubeConfig string
+		wantErr    string
+	}{
+		{
+			name:       "inline credentials",
+			kubeConfig: testKubeConfigInline,
+		},
+		{
+			name: "token file reference",
+			kubeConfig: `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://1.2.3.4
+  name: development
+contexts:
+- context:
+    cluster: development
+    user: developer
+  name: dev
+current-context: dev
+users:
+- name: developer
+  user:
+    tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token`,
+			wantErr: "user 'developer' references a tokenFile",
+		},
+		{
+			name: "client certificate file reference",
+			kubeConfig: `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://1.2.3.4
+  name: development
+contexts:
+- context:
+    cluster: development
+    user: developer
+  name: dev
+current-context: dev
+users:
+- name: developer
+  user:
+    client-certificate: /etc/ssl/client.crt
+    client-key: /etc/ssl/client.key`,
+			wantErr: "user 'developer' references a client-certificate file",
+		},
+		{
+			name: "client key file reference",
+			kubeConfig: `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://1.2.3.4
+  name: development
+contexts:
+- context:
+    cluster: development
+    user: developer
+  name: dev
+current-context: dev
+users:
+- name: developer
+  user:
+    client-key: /etc/ssl/client.key`,
+			wantErr: "user 'developer' references a client-key file",
+		},
+		{
+			name: "certificate authority file reference",
+			kubeConfig: `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority: /etc/ssl/ca.crt
+    server: https://1.2.3.4
+  name: development
+contexts:
+- context:
+    cluster: development
+    user: developer
+  name: dev
+current-context: dev
+users:
+- name: developer
+  user:
+    token: some-token`,
+			wantErr: "cluster 'development' references a certificate-authority file",
+		},
+		{
+			name:       "invalid kubeconfig",
+			kubeConfig: "bad",
+			wantErr:    "couldn't get version/kind",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := KubeConfigFromBytes([]byte(tt.kubeConfig))
+			if tt.wantErr != "" {
+				assert.Nil(t, cfg)
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, "https://1.2.3.4", cfg.Host)
+			assert.Equal(t, "some-token", cfg.BearerToken)
+		})
+	}
+}
+
+func TestValidateKubeConfig(t *testing.T) {
+	assert.ErrorContains(t, ValidateKubeConfig(nil), "kubeconfig is nil")
+	assert.ErrorContains(t, ValidateKubeConfig(&api.Config{
+		Clusters: map[string]*api.Cluster{"c": nil},
+	}), "cluster 'c' is nil")
+	assert.ErrorContains(t, ValidateKubeConfig(&api.Config{
+		AuthInfos: map[string]*api.AuthInfo{"u": nil},
+	}), "user 'u' is nil")
+	assert.NoError(t, ValidateKubeConfig(&api.Config{
+		Clusters:  map[string]*api.Cluster{"c": {Server: "https://1.2.3.4", CertificateAuthorityData: []byte("ca")}},
+		AuthInfos: map[string]*api.AuthInfo{"u": {Token: "t", ClientCertificateData: []byte("crt"), ClientKeyData: []byte("key")}},
+	}))
+}


### PR DESCRIPTION
Add `KubeConfigFromBytes` and `ValidateKubeConfig`, which require a serialized kubeconfig to be self-contained. Credentials and certificates must be embedded inline (token, client-certificate-data, client-key-data, certificate-authority-data); entries referencing local files are rejected.