### PR TITLE
Add `githubAppClientID` as an alternative to `githubAppID`

### DIFF
--- a/auth/githubapp/client.go
+++ b/auth/githubapp/client.go
@@ -97,6 +97,10 @@ func New(opts ...OptFunc) (*Client, error) {
 		return nil, fmt.Errorf("app ID or client ID must be provided to use github app authentication")
 	}
 
+	if p.appID != 0 && p.clientID != "" {
+		return nil, fmt.Errorf("only one of app ID or client ID must be provided to use github app authentication")
+	}
+
 	if p.installationOwner == "" && p.installationID == 0 {
 		return nil, fmt.Errorf("app installation owner or ID must be provided to use github app authentication")
 	}

--- a/auth/githubapp/client.go
+++ b/auth/githubapp/client.go
@@ -38,6 +38,7 @@ import (
 
 const (
 	KeyAppID                = "githubAppID"
+	KeyAppClientID          = "githubAppClientID"
 	KeyAppInstallationOwner = "githubAppInstallationOwner"
 	KeyAppInstallationID    = "githubAppInstallationID"
 	KeyAppPrivateKey        = "githubAppPrivateKey"
@@ -49,6 +50,7 @@ const (
 // Client is an authentication provider for GitHub Apps.
 type Client struct {
 	appID             int64
+	clientID          string
 	installationOwner string
 	installationID    int64
 	privateKey        []byte
@@ -91,8 +93,8 @@ func New(opts ...OptFunc) (*Client, error) {
 		transport.Proxy = proxyFunc
 	}
 
-	if p.appID == 0 {
-		return nil, fmt.Errorf("app ID must be provided to use github app authentication")
+	if p.appID == 0 && p.clientID == "" {
+		return nil, fmt.Errorf("app ID or client ID must be provided to use github app authentication")
 	}
 
 	if p.installationOwner == "" && p.installationID == 0 {
@@ -131,6 +133,9 @@ func WithAppData(appData map[string][]byte) OptFunc {
 	return func(p *Client) {
 		if val, ok := appData[KeyAppID]; ok {
 			p.appID, _ = strconv.ParseInt(string(val), 10, 64)
+		}
+		if val, ok := appData[KeyAppClientID]; ok {
+			p.clientID = string(val)
 		}
 		if val, ok := appData[KeyAppInstallationOwner]; ok {
 			p.installationOwner = string(val)
@@ -219,10 +224,14 @@ func (p *Client) createJWT() (string, error) {
 	now := time.Now().Truncate(time.Second)
 	iat := now.Add(-30 * time.Second) // Clock drift allowance
 	exp := iat.Add(2 * time.Minute)   // Short-lived JWT (only used to get installation token)
+	issuer := p.clientID
+	if issuer == "" {
+		issuer = strconv.FormatInt(p.appID, 10)
+	}
 	claims := jwt.RegisteredClaims{
 		IssuedAt:  jwt.NewNumericDate(iat),
 		ExpiresAt: jwt.NewNumericDate(exp),
-		Issuer:    strconv.FormatInt(p.appID, 10),
+		Issuer:    issuer,
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
@@ -411,6 +420,7 @@ func GetCredentials(ctx context.Context, opts ...OptFunc) (string, string, error
 func (p *Client) buildCacheKey() string {
 	keyParts := []string{
 		fmt.Sprintf("%s=%d", KeyAppID, p.appID),
+		fmt.Sprintf("%s=%s", KeyAppClientID, p.clientID),
 		fmt.Sprintf("%s=%s", KeyAppInstallationOwner, p.installationOwner),
 		fmt.Sprintf("%s=%d", KeyAppInstallationID, p.installationID),
 		fmt.Sprintf("%s=%s", KeyAppBaseURL, p.apiURL),

--- a/auth/githubapp/client_test.go
+++ b/auth/githubapp/client_test.go
@@ -28,9 +28,8 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/gomega"
-
 	"github.com/golang-jwt/jwt/v4"
+	. "github.com/onsi/gomega"
 
 	"github.com/fluxcd/pkg/cache"
 	"github.com/fluxcd/pkg/ssh"
@@ -105,9 +104,7 @@ func TestClient_Options(t *testing.T) {
 				KeyAppInstallationID: []byte(installationID),
 				KeyAppPrivateKey:     kp.PrivateKey,
 			})},
-			wantAppID:          123,
-			wantClientID:       clientID,
-			wantInstallationID: 456,
+			wantErr: errors.New("only one of app ID or client ID must be provided to use github app authentication"),
 		},
 		{
 			name: "Create new client with installation owner",
@@ -243,16 +240,6 @@ func TestClient_createJWT_Issuer(t *testing.T) {
 		{
 			name: "issuer is client ID when only client ID is set",
 			opts: []OptFunc{WithAppData(map[string][]byte{
-				KeyAppClientID:       []byte(clientID),
-				KeyAppInstallationID: []byte(installationID),
-				KeyAppPrivateKey:     kp.PrivateKey,
-			})},
-			wantIssuer: clientID,
-		},
-		{
-			name: "client ID wins when both are set",
-			opts: []OptFunc{WithAppData(map[string][]byte{
-				KeyAppID:             []byte(appID),
 				KeyAppClientID:       []byte(clientID),
 				KeyAppInstallationID: []byte(installationID),
 				KeyAppPrivateKey:     kp.PrivateKey,

--- a/auth/githubapp/client_test.go
+++ b/auth/githubapp/client_test.go
@@ -30,12 +30,15 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/golang-jwt/jwt/v4"
+
 	"github.com/fluxcd/pkg/cache"
 	"github.com/fluxcd/pkg/ssh"
 )
 
 func TestClient_Options(t *testing.T) {
 	appID := "123"
+	clientID := "Iv23liACLIENTID12345"
 	installationID := "456"
 	kp, _ := ssh.GenerateKeyPair(ssh.RSA_4096)
 	gitHubEnterpriseURL := "https://github.example.com/api/v3"
@@ -45,6 +48,8 @@ func TestClient_Options(t *testing.T) {
 		name                  string
 		opts                  []OptFunc
 		wantErr               error
+		wantAppID             int64
+		wantClientID          string
 		wantInstallationID    int64
 		wantInstallationOwner string
 	}{
@@ -58,6 +63,7 @@ func TestClient_Options(t *testing.T) {
 				}),
 				WithProxyURL(proxy),
 			},
+			wantAppID:          123,
 			wantInstallationID: 456,
 		},
 		{
@@ -67,6 +73,7 @@ func TestClient_Options(t *testing.T) {
 				KeyAppInstallationID: []byte(installationID),
 				KeyAppPrivateKey:     kp.PrivateKey,
 			})},
+			wantAppID:          123,
 			wantInstallationID: 456,
 		},
 		{
@@ -77,6 +84,29 @@ func TestClient_Options(t *testing.T) {
 				KeyAppBaseURL:        []byte(gitHubEnterpriseURL),
 				KeyAppPrivateKey:     kp.PrivateKey,
 			})},
+			wantAppID:          123,
+			wantInstallationID: 456,
+		},
+		{
+			name: "Create new client with client ID",
+			opts: []OptFunc{WithAppData(map[string][]byte{
+				KeyAppClientID:       []byte(clientID),
+				KeyAppInstallationID: []byte(installationID),
+				KeyAppPrivateKey:     kp.PrivateKey,
+			})},
+			wantClientID:       clientID,
+			wantInstallationID: 456,
+		},
+		{
+			name: "Create new client with both app ID and client ID",
+			opts: []OptFunc{WithAppData(map[string][]byte{
+				KeyAppID:             []byte(appID),
+				KeyAppClientID:       []byte(clientID),
+				KeyAppInstallationID: []byte(installationID),
+				KeyAppPrivateKey:     kp.PrivateKey,
+			})},
+			wantAppID:          123,
+			wantClientID:       clientID,
 			wantInstallationID: 456,
 		},
 		{
@@ -86,6 +116,7 @@ func TestClient_Options(t *testing.T) {
 				KeyAppInstallationOwner: []byte("my-org"),
 				KeyAppPrivateKey:        kp.PrivateKey,
 			})},
+			wantAppID:             123,
 			wantInstallationOwner: "my-org",
 		},
 		{
@@ -101,7 +132,7 @@ func TestClient_Options(t *testing.T) {
 		{
 			name:    "Create new client with empty data",
 			opts:    []OptFunc{WithAppData(map[string][]byte{})},
-			wantErr: errors.New("app ID must be provided to use github app authentication"),
+			wantErr: errors.New("app ID or client ID must be provided to use github app authentication"),
 		},
 		{
 			name: "Create new client with app data with missing AppID Key",
@@ -110,7 +141,7 @@ func TestClient_Options(t *testing.T) {
 				KeyAppPrivateKey:     kp.PrivateKey,
 			},
 			)},
-			wantErr: errors.New("app ID must be provided to use github app authentication"),
+			wantErr: errors.New("app ID or client ID must be provided to use github app authentication"),
 		},
 		{
 			name: "Create new client with app data with missing AppInstallationID Key",
@@ -138,7 +169,7 @@ func TestClient_Options(t *testing.T) {
 				KeyAppPrivateKey:     kp.PrivateKey,
 			},
 			)},
-			wantErr: errors.New("app ID must be provided to use github app authentication"),
+			wantErr: errors.New("app ID or client ID must be provided to use github app authentication"),
 		},
 		{
 			name: "Create new client with invalid installationID in app data",
@@ -173,7 +204,8 @@ func TestClient_Options(t *testing.T) {
 				g.Expect(err.Error()).To(ContainSubstring(tt.wantErr.Error()))
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(client.appID).To(Equal(int64(123)))
+				g.Expect(client.appID).To(Equal(tt.wantAppID))
+				g.Expect(client.clientID).To(Equal(tt.wantClientID))
 				g.Expect(client.installationID).To(Equal(tt.wantInstallationID))
 				g.Expect(client.installationOwner).To(Equal(tt.wantInstallationOwner))
 				g.Expect(client.privateKey).To(Equal(kp.PrivateKey))
@@ -184,6 +216,95 @@ func TestClient_Options(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClient_createJWT_Issuer(t *testing.T) {
+	appID := "123"
+	clientID := "Iv23liACLIENTID12345"
+	installationID := "456"
+	g := NewWithT(t)
+	kp, err := ssh.GenerateKeyPair(ssh.RSA_4096)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	tests := []struct {
+		name       string
+		opts       []OptFunc
+		wantIssuer string
+	}{
+		{
+			name: "issuer is numeric app ID when only app ID is set",
+			opts: []OptFunc{WithAppData(map[string][]byte{
+				KeyAppID:             []byte(appID),
+				KeyAppInstallationID: []byte(installationID),
+				KeyAppPrivateKey:     kp.PrivateKey,
+			})},
+			wantIssuer: "123",
+		},
+		{
+			name: "issuer is client ID when only client ID is set",
+			opts: []OptFunc{WithAppData(map[string][]byte{
+				KeyAppClientID:       []byte(clientID),
+				KeyAppInstallationID: []byte(installationID),
+				KeyAppPrivateKey:     kp.PrivateKey,
+			})},
+			wantIssuer: clientID,
+		},
+		{
+			name: "client ID wins when both are set",
+			opts: []OptFunc{WithAppData(map[string][]byte{
+				KeyAppID:             []byte(appID),
+				KeyAppClientID:       []byte(clientID),
+				KeyAppInstallationID: []byte(installationID),
+				KeyAppPrivateKey:     kp.PrivateKey,
+			})},
+			wantIssuer: clientID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			client, err := New(tt.opts...)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			tokenString, err := client.createJWT()
+			g.Expect(err).ToNot(HaveOccurred())
+
+			claims := &jwt.RegisteredClaims{}
+			_, _, err = jwt.NewParser().ParseUnverified(tokenString, claims)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(claims.Issuer).To(Equal(tt.wantIssuer))
+		})
+	}
+}
+
+func TestClient_buildCacheKey_DistinguishesClientID(t *testing.T) {
+	g := NewWithT(t)
+	kp, err := ssh.GenerateKeyPair(ssh.RSA_4096)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	base := func(extra map[string][]byte) *Client {
+		data := map[string][]byte{
+			KeyAppInstallationID: []byte("456"),
+			KeyAppPrivateKey:     kp.PrivateKey,
+		}
+		for k, v := range extra {
+			data[k] = v
+		}
+		c, err := New(WithAppData(data))
+		g.Expect(err).ToNot(HaveOccurred())
+		return c
+	}
+
+	appIDClient := base(map[string][]byte{KeyAppID: []byte("123")})
+	clientIDClient := base(map[string][]byte{KeyAppClientID: []byte("Iv23liACLIENTID12345")})
+	otherClientIDClient := base(map[string][]byte{KeyAppClientID: []byte("Iv23liDIFFERENT98765")})
+
+	// A client identified by client ID must not collide with one identified by app ID.
+	g.Expect(clientIDClient.buildCacheKey()).ToNot(Equal(appIDClient.buildCacheKey()))
+	// Two clients with different client IDs must not collide.
+	g.Expect(clientIDClient.buildCacheKey()).ToNot(Equal(otherClientIDClient.buildCacheKey()))
 }
 
 func TestClient_GetCredentials(t *testing.T) {

--- a/runtime/secrets/converter.go
+++ b/runtime/secrets/converter.go
@@ -298,23 +298,24 @@ func SSHAuthFromSecret(ctx context.Context, secret *corev1.Secret) (*SSHAuth, er
 
 // GitHubAppDataFromSecret retrieves GitHub App authentication data from a Kubernetes secret.
 //
-// The function expects the secret to contain "githubAppID" and "githubAppPrivateKey",
-// and exactly one of "githubAppInstallationOwner" or "githubAppInstallationID" fields.
-// All three fields are required and the function will return an error if any is missing.
+// The function expects the secret to contain "githubAppPrivateKey", at least one of
+// "githubAppID" or "githubAppClientID", and exactly one of "githubAppInstallationOwner" or
+// "githubAppInstallationID". It returns an error if these requirements are not met.
 // Optional "githubAppBaseURL" field can be present for GitHub Enterprise Server instances.
 func GitHubAppDataFromSecret(ctx context.Context, secret *corev1.Secret) (GitHubAppData, error) {
 	_, hasAppID := secret.Data[KeyGitHubAppID]
+	_, hasClientID := secret.Data[KeyGitHubAppClientID]
 	_, hasInstallationOwner := secret.Data[KeyGitHubAppInstallationOwner]
 	_, hasInstallationID := secret.Data[KeyGitHubAppInstallationID]
 	_, hasPrivateKey := secret.Data[KeyGitHubAppPrivateKey]
 
 	// Complete absence - return KeyNotFoundError (will be ignored by trySetAuth)
-	if !hasAppID && !hasInstallationOwner && !hasInstallationID && !hasPrivateKey {
+	if !hasAppID && !hasClientID && !hasInstallationOwner && !hasInstallationID && !hasPrivateKey {
 		return nil, &KeyNotFoundError{Key: KeyGitHubAppID, Secret: secret}
 	}
 
-	// Check for required fields - partial presence is an error
-	if !hasAppID {
+	// Require at least one identity: appID or clientID (permissive - clientID wins downstream)
+	if !hasAppID && !hasClientID {
 		return nil, &KeyNotFoundError{Key: KeyGitHubAppID, Secret: secret}
 	}
 	if !hasPrivateKey {
@@ -327,8 +328,14 @@ func GitHubAppDataFromSecret(ctx context.Context, secret *corev1.Secret) (GitHub
 	}
 
 	data := GitHubAppData{
-		KeyGitHubAppID:         secret.Data[KeyGitHubAppID],
 		KeyGitHubAppPrivateKey: secret.Data[KeyGitHubAppPrivateKey],
+	}
+
+	if appID, exists := secret.Data[KeyGitHubAppID]; exists {
+		data[KeyGitHubAppID] = appID
+	}
+	if clientID, exists := secret.Data[KeyGitHubAppClientID]; exists {
+		data[KeyGitHubAppClientID] = clientID
 	}
 
 	if owner, exists := secret.Data[KeyGitHubAppInstallationOwner]; exists {

--- a/runtime/secrets/converter.go
+++ b/runtime/secrets/converter.go
@@ -298,7 +298,7 @@ func SSHAuthFromSecret(ctx context.Context, secret *corev1.Secret) (*SSHAuth, er
 
 // GitHubAppDataFromSecret retrieves GitHub App authentication data from a Kubernetes secret.
 //
-// The function expects the secret to contain "githubAppPrivateKey", at least one of
+// The function expects the secret to contain "githubAppPrivateKey", exactly one of
 // "githubAppID" or "githubAppClientID", and exactly one of "githubAppInstallationOwner" or
 // "githubAppInstallationID". It returns an error if these requirements are not met.
 // Optional "githubAppBaseURL" field can be present for GitHub Enterprise Server instances.
@@ -314,9 +314,13 @@ func GitHubAppDataFromSecret(ctx context.Context, secret *corev1.Secret) (GitHub
 		return nil, &KeyNotFoundError{Key: KeyGitHubAppID, Secret: secret}
 	}
 
-	// Require at least one identity: appID or clientID (permissive - clientID wins downstream)
+	// Require exactly one identity: appID or clientID.
 	if !hasAppID && !hasClientID {
 		return nil, &KeyNotFoundError{Key: KeyGitHubAppID, Secret: secret}
+	}
+	if hasAppID && hasClientID {
+		return nil, fmt.Errorf("secret '%s' must contain exactly one of '%s' or '%s'",
+			client.ObjectKeyFromObject(secret), KeyGitHubAppID, KeyGitHubAppClientID)
 	}
 	if !hasPrivateKey {
 		return nil, &KeyNotFoundError{Key: KeyGitHubAppPrivateKey, Secret: secret}

--- a/runtime/secrets/converter_test.go
+++ b/runtime/secrets/converter_test.go
@@ -415,22 +415,17 @@ func TestGitHubAppDataFromSecret(t *testing.T) {
 			},
 		},
 		{
-			name: "valid GitHub App data with both app ID and client ID",
+			name: "both app ID and client ID provided",
 			secretData: map[string][]byte{
 				secrets.KeyGitHubAppID:             []byte("123456"),
 				secrets.KeyGitHubAppClientID:       []byte("Iv23liACLIENTID12345"),
 				secrets.KeyGitHubAppInstallationID: []byte("7890123"),
 				secrets.KeyGitHubAppPrivateKey:     []byte("test-private-key"),
 			},
-			wantData: map[string][]byte{
-				secrets.KeyGitHubAppID:             []byte("123456"),
-				secrets.KeyGitHubAppClientID:       []byte("Iv23liACLIENTID12345"),
-				secrets.KeyGitHubAppInstallationID: []byte("7890123"),
-				secrets.KeyGitHubAppPrivateKey:     []byte("test-private-key"),
-			},
+			errMsg: `secret 'default/github-app-secret' must contain exactly one of 'githubAppID' or 'githubAppClientID'`,
 		},
 		{
-			name: "missing app ID",
+			name: "neither app ID nor client ID",
 			secretData: map[string][]byte{
 				secrets.KeyGitHubAppInstallationID: []byte("7890123"),
 				secrets.KeyGitHubAppPrivateKey:     []byte("test-private-key"),

--- a/runtime/secrets/converter_test.go
+++ b/runtime/secrets/converter_test.go
@@ -189,6 +189,15 @@ func TestAuthMethodsFromSecret(t *testing.T) {
 			wantGitHubApp: true,
 		},
 		{
+			name: "GitHub App with client ID instead of app ID",
+			secretData: map[string][]byte{
+				secrets.KeyGitHubAppClientID:       []byte("Iv23liACLIENTID12345"),
+				secrets.KeyGitHubAppInstallationID: []byte("7890123"),
+				secrets.KeyGitHubAppPrivateKey:     []byte("test-private-key"),
+			},
+			wantGitHubApp: true,
+		},
+		{
 			name: "GitHub App + CA (source-controller PR scenario)",
 			secretData: map[string][]byte{
 				secrets.KeyGitHubAppID:             []byte("123456"),
@@ -308,8 +317,11 @@ func TestAuthMethodsFromSecret(t *testing.T) {
 
 			if tt.wantGitHubApp {
 				g.Expect(result.GitHubAppData).ToNot(BeNil())
-				g.Expect(result.GitHubAppData).To(HaveKey(secrets.KeyGitHubAppID))
 				g.Expect(result.GitHubAppData).To(HaveKey(secrets.KeyGitHubAppPrivateKey))
+				// At least one of app ID or client ID should be present
+				hasAppID := result.GitHubAppData[secrets.KeyGitHubAppID] != nil
+				hasClientID := result.GitHubAppData[secrets.KeyGitHubAppClientID] != nil
+				g.Expect(hasAppID || hasClientID).To(BeTrue(), "either app ID or client ID should be present")
 				// Exactly one of installation owner or installation ID should be present
 				hasInstallationOwner := result.GitHubAppData[secrets.KeyGitHubAppInstallationOwner] != nil
 				hasInstallationID := result.GitHubAppData[secrets.KeyGitHubAppInstallationID] != nil
@@ -390,6 +402,34 @@ func TestGitHubAppDataFromSecret(t *testing.T) {
 			},
 		},
 		{
+			name: "valid GitHub App data with client ID instead of app ID",
+			secretData: map[string][]byte{
+				secrets.KeyGitHubAppClientID:       []byte("Iv23liACLIENTID12345"),
+				secrets.KeyGitHubAppInstallationID: []byte("7890123"),
+				secrets.KeyGitHubAppPrivateKey:     []byte("test-private-key"),
+			},
+			wantData: map[string][]byte{
+				secrets.KeyGitHubAppClientID:       []byte("Iv23liACLIENTID12345"),
+				secrets.KeyGitHubAppInstallationID: []byte("7890123"),
+				secrets.KeyGitHubAppPrivateKey:     []byte("test-private-key"),
+			},
+		},
+		{
+			name: "valid GitHub App data with both app ID and client ID",
+			secretData: map[string][]byte{
+				secrets.KeyGitHubAppID:             []byte("123456"),
+				secrets.KeyGitHubAppClientID:       []byte("Iv23liACLIENTID12345"),
+				secrets.KeyGitHubAppInstallationID: []byte("7890123"),
+				secrets.KeyGitHubAppPrivateKey:     []byte("test-private-key"),
+			},
+			wantData: map[string][]byte{
+				secrets.KeyGitHubAppID:             []byte("123456"),
+				secrets.KeyGitHubAppClientID:       []byte("Iv23liACLIENTID12345"),
+				secrets.KeyGitHubAppInstallationID: []byte("7890123"),
+				secrets.KeyGitHubAppPrivateKey:     []byte("test-private-key"),
+			},
+		},
+		{
 			name: "missing app ID",
 			secretData: map[string][]byte{
 				secrets.KeyGitHubAppInstallationID: []byte("7890123"),
@@ -459,10 +499,23 @@ func TestGitHubAppDataFromSecret(t *testing.T) {
 				g.Expect(result).ToNot(BeNil())
 
 				// Verify required fields are present and have correct values
-				g.Expect(result).To(HaveKey(secrets.KeyGitHubAppID))
 				g.Expect(result).To(HaveKey(secrets.KeyGitHubAppPrivateKey))
-				g.Expect(string(result[secrets.KeyGitHubAppID])).To(Equal("123456"))
 				g.Expect(string(result[secrets.KeyGitHubAppPrivateKey])).To(Equal("test-private-key"))
+
+				// At least one of app ID or client ID should be present, matching the input
+				hasAppID := result[secrets.KeyGitHubAppID] != nil
+				hasClientID := result[secrets.KeyGitHubAppClientID] != nil
+				g.Expect(hasAppID || hasClientID).To(BeTrue(), "either app ID or client ID should be present")
+				if tt.wantData[secrets.KeyGitHubAppID] != nil {
+					g.Expect(string(result[secrets.KeyGitHubAppID])).To(Equal(string(tt.wantData[secrets.KeyGitHubAppID])))
+				} else {
+					g.Expect(result[secrets.KeyGitHubAppID]).To(BeNil())
+				}
+				if tt.wantData[secrets.KeyGitHubAppClientID] != nil {
+					g.Expect(string(result[secrets.KeyGitHubAppClientID])).To(Equal(string(tt.wantData[secrets.KeyGitHubAppClientID])))
+				} else {
+					g.Expect(result[secrets.KeyGitHubAppClientID]).To(BeNil())
+				}
 
 				// Verify exactly one of installation owner or installation ID has a non-nil value
 				hasInstallationOwner := result[secrets.KeyGitHubAppInstallationOwner] != nil

--- a/runtime/secrets/factory.go
+++ b/runtime/secrets/factory.go
@@ -238,29 +238,42 @@ func WithGitHubAppBaseURL(baseURL string) GitHubAppOption {
 	}
 }
 
+// WithGitHubAppClientID sets the client ID for the GitHub App secret.
+func WithGitHubAppClientID(clientID string) GitHubAppOption {
+	return func(data map[string]string) {
+		data[KeyGitHubAppClientID] = clientID
+	}
+}
+
 // MakeGitHubAppSecret creates a Kubernetes secret for GitHub App authentication.
 //
-// The function requires appID and privateKey to be non-empty.
+// The function requires privateKey to be non-empty, and exactly one of appID or clientID.
 // Exactly one of installationOwner or installationID must be provided.
 // Optional baseURL can be provided for GitHub Enterprise Server instances.
 // The resulting secret will be of type Opaque.
 func MakeGitHubAppSecret(name, namespace, appID, privateKey string,
 	opts ...GitHubAppOption) (*corev1.Secret, error) {
 
-	if err := validateRequired(appID, KeyGitHubAppID); err != nil {
-		return nil, err
-	}
 	if err := validateRequired(privateKey, KeyGitHubAppPrivateKey); err != nil {
 		return nil, err
 	}
 
 	data := map[string]string{
-		KeyGitHubAppID:         appID,
 		KeyGitHubAppPrivateKey: privateKey,
+	}
+	if appID != "" {
+		data[KeyGitHubAppID] = appID
 	}
 
 	for _, opt := range opts {
 		opt(data)
+	}
+
+	_, hasAppID := data[KeyGitHubAppID]
+	_, hasClientID := data[KeyGitHubAppClientID]
+	if hasAppID == hasClientID {
+		return nil, fmt.Errorf("exactly one of %s or %s must be provided",
+			KeyGitHubAppID, KeyGitHubAppClientID)
 	}
 
 	_, hasInstallationOwner := data[KeyGitHubAppInstallationOwner]

--- a/runtime/secrets/factory_test.go
+++ b/runtime/secrets/factory_test.go
@@ -597,15 +597,41 @@ func TestMakeGitHubAppSecret(t *testing.T) {
 			},
 		},
 		{
-			name:       "empty app ID",
+			name:       "github app secret with client ID instead of app ID",
 			secretName: "github-app-secret",
 			namespace:  testNS,
-			appID:      "",
+			privateKey: githubAppPrivateKey,
+			opts: []secrets.GitHubAppOption{
+				secrets.WithGitHubAppClientID("Iv23liACLIENTID12345"),
+				secrets.WithGitHubAppInstallationID("7891011"),
+			},
+			expectedData: map[string][]byte{
+				secrets.KeyGitHubAppClientID:       []byte("Iv23liACLIENTID12345"),
+				secrets.KeyGitHubAppInstallationID: []byte("7891011"),
+				secrets.KeyGitHubAppPrivateKey:     []byte(githubAppPrivateKey),
+			},
+		},
+		{
+			name:       "neither app ID nor client ID provided",
+			secretName: "github-app-secret",
+			namespace:  testNS,
 			privateKey: githubAppPrivateKey,
 			opts: []secrets.GitHubAppOption{
 				secrets.WithGitHubAppInstallationID("7891011"),
 			},
-			errMsg: "githubAppID is required",
+			errMsg: "exactly one of githubAppID or githubAppClientID must be provided",
+		},
+		{
+			name:       "both app ID and client ID provided",
+			secretName: "github-app-secret",
+			namespace:  testNS,
+			appID:      "123456",
+			privateKey: githubAppPrivateKey,
+			opts: []secrets.GitHubAppOption{
+				secrets.WithGitHubAppClientID("Iv23liACLIENTID12345"),
+				secrets.WithGitHubAppInstallationID("7891011"),
+			},
+			errMsg: "exactly one of githubAppID or githubAppClientID must be provided",
 		},
 		{
 			name:       "empty private key",

--- a/runtime/secrets/secrets.go
+++ b/runtime/secrets/secrets.go
@@ -56,6 +56,8 @@ const (
 
 	// KeyGitHubAppID is the key for GitHub App ID data in secrets.
 	KeyGitHubAppID = "githubAppID"
+	// KeyGitHubAppClientID is the key for GitHub App client ID data in secrets.
+	KeyGitHubAppClientID = "githubAppClientID"
 	// KeyGitHubAppInstallationOwner is the key for GitHub App installation owner data in secrets.
 	KeyGitHubAppInstallationOwner = "githubAppInstallationOwner"
 	// KeyGitHubAppInstallationID is the key for GitHub App installation ID data in secrets.


### PR DESCRIPTION
Refs: https://github.com/fluxcd/pkg/issues/1291

GitHub accepts either the numeric AppID or the ClientID of GH Apps as the JWT `iss` claim, and recommends the ClientID in the official docs ([GitHub](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app), [GHE](https://docs.github.com/en/enterprise-server@3.20/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app)). `pkg` currently only accepts the numeric AppID, so this PR adds `githubAppClientID` as an alternative across `auth/githubapp` (the JWT consumer) and `runtime/secrets` (the secret writer and reader). Existing secrets using only AppID are unaffected.

AppID and ClientID are treated as mutually exclusive. This is enforced in `New`, `MakeGitHubAppSecret`, and `GitHubAppDataFromSecret`, mirroring the existing `installationOwner` / `installationID` handling. 
They identify the same app for a single `iss` claim, so this keeps the behaviour unambiguous and avoids silently ignoring one identity when both are supplied. 
The ClientID is treated as a regular string, since GitHub documents no format for it (The ClientIDs I checked on GHE and GitHub also differed from each other with no common prefix). 
As `pkg` is a GA dependency consumed by all Flux controllers, `MakeGitHubAppSecret` keeps `appID` as a positional parameter and adds `clientID` via an option, because any change to the positional parameters of this exported function would break every existing consumer. 
If the preferred solution is to change to symmetric options (`WithGitHubAppID` + `WithGitHubAppClientID`) and accept the function signature break, I'm happy to switch.

Two behaviour changes to note, given the GA compatibility guarantee:
- changed the error message of `MakeGitHubAppSecret` from `"githubAppID is required"` to `"exactly one of githubAppID or githubAppClientID must be provided"`.
- `buildCacheKey` now includes the ClientID, which causes a new token to be requested on version upgrade (a one-time, self-healing re-fetch of short-lived installation tokens).

I applied the change across `auth/githubapp` and `runtime/secrets` in `pkg` so the new ClientID is usable end-to-end. If you prefer I can split it into two PRs. 

I added Tests for client-ID-only, both-set (rejected), and neither-set across writer, reader, and JWT issuer generation; `make test-auth` and `make test-runtime` pass.