### PR TITLE
git/gogit: add FetchAndReset for push-retry recovery

### DIFF
--- a/git/gogit/client.go
+++ b/git/gogit/client.go
@@ -433,6 +433,66 @@ func (g *Client) Push(ctx context.Context, cfg repository.PushConfig) error {
 	return nil
 }
 
+// FetchAndReset fetches branch from the remote and hard-resets the current
+// worktree onto the fetched tip, discarding any local commits or changes on
+// branch that are not present on the remote. It never modifies the remote.
+//
+// This is intended for recovering from a failed push in a long-lived working
+// directory without a full re-clone: fetch the new remote state, then
+// discard whatever local commit failed to push, so the caller can recompute
+// and retry. The branch must already be checked out; FetchAndReset only
+// reads branch to resolve which remote-tracking ref to reset onto, it does
+// not switch branches itself.
+//
+// Returns nil if the fetch found nothing new (go-git's
+// NoErrAlreadyUpToDate is swallowed, not treated as an error).
+func (g *Client) FetchAndReset(ctx context.Context, branch string) error {
+	if g.repository == nil {
+		return git.ErrNoGitRepository
+	}
+
+	authMethod, err := transportAuth(g.authOpts, g.useDefaultKnownHosts)
+	if err != nil {
+		return fmt.Errorf("failed to construct auth method with options: %w", err)
+	}
+
+	refspec := config.RefSpec(fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s",
+		branch, extgogit.DefaultRemoteName, branch))
+
+	err = g.repository.FetchContext(ctx, &extgogit.FetchOptions{
+		RemoteName:   extgogit.DefaultRemoteName,
+		RefSpecs:     []config.RefSpec{refspec},
+		Auth:         authMethod,
+		Tags:         extgogit.NoTags,
+		Force:        true,
+		ClientCert:   clientCert(g.authOpts),
+		ClientKey:    clientKey(g.authOpts),
+		CABundle:     caBundle(g.authOpts),
+		ProxyOptions: g.proxy,
+	})
+	if err != nil && !errors.Is(err, extgogit.NoErrAlreadyUpToDate) {
+		return fmt.Errorf("failed to fetch from remote: %w", err)
+	}
+
+	remoteRefName := plumbing.NewRemoteReferenceName(extgogit.DefaultRemoteName, branch)
+	remoteRef, err := g.repository.Reference(remoteRefName, true)
+	if err != nil {
+		return fmt.Errorf("could not resolve fetched remote reference '%s': %w", branch, err)
+	}
+
+	wt, err := g.repository.Worktree()
+	if err != nil {
+		return fmt.Errorf("failed to load worktree: %w", err)
+	}
+	if err := wt.Reset(&extgogit.ResetOptions{
+		Commit: remoteRef.Hash(),
+		Mode:   extgogit.HardReset,
+	}); err != nil {
+		return fmt.Errorf("failed to reset worktree to '%s': %w", remoteRef.Hash(), err)
+	}
+	return nil
+}
+
 // SwitchBranch switches the current branch to the given branch name.
 //
 // No new references are fetched from the remote during the process,

--- a/git/gogit/client_test.go
+++ b/git/gogit/client_test.go
@@ -587,6 +587,71 @@ func TestForcePush(t *testing.T) {
 	g.Expect(ref.Hash().String()).To(Equal(cc2.String()))
 }
 
+func TestFetchAndReset(t *testing.T) {
+	g := NewWithT(t)
+
+	server, repoURL, err := setupGitServer(false)
+	g.Expect(err).ToNot(HaveOccurred())
+	defer os.RemoveAll(server.Root())
+	defer server.StopHTTP()
+
+	tmpA := t.TempDir()
+	repoA, err := extgogit.PlainClone(tmpA, false, &extgogit.CloneOptions{
+		URL:        repoURL,
+		RemoteName: git.DefaultRemote,
+		Tags:       extgogit.NoTags,
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	ggcA, err := NewClient(tmpA, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	ggcA.repository = repoA
+
+	tmpB := t.TempDir()
+	repoB, err := extgogit.PlainClone(tmpB, false, &extgogit.CloneOptions{
+		URL:        repoURL,
+		RemoteName: git.DefaultRemote,
+		Tags:       extgogit.NoTags,
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	ggcB, err := NewClient(tmpB, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	ggcB.repository = repoB
+
+	// The winner pushes its change.
+	winnerCC, err := commitFile(repoA, "test", "winner content", time.Now())
+	g.Expect(err).ToNot(HaveOccurred())
+	err = ggcA.Push(context.TODO(), repository.PushConfig{})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// The loser makes its own, never-pushed local commit.
+	_, err = commitFile(repoB, "test", "loser content, discarded on reset", time.Now())
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = ggcB.FetchAndReset(context.TODO(), git.DefaultBranch)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	headB, err := repoB.Head()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(headB.Hash().String()).To(Equal(winnerCC.String()))
+
+	clean, err := ggcB.IsClean()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(clean).To(BeTrue())
+
+	wtB, err := repoB.Worktree()
+	g.Expect(err).ToNot(HaveOccurred())
+	f, err := wtB.Filesystem.Open("test")
+	g.Expect(err).ToNot(HaveOccurred())
+	content, err := io.ReadAll(f)
+	g.Expect(err).ToNot(HaveOccurred())
+	f.Close()
+	g.Expect(string(content)).To(Equal("winner content"))
+
+	// A second call with nothing new to fetch is a no-op, not an error.
+	err = ggcB.FetchAndReset(context.TODO(), git.DefaultBranch)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
 func TestSwitchBranch(t *testing.T) {
 	tests := []struct {
 		name                      string


### PR DESCRIPTION
## Why

In deployments with many independent `ImageUpdateAutomation` (IUA) objects pushing to the same branch of one GitOps repo (e.g. one IUA per service/region, all on independent reconcile timers), push rejections become common once write concurrency is high enough. Today `image-automation-controller` has no in-process retry for a failed push — the next attempt only happens on the next scheduled reconcile, or via controller-runtime's per-item exponential-backoff requeue (750ms doubling, capped at 15min). Under contention, a single IUA can lose several races in a row, each costing a full backoff cycle, turning a sub-minute git operation into a delay of tens of minutes.

A companion PR (fluxcd/image-automation-controller#1090) adds a retry-with-backoff loop there, analogous to a `git pull --rebase && git push` retry loop reusing the same local clone across attempts (no re-clone). go-git has no rebase API, so the equivalent here is: fetch (cheap, incremental) → hard-reset onto the new remote tip → let the caller recompute and recommit → push again. That retry loop needs a way to catch a working directory up to the new remote tip without a full re-clone (today `gogit.Client` only exposes `Clone`, not `Fetch`).


## What

- Adds `(*gogit.Client).FetchAndReset(ctx, branch)`: fetches `branch` from the remote via a scoped refspec and hard-resets the current worktree onto the fetched tip. Never touches the remote. Swallows go-git's `NoErrAlreadyUpToDate`. Mirrors `SwitchBranch`'s plain `(ctx, branchName)` signature — no new config struct, since there's exactly one purpose and one caller today.
- No changes to the `repository.Reader`/`Writer`/`Client` interfaces — `image-automation-controller` holds a concrete `*gogit.Client`, so this is purely an additive new method on the concrete type.

## Testing

- `TestFetchAndReset`: a stale client with its own unpushed local commit recovers onto the winner's pushed tip, working tree content included; a second call with nothing new is a no-op.
- `make test-git` passes, `go vet`/`gofmt` clean.
