### PR TITLE
knownhosts: scope HostKeyAlgorithms to the target host

### DIFF
--- a/git/gogit/transport.go
+++ b/git/gogit/transport.go
@@ -73,7 +73,7 @@ func transportAuth(opts *git.AuthOptions, fallbackToDefaultKnownHosts bool) (tra
 		var callback gossh.HostKeyCallback
 		var hkAlgos []string
 		if len(opts.KnownHosts) > 0 {
-			callback, hkAlgos, err = knownhosts.New(opts.KnownHosts)
+			callback, hkAlgos, err = knownhosts.New(opts.KnownHosts, opts.Host)
 			if err != nil {
 				return nil, err
 			}

--- a/ssh/knownhosts/knownhosts.go
+++ b/ssh/knownhosts/knownhosts.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sort"
 	"strings"
 
 	"golang.org/x/crypto/ssh"
@@ -165,18 +166,47 @@ func (db *inMemoryHostKeyDB) IsRevoked(key *ssh.Certificate) bool {
 	return ok
 }
 
-func (db *inMemoryHostKeyDB) hostKeyAlgorithms() []string {
-	var algos []string
-
+// hostKeyAlgorithms returns the host key algorithms held by the database for
+// the given address, sorted so that the negotiation order is deterministic.
+//
+// Only the algorithms known for a are returned. Advertising an algorithm for
+// which the database holds no entry for a lets the server select it, and
+// check then rejects the resulting host key as a mismatch.
+//
+// It returns nil when the database holds no host key for a, leaving the
+// negotiation to the defaults of golang.org/x/crypto/ssh.
+func (db *inMemoryHostKeyDB) hostKeyAlgorithms(a addr) []string {
 	uniq := make(map[string]struct{})
 	for _, hk := range db.hostKeys {
+		// A certificate authority entry holds the key that signs host
+		// certificates, not a host key algorithm the server can offer.
+		if hk.cert || !hk.match(a) {
+			continue
+		}
 		uniq[hk.key.Type()] = struct{}{}
 	}
+	if len(uniq) == 0 {
+		return nil
+	}
+
+	algos := make([]string, 0, len(uniq))
 	for k := range uniq {
 		algos = append(algos, k)
 	}
+	sort.Strings(algos)
 
 	return algos
+}
+
+// hostAddr parses a host, with or without a port, into an addr. It mirrors
+// the parsing done by newHostnameMatcher so that the address derived from the
+// connection target matches the known_hosts patterns.
+func hostAddr(host string) addr {
+	h, p, err := net.SplitHostPort(host)
+	if err != nil {
+		return addr{host: strings.Trim(host, "[]"), port: "22"}
+	}
+	return addr{host: h, port: p}
 }
 
 const markerCert = "@cert-authority"
@@ -381,7 +411,13 @@ func (db *inMemoryHostKeyDB) Read(r io.Reader) error {
 // operates on the hostname if available, i.e. if a server changes its
 // IP address, the host key check will still succeed, even though a
 // record of the new IP address is not available.
-func New(b []byte) (ssh.HostKeyCallback, []string, error) {
+//
+// It also returns the host key algorithms to advertise for host, for use in
+// ssh.ClientConfig.HostKeyAlgorithms. The host is the connection target, with
+// or without a port; only the algorithms held for that host are returned, so
+// that a blob covering several hosts does not make the server offer a host key
+// the callback then rejects.
+func New(b []byte, host string) (ssh.HostKeyCallback, []string, error) {
 	db := newInMemoryHostKeyDB()
 	r := bytes.NewReader(b)
 	if err := db.Read(r); err != nil {
@@ -393,7 +429,7 @@ func New(b []byte) (ssh.HostKeyCallback, []string, error) {
 	certChecker.IsRevoked = db.IsRevoked
 	certChecker.HostKeyFallback = db.check
 
-	return certChecker.CheckHostKey, db.hostKeyAlgorithms(), nil
+	return certChecker.CheckHostKey, db.hostKeyAlgorithms(hostAddr(host)), nil
 }
 
 func decodeHash(encoded string) (hashType string, salt, hash []byte, err error) {

--- a/ssh/knownhosts/knownhosts_test.go
+++ b/ssh/knownhosts/knownhosts_test.go
@@ -325,3 +325,48 @@ func TestHashedHostkeyCheck(t *testing.T) {
 		t.Errorf("got error %v, want %v", got, want)
 	}
 }
+
+func TestHostKeyAlgorithmsScopedToHost(t *testing.T) {
+	// A single known_hosts blob covering two hosts, each with a different
+	// set of key types. Only the key types held for the requested host may
+	// be advertised, or the server picks one that check rejects.
+	blob := []byte("github.com " + ecKeyStr + "\n" +
+		"gitlab.example.com " + edKeyStr + "\n" +
+		"gitlab.example.com " + ecKeyStr + "\n")
+
+	for _, tt := range []struct {
+		host string
+		want []string
+	}{
+		{host: "github.com", want: []string{"ecdsa-sha2-nistp256"}},
+		{host: "github.com:22", want: []string{"ecdsa-sha2-nistp256"}},
+		{host: "gitlab.example.com", want: []string{"ecdsa-sha2-nistp256", "ssh-ed25519"}},
+		{host: "unknown.example.com", want: nil},
+		{host: "github.com:2222", want: nil},
+	} {
+		// Repeated to catch a non-deterministic order: the previous
+		// implementation ranged over a map.
+		for i := 0; i < 20; i++ {
+			_, got, err := New(blob, tt.host)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("host %s: got %v, want %v", tt.host, got, tt.want)
+			}
+		}
+	}
+}
+
+func TestHostKeyAlgorithmsIgnoresCertAuthority(t *testing.T) {
+	blob := []byte("@cert-authority github.com " + edKeyStr + "\n" +
+		"github.com " + ecKeyStr + "\n")
+
+	_, got, err := New(blob, "github.com")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if want := []string{"ecdsa-sha2-nistp256"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
hostKeyAlgorithms collected the key types of every entry in the known_hosts
blob, without matching them against the host being dialled, and built the
slice by ranging over a map. A blob covering several hosts with different
key-type sets therefore advertised algorithms unknown for the host being
connected to, in a random order on every call. The server may pick one of
them, which checkAddr then rejects as a key mismatch, so verification
succeeded or failed depending on the permutation.

Match the entries against the target address, skip certificate authority
entries, which hold the signing key rather than a host key algorithm the
server can offer, and sort the result so the negotiation is deterministic.
Return nil when no entry matches, leaving the negotiation to the defaults of
golang.org/x/crypto/ssh.

New() now takes the connection target, and gogit passes AuthOptions.Host.

Regression from #943, which is correct for a single host per blob.

Signed-off-by: Adonai Costa <adonai.costa@gmail.com>
